### PR TITLE
allows the default post types property to be filtered

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -70,7 +70,7 @@ class Zoninator
 
 		add_action( 'split_shared_term', array( $this, 'split_shared_term' ), 10, 4 );
 		
-		$this->default_post_types = array( 'post' );
+		$this->default_post_types = add_filter( 'zoninator_default_post_types', array( 'post' ) );
 	}
 
 	function add_zone_feed() {


### PR DESCRIPTION
Perhaps this is [already taken care of](https://wordpress.org/support/topic/plugin-zone-manager-zoninator-add-specific-custom-post-types), but it could potentially be simplified with a filter.

This could probably close #12, (which is related to #2).
