### PR TITLE
Filterable widget posts rendering

### DIFF
--- a/widget.zone-posts.php
+++ b/widget.zone-posts.php
@@ -60,13 +60,9 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 		<?php endif; ?>
 
 		<ul>
-			<?php foreach ( $posts as $post ) : ?>
-				<li>
-					<a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>">
-						<?php echo esc_html( get_the_title( $post->ID ) ); ?>
-					</a>
-				</li>
-			<?php endforeach; ?>
+			<?php foreach ( $posts as $post ) {
+                $this->widget_post( $post );
+            };?>
 		</ul>
 
 		<?php echo wp_kses_post( $args['after_widget'] ); ?>
@@ -80,6 +76,18 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 		}
 		wp_cache_set( 'widget-zone-posts', $cache, 'widget' );
 	}
+
+    // extendable function to render a single post in a zone post widget
+    function widget_post( $post ) {
+        ?>
+        <li>
+            <img src="<?php echo esc_url( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'single-post-thumbnail' )[0] ); ?>">
+            <a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>">
+                <?php echo esc_html( get_the_title( $post->ID ) ); ?>
+            </a>
+        </li>
+    <?php
+    }
 
 	function update( $new_instance, $old_instance ) {
 		$instance     = $old_instance;

--- a/widget.zone-posts.php
+++ b/widget.zone-posts.php
@@ -57,13 +57,15 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 
 		<?php if ( ! empty( $zone->description ) && $show_description ) : ?>
 			<p class="description"><?php echo esc_html( $zone->description ); ?></p>
-		<?php endif; ?>
+		<?php endif;
 
-		<ul>
-			<?php foreach ( $posts as $post ) {
-                $this->widget_post( $post );
-            };?>
-		</ul>
+        if ( has_filter( 'widget_zone_posts_renderer' ) ) {
+            apply_filters('widget_zone_posts_renderer', $posts);
+        }
+        else {
+            $this->widget_posts( $posts );
+        }
+        ?>
 
 		<?php echo wp_kses_post( $args['after_widget'] ); ?>
 		<?php
@@ -77,15 +79,18 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 		wp_cache_set( 'widget-zone-posts', $cache, 'widget' );
 	}
 
-    // extendable function to render a single post in a zone post widget
-    function widget_post( $post ) {
+    // filterable function to render posts in a zone post widget
+    function widget_posts( $posts ) {
         ?>
-        <li>
-            <img src="<?php echo esc_url( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'single-post-thumbnail' )[0] ); ?>">
-            <a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>">
-                <?php echo esc_html( get_the_title( $post->ID ) ); ?>
-            </a>
-        </li>
+        <ul>
+            <?php foreach ( $posts as $post ) : ?>
+                <li>
+                    <a href="<?php echo esc_url( get_permalink( $post->ID ) ); ?>">
+                        <?php echo esc_html( get_the_title( $post->ID ) ); ?>
+                    </a>
+                </li>
+            <?php endforeach; ?>
+        </ul>
     <?php
     }
 


### PR DESCRIPTION
It would be handy to allow themes to override the rendering logic for a zone's widget. For example, a theme may want to include special CSS classes, or additional content such as thumbnail images or custom taxonomy. This is one way to implement this. Happy to try a different approach, etc.