### PR TITLE
Adding new content types by checking for what is registered

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Zone Manager (Zoninator) ===
-Contributors: batmoo, automattic, pkevan, matthumphreys, wpcomvip, 
+Contributors: batmoo, automattic, wpcomvip, pkevan, matthumphreys, potatomaster, jblz, nickdaugherty, betzster
 Tags: zones, post order, post list, posts, order, zonination, content curation, curation, content management
 Requires at least: 3.5
-Tested up to: 3.6
-Stable tag: 0.5
+Tested up to: 4.2
+Stable tag: 0.6
 License: GPLv2
 
 Curation made easy! Create "zones" then add and order your content!
@@ -57,7 +57,10 @@ Filter the following and change according to your needs:
 
 = 0.6 =
 
+* Support for term splitting in 4.2
 * Run the init hook later so that we can allow custom post types to attach themselves to the plugin http://wordpress.org/support/topic/plugin-zone-manager-zoninator-add-specific-custom-post-types
+* Better translation support
+* Coding standards cleanup
 
 = 0.5 =
 

--- a/zoninator.php
+++ b/zoninator.php
@@ -3,12 +3,12 @@
 Plugin Name: Zone Manager (Zoninator)
 Description: Curation made easy! Create "zones" then add and order your content!
 Author: Mohammad Jangda, Automattic
-Version: 0.5
+Version: 0.6
 Author URI: http://vip.wordpress.com
 Text Domain: zoninator
 Domain Path: /language/
 
-Copyright 2010-2012 Mohammad Jangda, Automattic
+Copyright 2010-2015 Mohammad Jangda, Automattic
 
 This plugin was built by Mohammad Jangda in conjunction with William Davis and the Bangor Daily News.
 
@@ -32,7 +32,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 if( ! class_exists( 'Zoninator' ) ) :
 
-define( 'ZONINATOR_VERSION', '0.5' );
+define( 'ZONINATOR_VERSION', '0.6' );
 define( 'ZONINATOR_PATH', dirname( __FILE__ ) );
 define( 'ZONINATOR_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 

--- a/zoninator.php
+++ b/zoninator.php
@@ -107,9 +107,19 @@ class Zoninator
 
 		do_action( 'zoninator_pre_init' );
 
-		
+
+		/**
+		 * Filter the default types before adding them.
+		 *
+		 * Access point to allow modification of post types.
+		 * The intent here is to allow the user to remove an already
+		 * registered post type from the list.
+		 *
+		 * @param array
+		 * @return array
+		 */
 		// Default post type support
-		foreach ( $this->default_post_types as $post_type ) {
+		foreach ( apply_filters( 'zoninator_default_types', $this->default_post_types ) as $post_type ) {
 			//check to see if the post type is registered
 			if ( post_type_exists( $post_type ) ) {
 				add_post_type_support( $post_type, $this->zone_taxonomy );

--- a/zoninator.php
+++ b/zoninator.php
@@ -70,7 +70,7 @@ class Zoninator
 
 		add_action( 'split_shared_term', array( $this, 'split_shared_term' ), 10, 4 );
 		
-		$this->default_post_types = array( 'post' );
+		$this->default_post_types = array( 'post', 'page' );
 	}
 
 	function add_zone_feed() {
@@ -91,12 +91,31 @@ class Zoninator
 		$this->zone_lock_period 	= apply_filters( 'zoninator_zone_lock_period', 		$this->zone_lock_period );
 		$this->zone_max_lock_period = apply_filters( 'zoninator_zone_max_lock_period', 	$this->zone_max_lock_period );
 		$this->posts_per_page 		= apply_filters( 'zoninator_posts_per_page', 		$this->posts_per_page );
-		
+
+		//update the default post types to include any custom post types
+
+		/**
+		 * Filter the options passed to get_post_types
+		 *
+		 * By default we going to look for only public, non-built in post types.
+		 * @param array
+		 * @return array
+		 */
+		$other_post_types = get_post_types( apply_filters( 'zoninator_get_post_type_options',  array( 'public' => true, '_builtin' => false ) ) );
+		$this->default_post_types = array_merge( $this->default_post_types, $other_post_types );
+
+
 		do_action( 'zoninator_pre_init' );
+
 		
 		// Default post type support
-		foreach( $this->default_post_types as $post_type )
-			add_post_type_support( $post_type, $this->zone_taxonomy );
+		foreach ( $this->default_post_types as $post_type ) {
+			//check to see if the post type is registered
+			if ( post_type_exists( $post_type ) ) {
+				add_post_type_support( $post_type, $this->zone_taxonomy );
+			}
+		}
+
 		
 		// Register taxonomy
 		if( ! taxonomy_exists( $this->zone_taxonomy ) ) {


### PR DESCRIPTION
Based on feedback for my pull request #31.  I have taken a different approach to adding in support for more post types for the Zoninator.

First, I have added 'page' to the default list. Then I am using get_post_types() with a filterable set of options to pull all public, non-built in post types. I have also added a filter to allow access to the list of post types just prior to adding them that will allow the user to remove post types and adding a post_type_exists() check in the loop.
