### PR TITLE
Replace date drop-down filter with datepicker

### DIFF
--- a/css/jquery-ui/smoothness/jquery-ui-zoninator.css
+++ b/css/jquery-ui/smoothness/jquery-ui-zoninator.css
@@ -345,3 +345,27 @@
 	font-weight: normal;
 	margin: -1px;
 }
+
+/* Datepicker
+----------------------------------*/
+.ui-datepicker { width: 17em; padding: .2em .2em 0; }
+.ui-datepicker .ui-datepicker-header { position:relative; padding:.2em 0; }
+.ui-datepicker .ui-datepicker-prev, .ui-datepicker .ui-datepicker-next { position:absolute; top: 2px; width: 1.8em; height: 1.8em; }
+.ui-datepicker .ui-datepicker-prev-hover, .ui-datepicker .ui-datepicker-next-hover { top: 1px; }
+.ui-datepicker .ui-datepicker-prev { left:2px; }
+.ui-datepicker .ui-datepicker-next { right:2px; }
+.ui-datepicker .ui-datepicker-prev-hover { left:1px; }
+.ui-datepicker .ui-datepicker-next-hover { right:1px; }
+.ui-datepicker .ui-datepicker-prev span, .ui-datepicker .ui-datepicker-next span { display: block; position: absolute; left: 50%; margin-left: -8px; top: 50%; margin-top: -8px;  }
+.ui-datepicker .ui-datepicker-title { margin: 0 2.3em; line-height: 1.8em; text-align: center; }
+.ui-datepicker .ui-datepicker-title select { font-size:1em; margin:1px 0; }
+.ui-datepicker select.ui-datepicker-month-year {width: 100%;}
+.ui-datepicker select.ui-datepicker-month, 
+.ui-datepicker select.ui-datepicker-year { width: 49%;}
+.ui-datepicker table {width: 100%; font-size: .9em; border-collapse: collapse; margin:0 0 .4em; }
+.ui-datepicker th { padding: .7em .3em; text-align: center; font-weight: bold; border: 0;  }
+.ui-datepicker td { border: 0; padding: 1px; }
+.ui-datepicker td span, .ui-datepicker td a { display: block; padding: .2em; text-align: right; text-decoration: none; }
+.ui-datepicker .ui-datepicker-buttonpane { background-image: none; margin: .7em 0 0 0; padding:0 .2em; border-left: 0; border-right: 0; border-bottom: 0; }
+.ui-datepicker .ui-datepicker-buttonpane button { float: right; margin: .5em .2em .4em; cursor: pointer; padding: .2em .6em .3em .6em; width:auto; overflow:visible; }
+.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current { float:left; }

--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -26,6 +26,11 @@ var zoninator = {}
 		// Bind actions to buttons
 		zoninator.initZonePost(zoninator.$zonePostsList.children());
 		
+		// Initialize date-picker
+		$('#zone_advanced_filter_date').datepicker({
+			dateFormat : 'yy-mm-dd'
+		});
+
 		// Initialize sortable
 		if(!zoninator.$zonePostsWrap.hasClass('readonly')) {
 			zoninator.$zonePostsList.sortable({

--- a/zoninator.php
+++ b/zoninator.php
@@ -135,7 +135,7 @@ class Zoninator
 
 	function admin_enqueue_scripts() {
 		if( $this->is_zoninator_page() ) {
-			wp_enqueue_script( 'zoninator-js', ZONINATOR_URL . 'js/zoninator.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-widget', 'jquery-ui-mouse', 'jquery-ui-position', 'jquery-ui-sortable', 'jquery-ui-autocomplete' ), ZONINATOR_VERSION, true );
+			wp_enqueue_script( 'zoninator-js', ZONINATOR_URL . 'js/zoninator.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-widget', 'jquery-ui-mouse', 'jquery-ui-position', 'jquery-ui-sortable', 'jquery-ui-autocomplete', 'jquery-ui-datepicker' ), ZONINATOR_VERSION, true );
 			
 			$options = array(
 				'baseUrl' => $this->_get_zone_page_url(),
@@ -511,19 +511,8 @@ class Zoninator
 				'id' => 'zone_advanced_filter_taxonomy',
 				'hide_if_empty' => true,
 			) ) );
-
-			$date_filters = apply_filters( 'zoninator_advanced_filter_date', array( 'all', 'today', 'yesterday') );
 			?>
-			<select name="zone_advanced_filter_date" id="zone_advanced_filter_date">
-				<?php
-				// Convert string dates into actual dates
-				foreach( $date_filters as $date ) :
-					$timestamp = strtotime( $date );
-					$output = ( $timestamp ) ? date( 'Y-m-d', $timestamp ) : 0;
-					echo sprintf( '<option value="%s" %s>%s</option>', esc_attr( $output ), selected( $output, $current_date, false ), esc_html( $date ) );
-				endforeach;
-				?>
-			</select>
+			<input type="text" name="zone_advanced_filter_date" id="zone_advanced_filter_date" placeholder="Pick a date">
 		</div>
 		<?php
 	}


### PR DESCRIPTION
Allows for a much broader range of date-selection, not just limited to today/yesterday. Allows someone to find post with similar titles that might only be differentiated by the slug otherwise.
