### PR TITLE
Clearing autocomplete cache if filter terms change

### DIFF
--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -15,10 +15,12 @@ var zoninator = {}
 
 
 		zoninator.$zoneAdvancedDate.change(function() {
+			zoninator.autocompleteCache = {};
 			zoninator.updateLatest();
 		});
 
 		zoninator.$zoneAdvancedCat.change(function() {
+			zoninator.autocompleteCache = {};
 			zoninator.updateLatest();
 		});
 


### PR DESCRIPTION
A couple of our clients have noticed that if they change the category or date filters, they don't affect the autocomplete search results for any previously searched terms until the page is refreshed. The latest posts dropdown does refresh and the search results should refresh too for a consistent user experience. 

I've added a couple lines here to just clear the autocomplete cache whenever one of the filters is updated.
