### PR TITLE
Add zone id to search so you can filter search args by zone id

### DIFF
--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -86,6 +86,7 @@ var zoninator = {}
 
 						request.cat = zoninator.getAdvancedCat();
 						request.date = zoninator.getAdvancedDate();
+						request.zone_id = zoninator.getZoneId();
 
 						if ( term in zoninator.autocompleteCache ) { //&& request.cat && request.date ) {
 							response( zoninator.autocompleteCache[ term ] );


### PR DESCRIPTION
Pass zone_id to the ajax search call allows you to know your zone when you use the filter hook `zoninator_search_args`.  This allows you to filter the post content per zone which can already be done w/ the `zoninator_recent_posts_args` filter hook.
