### PR TITLE
Resolved a duplicate WP_Query

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -1010,7 +1010,7 @@ class Zoninator
 			return $posts;
 		
 		$query = $this->get_zone_query( $zone, $args );
-		$posts = $query->get_posts();
+		$posts = $query->posts;
 		
 		// Add posts to cache
 		$this->add_zone_posts_to_cache( $posts, $zone, $args );


### PR DESCRIPTION
Resolved an issue where 2 WP_Queries were being ran to retrieve an array of posts using z_get_posts_in_zone()
