### PR TITLE
convert admin ajax endpoints to WP-API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/vendor

--- a/class-zoninator-constants.php
+++ b/class-zoninator-constants.php
@@ -1,0 +1,9 @@
+<?php
+
+class Zoninator_Constants
+{
+    const KEY = 'zoninator';
+    const ZONE_TAXONOMY = 'zoninator_zones';
+    const NONCE_PREFIX = 'zone-nonce';
+    const ZONE_AJAX_NONCE_ACTION = 'ajax-action';
+}

--- a/class-zoninator-permissions.php
+++ b/class-zoninator-permissions.php
@@ -1,0 +1,51 @@
+<?php
+
+
+class Zoninator_Permissions
+{
+    public function check( $action = '', $zone_id = null ) {
+        // TODO: should check if zone locked
+        switch( $action ) {
+            case 'insert':
+                $verify_function = 'current_user_can_add_zones';
+                break;
+            case 'update':
+            case 'delete':
+                $verify_function = 'current_user_can_edit_zones';
+                break;
+            default:
+                $verify_function = 'current_user_can_manage_zones';
+                break;
+        }
+
+        if( ! call_user_func( array( $this, $verify_function ), $zone_id ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    public function current_user_can_add_zones() {
+        return current_user_can( $this->_get_add_zones_cap() );
+    }
+
+    public function current_user_can_edit_zones( $zone_id ) {
+        $has_cap = current_user_can( $this->_get_edit_zones_cap() );
+        return apply_filters( 'zoninator_current_user_can_edit_zone', $has_cap, $zone_id );
+    }
+
+    public function current_user_can_manage_zones() {
+        return current_user_can( $this->get_manage_zones_cap() );
+    }
+
+    public function get_manage_zones_cap() {
+        return apply_filters( 'zoninator_manage_zone_cap', 'edit_others_posts' );
+    }
+
+    private function _get_add_zones_cap() {
+        return apply_filters( 'zoninator_add_zone_cap', 'edit_others_posts' );
+    }
+
+    private function _get_edit_zones_cap() {
+        return apply_filters( 'zoninator_edit_zone_cap', 'edit_others_posts' );
+    }
+}

--- a/class-zoninator-rest-api-controller.php
+++ b/class-zoninator-rest-api-controller.php
@@ -1,0 +1,435 @@
+<?php
+
+
+class Zoninator_Rest_Api_Controller
+{
+    const REST_NAMESPACE = 'zoninator/v1';
+
+    const ZONES = '/zones';
+    const ZONE_ITEM_REGEX = '/zones/(?P<zone_id>[\d]+)';
+    const ZONE_ITEM_POSTS_REGEX = '/zones/(?P<zone_id>[\d]+)/posts';
+    const ZONE_ITEM_POSTS_POST_REGEX = '/zones/(?P<zone_id>[\d]+)/posts/(?P<post_id>\d+)';
+
+    const INVALID_ZONE_ID = 'invalid-zone-id';
+    const INVALID_POST_ID = 'invalid-post-id';
+    const ZONE_ID_POST_ID_REQUIRED = 'zone-id-post-id-required';
+    const ZONE_ID_POST_IDS_REQUIRED = 'zone-id-post-ids-required';
+    const ZONE_ID_REQUIRED = 'zone-id-required';
+    const ZONE_FEED_ERROR = 'zone-feed-error';
+    const TERM_REQUIRED = 'term-required';
+
+    /**
+     * @var Zoninator_Zone_Gateway
+     */
+    private $_zone_gateway = null;
+
+    /**
+     * @var Zoninator_Permissions
+     */
+    private $_permissions = null;
+
+    /**
+     * @var Zoninator_View_Renderer
+     */
+    private $_renderer = null;
+
+    function __construct( $data_service, $permissions, $renderer ) {
+        $this->_zone_gateway = $data_service;
+        $this->_permissions = $permissions;
+        $this->_renderer = $renderer;
+        add_action('rest_api_init', array($this, 'init_restful_resources'));
+    }
+
+    function init_restful_resources() {
+        register_rest_route(self::REST_NAMESPACE, self::ZONES, array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_zones')
+        ));
+
+        register_rest_route(self::REST_NAMESPACE, self::ZONE_ITEM_REGEX, array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_zone'),
+            'args' => $this->_get_zone_rest_route_params()
+        ));
+
+        register_rest_route(self::REST_NAMESPACE, self::ZONE_ITEM_POSTS_REGEX, array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_zone_feed'),
+            'args' => $this->_get_zone_rest_route_params()
+        ));
+
+        register_rest_route(self::REST_NAMESPACE, self::ZONE_ITEM_POSTS_REGEX, array(
+            'methods' => WP_REST_Server::CREATABLE,
+            'callback' => array($this, 'add_post'),
+            'permission_callback' => array($this, 'verify_access'),
+            'args' => $this->_get_zone_post_rest_route_params()
+        ));
+
+        register_rest_route(self::REST_NAMESPACE, self::ZONE_ITEM_POSTS_POST_REGEX, array(
+            'methods' => WP_REST_Server::DELETABLE,
+            'callback' => array($this, 'remove_post'),
+            'permission_callback' => array($this, 'verify_access'),
+            'args' => $this->_get_zone_post_rest_route_params()
+        ));
+
+        register_rest_route(self::REST_NAMESPACE, self::ZONE_ITEM_POSTS_REGEX . '/order', array(
+            'methods' => 'PUT',
+            'callback' => array($this, 'reorder_posts'),
+            'permission_callback' => array($this, 'verify_access'),
+            'args' => $this->_get_zone_rest_route_params()
+        ));
+
+        register_rest_route(self::REST_NAMESPACE, self::ZONE_ITEM_REGEX . '/lock', array(
+            'methods' => 'PUT',
+            'callback' => array($this, 'zone_update_lock'),
+            'permission_callback' => array($this, 'verify_access'),
+            'args' => $this->_get_zone_rest_route_params()
+        ));
+
+        register_rest_route(self::REST_NAMESPACE, '/posts/search', array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => array($this, 'search_posts')
+        ));
+
+        register_rest_route(self::REST_NAMESPACE, '/posts/recent', array(
+            'methods' => WP_REST_Server::READABLE,
+            'callback' => array($this, 'get_recent_posts')
+        ));
+    }
+
+    function get_zones() {
+        return $this->_zone_gateway->get_zones();
+    }
+
+    function get_zone(WP_REST_Request $request) {
+        $zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
+        return $this->_zone_gateway->get_zone( $zone_id );
+    }
+
+    function add_post(WP_REST_Request $request) {
+        $zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
+        $post_id = $this->_get_param( $request, 'post_id', 0, 'absint' );
+
+        $post = get_post( $post_id );
+
+        if ( ! $post ) {
+            return $this->_bad_request(self::INVALID_POST_ID, __('invalid post id', 'zonimator'));
+        }
+
+        $zone = $this->_zone_gateway->get_zone($zone_id);
+
+        if ( ! $zone ) {
+            return $this->_bad_request(self::INVALID_ZONE_ID, __('invalid zone id', 'zonimator'));
+        }
+
+        $result = $this->_zone_gateway->add_zone_posts($zone_id, $post, true);
+
+        if ( is_wp_error( $result ) ) {
+            $status = 500;
+            $content = $result->get_error_message();
+        } else {
+            ob_start();
+            $this->_renderer->admin_page_zone_post($post, $zone);
+            $content = ob_get_contents();
+            ob_end_clean();
+            $status = 200;
+        }
+
+        $response = new WP_REST_Response( array(
+            'zone_id' => $zone_id,
+            'content' => $content,
+            'status' => $status) );
+
+        $response->set_status($status);
+
+        return $response;
+    }
+
+    function verify_access(WP_REST_Request $request) {
+        $zone_id = intval($request->get_param('zone_id'));
+        $action = $request->get_method();
+
+        // TODO: should check if zone locked
+
+        switch ($action) {
+            case WP_REST_Server::CREATABLE:
+                $verify_function = 'insert';
+                break;
+            case WP_REST_Server::EDITABLE:
+            case WP_REST_Server::DELETABLE:
+                $verify_function = 'update';
+                break;
+            default:
+                $verify_function = '';
+                break;
+        }
+
+        if (!$this->_permissions->check($verify_function, $zone_id)) {
+            return $this->_bad_request('rest-permission-denied', __('Sorry, you\'re not supposed to do that...', 'zoninator'));
+        }
+        return true;
+    }
+
+    function remove_post(WP_REST_Request $request) {
+        $zone_id = intval($request->get_param('zone_id'));
+        $post_id = intval($request->get_param('post_id'));
+
+        if (!$zone_id || !$post_id) {
+            return $this->_bad_request(self::ZONE_ID_POST_ID_REQUIRED, __('post id and zone id required', 'zonimator'));
+        }
+
+        $result = $this->_zone_gateway->remove_zone_posts($zone_id, $post_id);
+
+        if (is_wp_error($result)) {
+            $status = 500;
+            $content = $result->get_error_message();
+        } else {
+            $status = 200;
+            $content = '';
+        }
+
+        return new WP_REST_Response(array(
+            'zone_id' => $zone_id,
+            'post_id' => $post_id,
+            'content' => $content,
+            'status' => $status), $status);
+    }
+
+    function reorder_posts($request) {
+        $zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
+        $post_ids = (array) $this->_get_param( $request, 'posts', array(), 'absint' );
+
+        if ( ! $zone_id || empty( $post_ids ) ) {
+            return $this->_bad_request( self::ZONE_ID_POST_IDS_REQUIRED, __('post ids and zone id required', 'zonimator') );
+        }
+
+        $result = $this->_zone_gateway->add_zone_posts( $zone_id, $post_ids, false );
+
+        if (is_wp_error($result)) {
+            $status = 0;
+            $http_status = 500;
+            $content = $result->get_error_message();
+        } else {
+            $status = 1;
+            $http_status = 200;
+            $content = '';
+        }
+
+        return new WP_REST_Response(array(
+            'zone_id' => $zone_id,
+            'post_ids' => $post_ids,
+            'content' => $content,
+            'status' => $status), $http_status);
+    }
+
+    function zone_update_lock(WP_REST_Request $request)
+    {
+        $zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
+
+        if (!$zone_id) {
+            return $this->_bad_request('rest_zone_update_lock-zone-id-required', __('zone id required', 'zonimator'));
+        }
+
+        if (!$this->_zone_gateway->is_zone_locked($zone_id)) {
+            $this->_zone_gateway->lock_zone($zone_id);
+            return new WP_REST_Response(array(
+                'zone_id' => $zone_id,
+                'status' => 1), 200);
+        }
+
+        return new WP_REST_Response(array(
+            'zone_id' => $zone_id,
+            'status' => 0), 400);
+    }
+
+    function search_posts(WP_REST_Request $request)
+    {
+        $q = $this->_get_param($request, 'term', '', 'stripslashes');
+
+        if (empty($q)) {
+            return $this->_bad_request(self::TERM_REQUIRED, __('parameter term is required', 'zonimator'));
+        }
+
+        $filter_cat = $this->_get_param($request, 'cat', '', 'absint');
+        $filter_date = $this->_get_param($request, 'date', '', 'striptags');
+
+        $post_types = $this->_zone_gateway->get_supported_post_types();
+        $limit = $this->_get_param($request, 'limit', $this->_zone_gateway->posts_per_page);
+
+        if ( 0 >= $limit ) {
+            $limit = $this->_zone_gateway->posts_per_page;
+        }
+
+        $exclude = (array)$this->_get_param( $request, 'exclude', array(), 'absint' );
+
+        $args = apply_filters('zoninator_search_args', array(
+            's' => $q,
+            'post__not_in' => $exclude,
+            'posts_per_page' => $limit,
+            'post_type' => $post_types,
+            'post_status' => array('publish', 'future'),
+            'order' => 'DESC',
+            'orderby' => 'post_date',
+            'suppress_filters' => true,
+        ));
+
+        if ( $this->_validate_category_filter( $filter_cat ) ) {
+            $args['cat'] = $filter_cat;
+        }
+
+        if ( $this->_validate_date_filter( $filter_date ) ) {
+            $filter_date_parts = explode( '-', $filter_date );
+            $args['year'] = $filter_date_parts[0];
+            $args['monthnum'] = $filter_date_parts[1];
+            $args['day'] = $filter_date_parts[2];
+        }
+
+        $query = new WP_Query($args);
+
+        $stripped_posts = array();
+
+        if ( $query->have_posts() ) {
+            foreach ( $query->posts as $post ) {
+                $stripped_posts[] = apply_filters( 'zoninator_search_results_post', array(
+                    'title' => !empty( $post->post_title ) ? $post->post_title : __( '(no title)', 'zoninator' ),
+                    'post_id' => $post->ID,
+                    'date' => get_the_time( get_option( 'date_format' ), $post ),
+                    'post_type' => $post->post_type,
+                    'post_status' => $post->post_status,
+                ), $post );
+            }
+        }
+
+        return new WP_REST_Response( $stripped_posts, 200 );
+    }
+
+    function get_zone_feed( WP_REST_Request $request )
+    {
+        $zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
+
+        if ( empty( $zone_id ) ) {
+            return $this->_bad_request( self::ZONE_ID_REQUIRED, __('zone_id is required', 'zonimator' ) );
+        }
+
+        $results = $this->_zone_gateway->get_zone_feed( $zone_id );
+
+        if ( is_wp_error( $results ) ) {
+            return $this->_bad_request( self::ZONE_FEED_ERROR, $results->get_error_message() );
+        }
+
+        return new WP_REST_Response( $results, 200 );
+    }
+
+    function get_recent_posts(WP_REST_Request $request)
+    {
+        $cat = $this->_get_param( $request, 'cat', '', 'absint' );
+        $date = $this->_get_param( $request, 'date', '', 'striptags' );
+        $zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
+
+        $limit = $this->_zone_gateway->posts_per_page;
+        $post_types = $this->_zone_gateway->get_supported_post_types();
+        $zone_posts = $this->_zone_gateway->get_zone_posts($zone_id);
+        $zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
+
+        $http_status = 200;
+
+        if ( is_wp_error( $zone_posts ) ) {
+            $status = 0;
+            $content = $zone_posts->get_error_message();
+            $http_status = 500;
+        } else {
+            $args = apply_filters( 'zoninator_recent_posts_args', array(
+                'posts_per_page' => $limit,
+                'order' => 'DESC',
+                'orderby' => 'post_date',
+                'post_type' => $post_types,
+                'ignore_sticky_posts' => true,
+                'post_status' => array( 'publish', 'future' ),
+                'post__not_in' => $zone_post_ids,
+            ) );
+
+            if ( $this->_validate_category_filter( $cat ) ) {
+                $args['cat'] = $cat;
+            }
+
+            if ( $this->_validate_date_filter( $date ) ) {
+                $filter_date_parts = explode( '-', $date );
+                $args['year'] = $filter_date_parts[0];
+                $args['monthnum'] = $filter_date_parts[1];
+                $args['day'] = $filter_date_parts[2];
+            }
+
+            $content = '';
+            $recent_posts = get_posts( $args );
+            foreach ( $recent_posts as $post ) {
+                $content .= sprintf('<option value="%d">%s</option>', $post->ID, get_the_title($post->ID) . ' (' . $post->post_status . ')');
+            }
+
+            wp_reset_postdata();
+            $status = 1;
+        }
+
+        if ( ! $content ) {
+            $empty_label = __( 'No results found', 'zoninator' );
+        } elseif ( $cat ) {
+            $empty_label = sprintf(__('Choose post from %s', 'zoninator'), get_the_category_by_ID($cat));
+        } else {
+            $empty_label = __('Choose a post', 'zoninator');
+        }
+
+        $content = '<option value="">' . esc_html($empty_label) . '</option>' . $content;
+
+        $response = new WP_REST_Response(array(
+            'zone_id' => $zone_id,
+            'content' => $content,
+            'status' => $status));
+        $response->set_status($http_status);
+        return $response;
+    }
+
+    function _get_param(WP_REST_Request $object, $var, $default = '', $sanitize_callback = '') {
+        $value = $object->get_param( $var );
+        $value = ($value !== null) ? $value : $default;
+
+
+        if ( is_callable( $sanitize_callback ) ) {
+            $value = ( is_array( $value ) ) ? array_map( $sanitize_callback, $value ) : call_user_func( $sanitize_callback, $value );
+        }
+
+        return $value;
+    }
+
+    function is_numeric($item) {
+        // see https://github.com/WP-API/WP-API/issues/1520 on why we do not use is_numeric directly
+        return is_numeric( $item );
+    }
+
+    private function _validate_date_filter($date) {
+        return preg_match( '/([0-9]{4})-([0-9]{2})-([0-9]{2})/', $date );
+    }
+
+    private function _validate_category_filter($cat) {
+        return $cat && get_term_by( 'id', $cat, 'category' );
+    }
+
+    private function _get_zone_rest_route_params() {
+        return array(
+            'zone_id' => array(
+                'validate_callback' => array($this, 'is_numeric')
+            )
+        );
+    }
+
+    private function _get_zone_post_rest_route_params() {
+        $zone_params = $this->_get_zone_rest_route_params();
+        return array_merge(array(
+            'post_id' => array(
+                'validate_callback' => array($this, 'is_numeric')
+            )
+        ), $zone_params);
+    }
+
+    private function _bad_request($code, $message) {
+        return new WP_Error( $code, $message, array( 'status' => 400 ) );
+    }
+}

--- a/class-zoninator-view-renderer.php
+++ b/class-zoninator-view-renderer.php
@@ -1,0 +1,85 @@
+<?php
+
+class Zoninator_View_Renderer
+{
+    /**
+     * @var Zoninator_Zone_Gateway
+     */
+    private $_zone_gateway = null;
+
+    public function __construct( $zone_gateway )
+    {
+        $this->_zone_gateway = $zone_gateway;
+    }
+
+    public function admin_page_zone_post($post, $zone)
+    {
+        $columns = apply_filters('zoninator_zone_post_columns', array(
+            'position' => array($this, 'admin_page_zone_post_col_position'),
+            'info' => array($this, 'admin_page_zone_post_col_info')
+        ), $post, $zone);
+        ?>
+        <div id="zone-post-<?php echo $post->ID; ?>" class="zone-post" data-post-id="<?php echo $post->ID; ?>">
+            <table>
+                <tr>
+                    <?php foreach ($columns as $column_key => $column_callback) : ?>
+                        <?php if (is_callable($column_callback)) : ?>
+                            <td class="zone-post-col zone-post-<?php echo $column_key; ?>">
+                                <?php call_user_func($column_callback, $post, $zone); ?>
+                            </td>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </tr>
+            </table>
+            <input type="hidden" name="zone-post-id" value="<?php echo $post->ID; ?>"/>
+        </div>
+        <?php
+    }
+
+    function admin_page_zone_post_col_position( $post, $zone ) {
+        $current_position = $this->_zone_gateway->get_post_order( $post->ID, $zone );
+        ?>
+        <span title="<?php esc_attr_e( 'Click and drag to change the position of this item.', 'zoninator' ); ?>">
+			<?php echo esc_html( $current_position ); ?>
+		</span>
+        <?php
+    }
+
+    function admin_page_zone_post_col_info( $post, $zone ) {
+        $action_links = array(
+            sprintf( '<a href="%s" class="edit" target="_blank" title="%s">%s</a>', get_edit_post_link( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'Edit', 'zoninator' ) ),
+            sprintf( '<a href="#" class="delete" title="%s">%s</a>', __( 'Remove this item from the zone', 'zoninator' ), __( 'Remove', 'zoninator' ) ),
+            sprintf( '<a href="%s" class="view" target="_blank" title="%s">%s</a>', get_permalink( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'View', 'zoninator' ) ),
+            // Move To
+            // Copy To
+        );
+        ?>
+        <?php echo sprintf( '%s <span class="zone-post-status">(%s)</span>', esc_html( $post->post_title ), esc_html( $post->post_status ) ); ?>
+
+        <div class="row-actions">
+            <?php echo implode( ' | ', $action_links ); ?>
+        </div>
+        <?php
+    }
+
+    function zone_admin_search_form() {
+        ?>
+        <div class="zone-search-wrapper">
+            <label for="zone-post-search"><?php esc_html_e( 'Search for content', 'zoninator' );?></label>
+            <input type="text" id="zone-post-search" name="search" />
+            <p class="description"><?php esc_html_e( 'Enter a term or phrase in the text box above to search for and add content to this zone.', 'zoninator' ); ?></p>
+        </div>
+        <?php
+    }
+
+    function zone_advanced_search_filters() {
+        ?>
+        <div class="zone-advanced-search-filters-heading">
+            <span class="zone-toggle-advanced-search" data-alt-label="<?php esc_attr_e( 'Hide', 'zoninator' ); ?>"><?php esc_html_e( 'Show Filters', 'zoninator' ); ?></span>
+        </div>
+        <div class="zone-advanced-search-filters-wrapper">
+            <?php do_action( 'zoninator_advanced_search_fields' ); ?>
+        </div>
+        <?php
+    }
+}

--- a/class-zoninator-zone-gateway.php
+++ b/class-zoninator-zone-gateway.php
@@ -1,0 +1,591 @@
+<?php
+
+class Zoninator_Zone_Gateway
+{
+    var $post_types = null;
+
+    var $zone_detail_defaults = array(
+        'description' => ''
+        // Add additional properties here!
+    );
+
+    var $zone_term_prefix = 'zone-';
+
+    var $zone_meta_prefix = '_zoninator_order_';
+
+    var $zone_lock_period = 30; // number of seconds a lock is valid for
+
+    var $zone_max_lock_period = 600; // max number of seconds for all locks in a session
+
+    var $posts_per_page = 10;
+
+    function __construct() {
+        $this->zone_lock_period = apply_filters( 'zoninator_zone_lock_period', $this->zone_lock_period );
+        $this->zone_max_lock_period = apply_filters( 'zoninator_zone_max_lock_period', $this->zone_max_lock_period );
+        $this->posts_per_page = apply_filters( 'zoninator_posts_per_page', $this->posts_per_page );
+
+        add_action( 'split_shared_term', array( $this, 'split_shared_term' ), 10, 4 );
+        $this->default_post_types = array( 'post' );
+    }
+
+    function init() {
+        // Default post type support
+        foreach( $this->default_post_types as $post_type )
+            add_post_type_support( $post_type, Zoninator_Constants::ZONE_TAXONOMY );
+
+        // Register taxonomy
+        if( ! taxonomy_exists( Zoninator_Constants::ZONE_TAXONOMY ) ) {
+            register_taxonomy( Zoninator_Constants::ZONE_TAXONOMY, $this->get_supported_post_types(), array(
+                'label' => __( 'Zones', 'zoninator' ),
+                'hierarchical' => false,
+                'query_var' => false,
+                'rewrite' => false,
+                'public' => false,
+
+            ) );
+        }
+    }
+
+    function insert_zone( $slug, $name = '', $details = array() ) {
+
+        // slug cannot be empty
+        if( empty( $slug ) ) {
+            return new WP_Error( 'zone-empty-slug', __( 'Slug is a required field.', 'zoninator' ) );
+        }
+
+        $slug = $this->get_formatted_zone_slug( $slug );
+
+        if ( empty( $name ) ) {
+            $name = $slug;
+        }
+
+        $details = wp_parse_args( $details, $this->zone_detail_defaults );
+        $details = maybe_serialize( stripslashes_deep( $details ) );
+
+        $args = array(
+            'slug' => $slug,
+            'description' => $details,
+        );
+
+        // Filterize to allow other inputs
+        $args = apply_filters( 'zoninator_insert_zone', $args );
+
+        return wp_insert_term( $name, Zoninator_Constants::ZONE_TAXONOMY, $args );
+    }
+
+    function update_zone( $zone, $data = array() ) {
+        $zone_id = $this->get_zone_id( $zone );
+
+        if( $this->zone_exists( $zone_id ) ) {
+            $zone = $this->get_zone( $zone );
+
+            $name = $this->_get_value_or_default( 'name', $data, $zone->name );
+            $slug = $this->_get_value_or_default( 'slug', $data, $zone->slug, array( $this, 'get_formatted_zone_slug' ) );
+            $details = $this->_get_value_or_default( 'details', $data, array() );
+
+            // TODO: Back-fill current zone details
+            //$details = wp_parse_args( $details, $this->zone_detail_defaults );
+            $details = wp_parse_args( $details, $this->zone_detail_defaults );
+            $details = maybe_serialize( stripslashes_deep( $details ) );
+
+            $args = array(
+                'name' => $name,
+                'slug' => $slug,
+                'description' => $details
+            );
+
+            // Filterize to allow other inputs
+            $args = apply_filters( 'zoninator_update_zone', $args, $zone_id, $zone );
+
+            return wp_update_term( $zone_id, Zoninator_Constants::ZONE_TAXONOMY, $args );
+        }
+        return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
+    }
+
+    function get_zone_feed( $zone_slug_or_id ) {
+        $zone_id = $this->get_zone( $zone_slug_or_id );
+
+        if ( empty( $zone_id ) ) {
+            return new WP_Error( 'invalid-zone-supplied', __( 'Invalid zone supplied', 'zoninator' ) );
+        }
+
+        $results = $this->get_zone_posts( $zone_id, apply_filters( 'zoninator_json_feed_fields', array(), $zone_slug_or_id ) );
+
+        if ( empty( $results ) ) {
+            return new WP_Error( 'no-zone-posts-found',  __( 'No zone posts found', 'zoninator' ) );
+        }
+
+        $filtered_results = $this->filter_zone_feed_fields( $results );
+
+        return apply_filters( 'zoninator_json_feed_results', $filtered_results, $zone_slug_or_id );
+    }
+
+    private function filter_zone_feed_fields( $results ) {
+        $white_listed_fields = array( 'ID', 'post_date', 'post_title', 'post_content', 'post_excerpt', 'post_status', 'guid' );
+        $filtered_results = array();
+
+        $i = 0;
+        foreach ( $results as $result ) {
+            foreach( $white_listed_fields as $field ) {
+                if ( ! array_key_exists( $i, $filtered_results ) ) {
+                    $filtered_results[$i] = new stdClass();
+                }
+                $filtered_results[$i]->$field = $result->$field;
+            }
+            $i++;
+        }
+
+        return $filtered_results;
+    }
+
+    function get_zones( $args = array() ) {
+
+        $args = wp_parse_args( $args, array(
+            'orderby' => 'id',
+            'order' => 'ASC',
+            'hide_empty' => 0,
+        ) );
+
+        $zones = get_terms( Zoninator_Constants::ZONE_TAXONOMY, $args );
+
+        // Add extra fields in description as properties
+        foreach( $zones as $zone ) {
+            $zone = $this->_fill_zone_details( $zone );
+        }
+
+        return $zones;
+    }
+
+    function get_post_order( $post, $zone ) {
+        $post_id = $this->get_post_id( $post );
+        $meta_key = $this->get_zone_meta_key( $zone );
+
+        return get_metadata( 'post', $post_id, $meta_key, true );
+    }
+
+    function get_zone( $zone ) {
+        if( is_int( $zone ) ) {
+            $field = 'id';
+        } elseif( is_string( $zone ) ) {
+            $field = 'slug';
+            $zone = $this->get_zone_slug( $zone );
+        } elseif( is_object( $zone ) ) {
+            return $zone;
+        } else {
+            return false;
+        }
+
+        $zone = get_term_by( $field, $zone, Zoninator_Constants::ZONE_TAXONOMY );
+
+        if( ! $zone )
+            return false;
+
+        return $this->_fill_zone_details( $zone );
+    }
+
+    function get_zone_posts( $zone, $args = array() ) {
+        // Check cache first
+        if( $posts = $this->get_zone_posts_from_cache( $zone, $args ) )
+            return $posts;
+
+        $query = $this->get_zone_query( $zone, $args );
+        $posts = $query->posts;
+
+        // Add posts to cache
+        $this->add_zone_posts_to_cache( $posts, $zone, $args );
+
+        return $posts;
+    }
+
+    function add_zone_posts( $zone, $posts, $append = false ) {
+        $zone = $this->get_zone( $zone );
+        $meta_key = $this->get_zone_meta_key( $zone );
+
+        $this->_empty_zone_posts_cache( $meta_key );
+
+        if( $append ) {
+            // Order should be the highest post order
+            $last_post = $this->get_last_post_in_zone( $zone );
+            if( $last_post )
+                $order = $this->get_post_order( $last_post, $zone );
+            else
+                $order = 0;
+        } else {
+            $order = 0;
+            $this->remove_zone_posts( $zone );
+        }
+
+        foreach( (array) $posts as $post ) {
+            $post_id = $this->get_post_id( $post );
+            if( $post_id ) {
+                $order++;
+                update_metadata( 'post', $post_id, $meta_key, $order, true );
+            }
+            // TODO: remove_object_terms -- but need remove object terms function :(
+        }
+
+        clean_term_cache( $this->get_zone_id( $zone ), Zoninator_Constants::ZONE_TAXONOMY ); // flush cache for our zone term and related APC caches
+
+        do_action( 'zoninator_add_zone_posts', $posts, $zone );
+        return null;
+    }
+
+    function lock_zone( $zone, $user_id = 0 ) {
+        $zone_id = $this->get_zone_id( $zone );
+
+        if( ! $zone_id )
+            return false;
+
+        if( ! $user_id ) {
+            $user = wp_get_current_user();
+            $user_id = $user->ID;
+        }
+
+        $lock_key = $this->get_zone_meta_key( $zone );
+        $expiry = $this->zone_lock_period + 1; // Add a one to avoid most race condition issues between lock expiry and ajax call
+        set_transient( $lock_key, $user->ID, $expiry );
+
+        // Possible alternative: set zone lock as property with time and user
+    }
+
+    // Not really needed with transients...
+    function unlock_zone( $zone ) {
+        $zone_id = $this->get_zone_id( $zone );
+
+        if( ! $zone_id )
+            return false;
+
+        $lock_key = $this->get_zone_meta_key( $zone );
+
+        delete_transient( $lock_key );
+    }
+
+    function is_zone_locked( $zone ) {
+        $zone_id = $this->get_zone_id( $zone );
+        if( ! $zone_id )
+            return false;
+
+        $user = wp_get_current_user();
+        $lock_key = $this->get_zone_meta_key( $zone );
+
+        $lock = get_transient( $lock_key );
+
+        // If lock doesn't exist, or check if current user same as lock user
+        if( ! $lock || absint( $lock ) === absint( $user->ID ) )
+            return false;
+        else
+            // return user_id of locking user
+            return absint( $lock );
+    }
+
+    function zone_exists( $zone ) {
+        $zone_id = $this->get_zone_id( $zone );
+
+        if( term_exists( $zone_id, Zoninator_Constants::ZONE_TAXONOMY ) )
+            return true;
+
+        return false;
+    }
+
+    function delete_zone( $zone ) {
+        $zone_id = $this->get_zone_id( $zone );
+        $meta_key = $this->get_zone_meta_key( $zone );
+
+        $this->_empty_zone_posts_cache( $meta_key );
+
+        if( $this->zone_exists( $zone_id ) ) {
+            // Delete all post associations for the zone
+            $this->remove_zone_posts( $zone_id );
+
+            // Delete the term
+            $delete = wp_delete_term( $zone_id, Zoninator_Constants::ZONE_TAXONOMY );
+
+            if( ! $delete ) {
+                return new WP_Error( 'delete-zone', __( 'Sorry, we couldn\'t delete the zone.', 'zoninator' ) );
+            } else {
+                do_action( 'zoninator_delete_zone', $zone_id );
+                return $delete;
+            }
+        }
+        return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
+    }
+
+    function remove_zone_posts( $zone, $posts = null ) {
+        $zone = $this->get_zone( $zone );
+        $meta_key = $this->get_zone_meta_key( $zone );
+
+        $this->_empty_zone_posts_cache( $meta_key );
+
+        // if null, delete all
+        if( ! $posts )
+            $posts = $this->get_zone_posts( $zone );
+
+        foreach( (array) $posts as $post ) {
+            $post_id = $this->get_post_id( $post );
+            if( $post_id )
+                delete_metadata( 'post', $post_id, $meta_key );
+        }
+
+        clean_term_cache( $this->get_zone_id( $zone ), Zoninator_Constants::ZONE_TAXONOMY ); // flush cache for our zone term and related APC caches
+
+        do_action( 'zoninator_remove_zone_posts', $posts, $zone );
+        return null;
+    }
+
+    function get_post_id( $post ) {
+        if( is_int( $post ) )
+            return $post;
+        elseif( is_array( $post ) )
+            return absint( $post['ID'] );
+        elseif( is_object( $post ) )
+            return $post->ID;
+
+        return false;
+    }
+
+    function get_zone_meta_key( $zone ) {
+        $zone_id = $this->get_zone_id( $zone );
+        return $this->zone_meta_prefix . $zone_id;
+    }
+
+    function get_zone_id( $zone ) {
+        if( is_int( $zone ) )
+            return $zone;
+
+        $zone = $this->get_zone( $zone );
+        if( is_object( $zone ) )
+            $zone = $zone->term_id;
+
+        return (int)$zone;
+    }
+
+    function get_first_post_in_zone( $zone ) {
+        return $this->get_single_post_in_zone( $zone );
+    }
+
+    function get_prev_post_in_zone( $zone, $post_id ) {
+        // TODO: test this works
+        $order = $this->get_post_order_in_zone( $zone, $post_id );
+
+        return $this->get_single_post_in_zone( $zone, array(
+            'meta_value' => $order,
+            'meta_compare' => '<='
+        ) );
+    }
+
+    function get_next_post_in_zone( $zone, $post_id ) {
+        // TODO: test this works
+        $order = $this->get_post_order_in_zone( $zone, $post_id );
+
+        return $this->get_single_post_in_zone( $zone, array(
+            'meta_value' => $order,
+            'meta_compare' => '>='
+        ) );
+
+    }
+
+    // Handle 4.2 term-splitting
+    function split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
+        if ( Zoninator_Constants::ZONE_TAXONOMY === $taxonomy ) {
+            do_action( 'zoninator_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
+
+            // Quick, easy switcheroo; add posts to new zone id and remove from the old one.
+            $posts = $this->get_zone_posts( $old_term_id );
+            if ( ! empty( $posts ) ) {
+                $this->add_zone_posts( $new_term_id, $posts );
+                $this->remove_zone_posts( $old_term_id );
+            }
+
+            do_action( 'zoninator_did_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
+        }
+    }
+
+    function get_post_order_in_zone( $zone, $post_id ) {
+        // TODO: implement
+        return 0;
+    }
+
+    function get_zone_posts_from_cache( $zone, $args = array() ) {
+        return false; // TODO: implement
+
+//        $meta_key = $this->get_zone_meta_key( $zone );
+//        $cache_key = $this->get_zone_cache_key( $zone, $args );
+//        if( $posts = wp_cache_get( $cache_key, $meta_key ) )
+//            return $posts;
+//        return false;
+    }
+
+    function add_zone_posts_to_cache( $posts, $zone, $args = array() ) {
+        return; // TODO: implement
+
+//        $meta_key = $this->get_zone_meta_key( $zone );
+//        $cache_key = $this->get_zone_cache_key( $zone, $args );
+//        wp_cache_set( $cache_key, $posts, $meta_key );
+    }
+
+    function get_supported_post_types() {
+        if( isset( $this->post_types ) )
+            return $this->post_types;
+
+        $this->post_types = array();
+
+        foreach( get_post_types() as $post_type ) {
+            if( post_type_supports( $post_type, Zoninator_Constants::ZONE_TAXONOMY ) )
+                array_push( $this->post_types, $post_type );
+        }
+
+        return $this->post_types;
+    }
+
+    function get_zone_query( $zone, $args = array() ) {
+        $meta_key = $this->get_zone_meta_key( $zone );
+
+        $defaults = array(
+            'order' => 'ASC',
+            'posts_per_page' => -1,
+            'post_type' => $this->get_supported_post_types(),
+            'ignore_sticky_posts' => '1', // don't want sticky posts messing up our order
+        );
+
+        // Default to published posts on the front-end
+        if ( ! is_admin() )
+            $defaults['post_status'] = array( 'publish' );
+
+        if ( is_admin() ) // skip APC in the admin
+            $defaults['suppress_filters'] = true;
+
+        $args = wp_parse_args( $args, $defaults );
+
+        // Un-overridable args
+        $args['orderby'] = 'meta_value_num';
+        $args['meta_key'] = $meta_key;
+
+        /* // 3.1-friendly, though missing sort support which is why we're using the old way
+        if( function_exists( 'get_post_format' ) ) {
+            $args['meta_query'] = array(
+                array(
+                    'key' => $meta_key,
+                    'type' => 'NUMERIC'
+                )
+            );
+        } else {
+            $args['meta_key'] = $meta_key;
+        }
+        */
+        return new WP_Query( $args );
+    }
+
+    function get_zone_slug( $zone ) {
+        if( is_int( $zone ) )
+            $zone = $this->get_zone( $zone );
+
+        if( is_object( $zone ) )
+            $zone = $zone->slug;
+
+        return $this->get_formatted_zone_slug( $zone );
+    }
+
+    function get_formatted_zone_slug( $slug ) {
+        return $slug; // legacy function -- slugs can no longer be changed
+    }
+
+    function get_last_post_in_zone( $zone ) {
+        return $this->get_single_post_in_zone( $zone, array(
+            'order' => 'DESC',
+        ) );
+    }
+
+    // TODO: Caching needs to be testing properly before being implemented!
+    function get_zone_cache_key( $zone, $args = array() ) {
+        return '';
+//
+//        $meta_key = $this->get_zone_meta_key( $zone );
+//        $hash = md5( serialize( $args ) );
+//        return $meta_key . $hash;
+    }
+
+    function get_single_post_in_zone( $zone, $args = array() ) {
+
+        $args = wp_parse_args( $args, array(
+            'posts_per_page' => 1,
+            'showposts' => 1,
+        ) );
+
+        $post = $this->get_zone_posts( $zone, $args );
+
+        if( is_array( $post ) && ! empty( $post ) )
+            return array_pop( $post );
+
+        return false;
+    }
+
+    private function _fill_zone_details( $zone ) {
+        if( ! empty( $zone->zoninator_parsed ) && $zone->zoninator_parsed )
+            return $zone;
+
+        $details = array();
+
+        if( ! empty( $zone->description ) )
+            $details = maybe_unserialize( $zone->description );
+
+        $details = wp_parse_args( $details, $this->zone_detail_defaults );
+
+        foreach( $details as $detail_key => $detail_value ) {
+            $zone->$detail_key = $detail_value;
+        }
+
+        $zone->zoninator_parsed = true;
+
+        return $zone;
+    }
+
+    private function _empty_zone_posts_cache( $meta_key ) {
+        return; // TODO: implement
+    }
+
+    function get_zones_for_post( $post_id ) {
+        // TODO: build this out
+
+        // get_object_terms
+        // get_terms
+
+        // OR
+
+        // get all meta_keys that match the prefix
+        // strip the prefix
+
+        // OR
+
+        // get all zones and see if there's a matching meta entry
+        // strip the prefix from keys
+
+        // array_map( 'absint', $zone_ids )
+        // $zones = array();
+        // foreach( $zone_ids as $zone_id ) {
+        // $zones[] = get_zone( $zone_id );
+        //}
+        //return $zones;
+    }
+
+    function get_unformatted_zone_slug( $slug ) {
+        return $slug; // legacy function -- slugs can no longer be changed
+    }
+
+    private function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {
+        if( is_object( $object ) )
+            $value = ! empty( $object->$var ) ? $object->$var : $default;
+        elseif( is_array( $object ) )
+            $value = ! empty( $object[$var] ) ? $object[$var] : $default;
+        else
+            $value = $default;
+
+        if( is_callable( $sanitize_callback ) ) {
+            if( is_array( $value ) )
+                $value = array_map( $sanitize_callback, $value );
+            else
+                $value = call_user_func( $sanitize_callback, $value );
+        }
+
+        return $value;
+    }
+}

--- a/functions.php
+++ b/functions.php
@@ -10,7 +10,7 @@ function z_get_zoninator() {
  * @return array List of all zones
  */
 function z_get_zones() {
-	return z_get_zoninator()->get_zones();
+	return z_get_zoninator()->get_zone_gateway()->get_zones();
 }
 
 /**
@@ -18,7 +18,7 @@ function z_get_zones() {
  * @return array Zone object
  */
 function z_get_zone( $zone ) {
-	return z_get_zoninator()->get_zone( $zone );
+	return z_get_zoninator()->get_zone_gateway()->get_zone( $zone );
 }
 
 /**
@@ -27,7 +27,7 @@ function z_get_zone( $zone ) {
  * @return array List of orders post objects
  */
 function z_get_posts_in_zone( $zone, $args = array() ) {
-	return z_get_zoninator()->get_zone_posts( $zone, $args );
+	return z_get_zoninator()->get_zone_gateway()->get_zone_posts( $zone, $args );
 }
 
 /**
@@ -35,7 +35,7 @@ function z_get_posts_in_zone( $zone, $args = array() ) {
  * @return WP_Query List of orders post objects
  */
 function z_get_zone_query( $zone, $args = array() ) {
-	return z_get_zoninator()->get_zone_query( $zone, $args );
+	return z_get_zoninator()->get_zone_gateway()->get_zone_query( $zone, $args );
 }
 
 /**
@@ -45,17 +45,17 @@ function z_get_zone_query( $zone, $args = array() ) {
  */
 function z_get_next_post_in_zone( $zone, $post_id = 0 ) {
 	$post_id = z_get_loop_post_id_or_default( $post_id );
-	return z_get_zoninator()->get_next_post_in_zone( $zone, $post_id );
+	return z_get_zoninator()->get_zone_gateway()->get_next_post_in_zone( $zone, $post_id );
 }
 
 /**
  * @param $zone int|string ID or Slug of the zone
  * @param $post_id int ID of the post (or, null if in The Loop)
- * @return array|false Returns previous post relative to post_id for the given zone 
+ * @return array|false Returns previous post relative to post_id for the given zone
  */
 function z_get_prev_post_in_zone( $zone, $post_id = 0 ) {
 	$post_id = z_get_loop_post_id_or_default( $post_id );
-	return z_get_zoninator()->get_prev_post_in_zone( $zone, $post_id );
+	return z_get_zoninator()->get_zone_gateway()->get_prev_post_in_zone( $zone, $post_id );
 }
 
 /**
@@ -64,7 +64,7 @@ function z_get_prev_post_in_zone( $zone, $post_id = 0 ) {
  */
 function z_get_post_zones( $post_id = 0 ) {
 	$post_id = z_get_loop_post_id_or_default( $post_id );
-	return z_get_zoninator()->get_zones_for_post( $post_id );
+	return z_get_zoninator()->get_zone_gateway()->get_zones_for_post( $post_id );
 }
 
 function z_get_loop_post_id_or_default( $post_id = 0 ) {

--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -1,18 +1,18 @@
 var zoninator = {}
 
 ;(function($, window, undefined) {
-	
+	var zoninatorOptions = window.zoninatorOptions || {};
+
 	zoninator.init = function() {
-		zoninator.autocompleteCache = {}
-		zoninator.autocompleteAjax = {}
+		zoninator.autocompleteCache = {};
+		zoninator.autocompleteAjax = {};
 		zoninator.$zonePostsList = $('.zone-posts-list');
 		zoninator.$zonePostsWrap = $('.zone-posts-wrapper');
 		zoninator.$zonePostSearch = $("#zone-post-search");
 		zoninator.$zonePostLatest = $("#zone-post-latest");
 		zoninator.$zoneAdvancedCat = $("#zone_advanced_filter_taxonomy");
 		zoninator.$zoneAdvancedDate = $("#zone_advanced_filter_date");
-		zoninator.$zoneSubmit = $("#zone-info input[type='submit']")
-
+		zoninator.$zoneSubmit = $("#zone-info input[type='submit']");
 
 		zoninator.$zoneAdvancedDate.change(function() {
 			zoninator.autocompleteCache = {};
@@ -24,11 +24,11 @@ var zoninator = {}
 			zoninator.updateLatest();
 		});
 
-		zoninator.updatePostOrder();		
-	
+		zoninator.updatePostOrder();
+
 		// Bind actions to buttons
 		zoninator.initZonePost(zoninator.$zonePostsList.children());
-		
+
 		// Initialize sortable
 		if(!zoninator.$zonePostsWrap.hasClass('readonly')) {
 			zoninator.$zonePostsList.sortable({
@@ -38,7 +38,7 @@ var zoninator = {}
 				//, handle: '.zone-post-handle'
 			});
 		}
-		
+
 		// Bind loading events
 		zoninator.$zonePostsWrap
 			.bind('loading.start', function() {
@@ -49,17 +49,17 @@ var zoninator = {}
 				$(this).removeClass('loading');
 				zoninator.$zoneSubmit.attr("disabled", false);
 			});
-		
+
 		// Validate form
 		// TODO: This is really simplistic validation; beef it up a bit.
 		$('#zone-info').submit(function(e) {
 			var $form = $(this);
 			var $name = $form.find('input[name="name"]');
 			if( !$name.val().trim() ) {
-				$name.closest( '.zone-field' ).addClass('error'); 
+				$name.closest( '.zone-field' ).addClass('error');
 				return false;
 			} else {
-				$name.closest( '.zone-field' ).removeClass('error'); 
+				$name.closest( '.zone-field' ).removeClass('error');
 			}
 		});
 
@@ -72,7 +72,7 @@ var zoninator = {}
 			}
 		});
 
-		
+
 
 		// Initialize autocomplete
 		if(zoninator.$zonePostSearch.length) {
@@ -98,15 +98,14 @@ var zoninator = {}
 							zoninator.$zonePostSearch.trigger('loading.end');
 							return;
 						}
-					
+
 						// Append more request vars
-						request.action = zoninator.getAjaxAction('search_posts');
 						request.exclude = zoninator.getZonePostIds();
 
 						// Allow developers to hook onto the request
 						zoninator.$zonePostSearch.trigger('search.request', request);
 
-						zoninator.autocompleteAjax = $.getJSON( ajaxurl, request, function( data, status, xhr ) {
+						zoninator.autocompleteAjax = $.getJSON( '/wp-json/zoninator/v1/posts/search', request, function( data, status, xhr ) {
 							zoninator.autocompleteCache[ term ] = data;
 							if ( xhr === zoninator.autocompleteAjax ) {
 								response( data );
@@ -139,7 +138,7 @@ var zoninator = {}
 					;
 			}
 		}
-		
+
 		// Initialize lock heartbeat
 		if( zoninator.getZoneId() && ! $('#zone-locked').length ) {
 			zoninator.currentLockPeriod = 0;
@@ -149,23 +148,25 @@ var zoninator = {}
 			if( zoninator.heartbeatInterval > 0 && zoninator.maxLockPeriod != -1) {
 				zoninator.heartbeatInterval = zoninator.heartbeatInterval * 1000;
 				zoninator.maxLockPeriod = zoninator.maxLockPeriod * 1000;
-				
+
 				zoninator.updateLock();
 			}
 		}
-		
+
 		// TODO: move / copy posts to zones
-	}
+	};
 
 	zoninator.updateLatest = function() {
-	
+
 		zoninator.$zonePostSearch.trigger('loading.start');
-		zoninator.ajax('update_recent', {
-			zone_id: zoninator.getZoneId(),
-			cat: zoninator.getAdvancedCat(),
-			date: zoninator.getAdvancedDate()
-		}, zoninator.addUpdateLatestSuccessCallback);
-	}
+		zoninator.ajax('/posts/recent',
+			'GET', {
+				zone_id: zoninator.getZoneId(),
+				cat: zoninator.getAdvancedCat(),
+				date: zoninator.getAdvancedDate()
+			}, zoninator.addUpdateLatestSuccessCallback);
+
+	};
 
 	zoninator.addUpdateLatestSuccessCallback = function(returnData) {
 
@@ -173,104 +174,121 @@ var zoninator = {}
 		var $list = $(returnData.content);
 		$('#zone-post-latest').html($list);
 
-	}
+	};
 
 	zoninator.addPost = function(postId) {
-		
+
 		zoninator.$zonePostSearch.trigger('loading.start');
-		
-		zoninator.ajax('add_post', {
-			zone_id: zoninator.getZoneId()
-			, post_id: postId
-		}, zoninator.addPostSuccessCallback);
-		
-	}
-	
+
+		zoninator.ajax('/zones/' + zoninator.getZoneId() + '/posts',
+			'POST', {post_id: postId}, zoninator.addPostSuccessCallback);
+
+	};
+
+	zoninator.ajax = function (endpoint, method, data, successCallback, errorCallback) {
+		if (!data) {
+			data = {};
+		}
+
+		zoninator.$zonePostSearch.trigger( 'zoninator.ajax', [ endpoint, method, data ] );
+
+		return $.ajax( {
+			url: zoninatorOptions.restApiUrl + endpoint,
+			method: method,
+			beforeSend: function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', zoninatorOptions.restApiNonce );
+			},
+			success: function(returnData) {
+				zoninator.ajaxSuccessCallback(returnData, data, successCallback, errorCallback);
+			},
+			error: function(returnData) {
+				zoninator.ajaxErrorCallback(returnData, data, successCallback, errorCallback);
+			},
+			data:data
+		} );
+	};
+
 	zoninator.addPostSuccessCallback = function(returnData) {
-		
+
 		zoninator.$zonePostSearch.trigger('loading.end');
-		
+
 		// Add Post to List
 		var $post = $(returnData.content);
 		$post.hide()
 			.appendTo(zoninator.$zonePostsList)
 			.fadeIn()
 			;
-		
+
 		zoninator.initZonePost($post);
-		
+
 		// Reorder Posts
 		zoninator.updatePostOrder(true);
-	}
-	
+	};
+
 	zoninator.initZonePost = function($elem) {
 		$elem.bind('loading.start', function(e) {
 			$(this).addClass('loading');
 		}).bind('loading.end', function(e) {
 			$(this).removeClass('loading');
 		});
-		
+
 		$elem.find('.delete').bind('click', function(e) {
 			e.preventDefault();
 			var postId = zoninator.getPostIdFromElem(this);
 			zoninator.removePost(postId);
 		});
-	}
+	};
 
 	zoninator.removePost = function(postId) {
 		zoninator.getPost(postId).trigger('loading.start');
-		
-		zoninator.ajax('remove_post', {
-			zone_id: zoninator.getZoneId()
-			, post_id: postId
-		}, zoninator.removePostSuccessCallback);	
-	}
-	
-	zoninator.removePostSuccessCallback = function(returnData, originalData) {
-		var postId = originalData.post_id;
-		
+		zoninator.ajax('/zones/' + zoninator.getZoneId() + '/posts/' + postId,
+			'DELETE', {}, zoninator.removePostSuccessCallback);
+	};
+
+	zoninator.removePostSuccessCallback = function(returnData) {
+		var postId = returnData.post_id;
 		zoninator.getPost(postId).fadeOut('slow', function() {
 			$(this).remove();
-			if ( zoninator.getZonePostIds().length )
+			if ( zoninator.getZonePostIds().length ) {
 				zoninator.updatePostOrder(true);
+			}
+
 			zoninator.$zonePostsWrap.trigger('loading.end');
 		});
-	}
+	};
 
 	zoninator.reorderPosts = function() {
 		// get list of post ids
-		var zoneId = zoninator.getZoneId()
-			, postIds = zoninator.getZonePostIds()
-			;
-		
+		var zoneId = zoninator.getZoneId(),
+			postIds = zoninator.getZonePostIds();
+
 		// Reorder only if changed
 		if(!compareArrays(postIds, zoninator.getPostOrder())) {
 			var data = {
-				zone_id: zoneId
-				, posts: postIds
-			}
-			
+				zone_id: zoneId,
+				posts: postIds
+			};
+
 			zoninator.$zonePostsWrap.trigger('loading.start');
-			
+
 			// make ajax call to save order
-			zoninator.ajax('reorder_posts', data, zoninator.reorderPostsSuccessCallback);
+			zoninator.ajax('/zones/' + zoninator.getZoneId() + '/posts/order',
+				'PUT', data, zoninator.reorderPostsSuccessCallback);
 		}
-	}
-	
+	};
+
 	zoninator.reorderPostsSuccessCallback = function(returnData, originalData) {
 		zoninator.$zonePostsWrap.trigger('loading.end');
 		zoninator.updatePostOrder(false);
-		
+
 		// The user took some action so reset the lock period
 		zoninator.resetCurrentLockPeriod();
-	}
-	
+	};
+
 	zoninator.updateLock = function() {
-		zoninator.ajax('update_lock', {
-			zone_id: zoninator.getZoneId()
-		}, function(returnData, originalData) { 
+		zoninator.ajax('/zones/' + zoninator.getZoneId() + '/lock', 'PUT', {}, function(returnData, originalData) {
 			zoninator.currentLockPeriod += zoninator.heartbeatInterval;
-			
+
 			// We want to set a max to avoid people leaving their tabs open and then running away for long periods
 			if( zoninator.currentLockPeriod < zoninator.maxLockPeriod ) {
 				setTimeout(zoninator.updateLock, zoninator.heartbeatInterval);
@@ -280,60 +298,33 @@ var zoninator = {}
 			}
 		}, function(returnData, originalData) {
 			// Show alert and reload page to update lock
-			alert(zoninatorOptions.errorZoneLock);
+			alert(window.zoninatorOptions.errorZoneLock);
 			location.reload();
 		});
-	}
-	
+	};
+
 	zoninator.resetCurrentLockPeriod = function() {
 		zoninator.currentLockPeriod = 0;
-	}
-	
-	zoninator.ajax = function(action, values, successCallback, errorCallback, params) {
-		var data = {
-			action: zoninator.getAjaxAction(action)
-			, _wpnonce: zoninator.getAjaxNonce()
-		}
-		data = $.extend({}, data, values);
+	};
 
-		// Allow developers to filter the ajax parameters
-		zoninator.$zonePostSearch.trigger( 'zoninator.ajax', [ action, data ] );
-
-		var defaultParams = {
-			url: ajaxurl
-			, data: data
-			, dataType: 'json'
-			, type: 'POST'
-			, success: function(returnData) {
-				zoninator.ajaxSuccessCallback(returnData, data, successCallback, errorCallback);
-			}
-			, error: function(returnData) {
-				zoninator.ajaxErrorCallback(returnData, data, successCallback, errorCallback);
-			}
-		}
-		params = $.extend({}, defaultParams, params);
-		
-		$.ajax(params);
-	}
-	
 	zoninator.ajaxSuccessCallback = function(returnData, originalData, successCallback, errorCallback) {
 		if(typeof(returnData) === 'undefined' || !returnData.status) {
 			// If we didn't get a valid return, it's probably an error
 			return zoninator.ajaxErrorCallback(returnData, originalData, successCallback, errorCallback);
 		}
-		
+
 		//console.log('ajaxSuccessCallback', returnData, originalData);
-		
+
 		if(returnData.nonce)
 			zoninator.updateAjaxNonce(returnData.nonce);
-		
+
 		if(typeof(successCallback) === 'function') {
-			return successCallback(returnData, originalData); 
+			return successCallback(returnData, originalData);
 		} else {
 			alert(returnData.content);
 		}
-	}
-	
+	};
+
 	zoninator.ajaxErrorCallback = function(returnData, originalData, successCallback, errorCallback) {
 		if( typeof(returnData) === 'undefined' || !returnData ) {
 			returnData = {
@@ -341,54 +332,54 @@ var zoninator = {}
 				, content: zoninatorOptions.errorGeneral
 			}
 		}
-		
+
 		//console.log('ajaxErrorCallback', returnData, originalData);
-		
+
 		if(typeof(errorCallback) === 'function') {
-			return errorCallback(returnData, originalData); 
+			return errorCallback(returnData, originalData);
 		} else {
 			if( typeof(returnData.content) === 'undefined' || !returnData.content )
 				returnData.content = zoninatorOptions.errorGeneral;
 			alert(returnData.content);
 		}
-	}
-	
+	};
+
 	zoninator.updateAjaxNonce = function(action, nonce) {
 		zoninator.getAjaxNonceField(action).val(nonce);
-	}
+	};
 
 	zoninator.getAdvancedCat = function() {
 		return $('#zone_advanced_filter_taxonomy').length ? zoninator.$zoneAdvancedCat.val() : 0;
-	}
+	};
 
 	zoninator.getAdvancedDate = function() {
 		return $('#zone_advanced_filter_date').length ? zoninator.$zoneAdvancedDate.val() : 0;
-	}
-	
+	};
+
 	zoninator.getAjaxNonce = function(action) {
 		return zoninator.getAjaxNonceField(action).val();
-	}
+	};
 	zoninator.getAjaxNonceField = function(action) {
 		action = action || zoninatorOptions.ajaxNonceAction;
 		return $('#' + action );
-	}
-	
+	};
+
 	zoninator.getZoneId = function() {
 		return $('#zone_id').length ? $('#zone_id').val() : 0;
-	}
-	
+	};
+
 	zoninator.getZonePosts = function() {
 		return zoninator.$zonePostsList.children();
-	}
-	
+	};
+
 	zoninator.getPost = function(postId) {
 		return $('#zone-post-' + postId);
-	}
-	
+	};
+
 	zoninator.getPostIdFromElem = function(elem) {
 		return $(elem).closest('.zone-post').attr('data-post-id');
-	}
-	
+	};
+
 	zoninator.getZonePostIds = function() {
 		var ids = []
 			, $posts = zoninator.getZonePosts();
@@ -396,32 +387,30 @@ var zoninator = {}
 			ids.push(elem.value);
 		});
 		return ids;
-	}
-	
+	};
+
 	zoninator.getPostOrder = function() {
-		if(!$.isArray(zoninator.currentPostOrder))
+		if(!$.isArray(zoninator.currentPostOrder)) {
 			zoninator.updatePostOrder();
+		}
 		return zoninator.currentPostOrder;
-	}
-	
+	};
+
 	zoninator.updatePostOrder = function(save) {
-		if(save)
+		if(save) {
 			zoninator.reorderPosts();
-		
+		}
+
 		zoninator.currentPostOrder = zoninator.getZonePostIds();
 		zoninator.renumberPosts();
-	}
-	
+	};
+
 	zoninator.renumberPosts = function() {
 		var $numbers = zoninator.$zonePostsList.find('.zone-post-position');
 		$numbers.each(function(i, elem) {
 		    $(elem).text(i + 1);
         });
-	}
-	
-	zoninator.getAjaxAction = function(action) {
-		return 'zoninator_' + action;
-	}
+	};
 
 	zoninator.emptyFunc = function() {}
 
@@ -440,13 +429,13 @@ var zoninator = {}
 	 */
     var compareArrays = function(arr1, arr2, sort) {
         if (arr1.length != arr2.length) return false;
-        
+
         if(sort) {
             arr1 = arr1.sort(),
             arr2 = arr2.sort();
         }
         for (var i = 0; arr2[i]; i++) {
-            if (arr1[i] !== arr2[i]) { 
+            if (arr1[i] !== arr2[i]) {
                 return false;
             }
         }
@@ -464,17 +453,18 @@ var zoninator = {}
 	});
 
 	// TODO: fix this
-	function parseIntOrZero(str) {		
+	function parseIntOrZero(str) {
 		var parsed = parseInt( str );
 		if( isNaN(parsed) || !parsed ) parsed = 0;
 		return parsed;
-	}
+	};
 
 	$(document).ready(function() {
 		zoninator.init();
 
-	})
+	});
 })(jQuery, window);
 
-if(typeof(console) === 'undefined')
-	console = { log: function(){} }
+if(typeof(console) === 'undefined') {
+	console = { log: function(){} };
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Zone Manager (Zoninator) ===
 Contributors: batmoo, automattic, wpcomvip, pkevan, matthumphreys, potatomaster, jblz, nickdaugherty, betzster
 Tags: zones, post order, post list, posts, order, zonination, content curation, curation, content management
-Requires at least: 3.5
+Requires at least: 4.4
 Tested up to: 4.4
-Stable tag: 0.6
+Stable tag: 0.7
 License: GPLv2
 
 Curation made easy! Create "zones" then add and order your content!
@@ -54,6 +54,11 @@ Filter the following and change according to your needs:
 1. Create and manage your zones and content through a fairly intuitive and familiar interface
 
 == Changelog ==
+
+= 0.8 =
+
+* WordPress version requirements bumped to 4.4
+* Converted custom admin ajax endpoints to WP-API
 
 = 0.7 =
 

--- a/tests/.travis.yml
+++ b/tests/.travis.yml
@@ -1,0 +1,23 @@
+language: php
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+php:
+  - 5.3
+  - 5.6
+
+env:
+  - WP_VERSION=latest WP_MULTISITE=0
+
+matrix:
+  include:
+    - php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=1
+
+before_script:
+  - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+
+script: phpunit

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,8 @@
+### Running Unit Tests
+
+PHPUnit test setup only tested under Chassis.
+
+```bash
+./setup_test_env.sh
+./vendor/bin/phpunit
+```

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+	fi
+
+	cd $WP_TESTS_DIR
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "automattic/zoninator",
+    "description": "Zone Editor",
+    "type": "test suite",
+    "require": {
+        "phpunit/phpunit": "4.8",
+        "wp-cli/wp-cli": "^0.21.1",
+        "psy/psysh": "^0.6.1"
+    },
+    "license": "GPL v2",
+    "authors": [
+        {
+            "name": "Automattic",
+            "email": "info@automattic.com"
+        }
+    ],
+    "minimum-stability": "dev"
+}

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -1,0 +1,1798 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "f673840b09aa5fad1d303dde4ec6a298",
+    "content-hash": "2f924054373b5ee2e4b5f8c99d9acc75",
+    "packages": [
+        {
+            "name": "composer/semver",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "d0e1ccc6d44ab318b758d709e19176037da6b1ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/d0e1ccc6d44ab318b758d709e19176037da6b1ba",
+                "reference": "d0e1ccc6d44ab318b758d709e19176037da6b1ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "~2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com"
+                },
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2015-09-21 09:42:36"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "265b8593498b997dc2d31e75b89f053b5cc9621a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/265b8593498b997dc2d31e75b89f053b5cc9621a",
+                "reference": "265b8593498b997dc2d31e75b89f053b5cc9621a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "@stable"
+            },
+            "type": "project",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "time": "2014-10-24 07:27:01"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "jakub-onderka/php-console-color",
+            "version": "0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Console-Color.git",
+                "reference": "e0b393dacf7703fc36a4efc3df1435485197e6c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Color/zipball/e0b393dacf7703fc36a4efc3df1435485197e6c1",
+                "reference": "e0b393dacf7703fc36a4efc3df1435485197e6c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "jakub-onderka/php-code-style": "1.0",
+                "jakub-onderka/php-parallel-lint": "0.*",
+                "jakub-onderka/php-var-dump-check": "0.*",
+                "phpunit/phpunit": "3.7.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JakubOnderka\\PhpConsoleColor": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com",
+                    "homepage": "http://www.acci.cz"
+                }
+            ],
+            "time": "2014-04-08 15:00:19"
+        },
+        {
+            "name": "jakub-onderka/php-console-highlighter",
+            "version": "v0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Console-Highlighter.git",
+                "reference": "7daa75df45242c8d5b75a22c00a201e7954e4fb5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Highlighter/zipball/7daa75df45242c8d5b75a22c00a201e7954e4fb5",
+                "reference": "7daa75df45242c8d5b75a22c00a201e7954e4fb5",
+                "shasum": ""
+            },
+            "require": {
+                "jakub-onderka/php-console-color": "~0.1",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "jakub-onderka/php-code-style": "~1.0",
+                "jakub-onderka/php-parallel-lint": "~0.5",
+                "jakub-onderka/php-var-dump-check": "~0.1",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JakubOnderka\\PhpConsoleHighlighter": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "acci@acci.cz",
+                    "homepage": "http://www.acci.cz/"
+                }
+            ],
+            "time": "2015-04-20 18:58:01"
+        },
+        {
+            "name": "mustache/mustache",
+            "version": "v2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/mustache.php.git",
+                "reference": "c745b01956caf27d26b55a72a90aff56bc169cd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/c745b01956caf27d26b55a72a90aff56bc169cd6",
+                "reference": "c745b01956caf27d26b55a72a90aff56bc169cd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.4"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "~1.6",
+                "phpunit/phpunit": "~3.7|~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mustache": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info",
+                    "homepage": "http://justinhileman.com"
+                }
+            ],
+            "description": "A Mustache implementation in PHP.",
+            "homepage": "https://github.com/bobthecow/mustache.php",
+            "keywords": [
+                "mustache",
+                "templating"
+            ],
+            "time": "2015-08-15 19:23:13"
+        },
+        {
+            "name": "nb/oxymel",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nb/oxymel.git",
+                "reference": "cbe626ef55d5c4cc9b5e6e3904b395861ea76e3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nb/oxymel/zipball/cbe626ef55d5c4cc9b5e6e3904b395861ea76e3c",
+                "reference": "cbe626ef55d5c4cc9b5e6e3904b395861ea76e3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Oxymel": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nikolay Bachiyski",
+                    "email": "nb@nikolay.bg",
+                    "homepage": "http://extrapolate.me/"
+                }
+            ],
+            "description": "A sweet XML builder",
+            "homepage": "https://github.com/nb/oxymel",
+            "keywords": [
+                "xml"
+            ],
+            "time": "2013-02-24 15:01:54"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "719ca71d4ac80e1985dcd91dd8ec5a47db58ad80"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/719ca71d4ac80e1985dcd91dd8ec5a47db58ad80",
+                "reference": "719ca71d4ac80e1985dcd91dd8ec5a47db58ad80",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2015-12-07 11:12:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "phpDocumentor": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "time": "2015-02-03 12:10:50"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "e55e3e32a870bd4f05425fa4f717b52bd40e5659"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e55e3e32a870bd4f05425fa4f717b52bd40e5659",
+                "reference": "e55e3e32a870bd4f05425fa4f717b52bd40e5659",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "~2.0",
+                "sebastian/comparator": "~1.1",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2015-12-28 13:26:33"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.2.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "^1.3.2",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-10-06 15:47:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2015-06-21 08:01:12"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "cab6c6fefee93d7b7c3a01292a0fe0884ea66644"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/cab6c6fefee93d7b7c3a01292a0fe0884ea66644",
+                "reference": "cab6c6fefee93d7b7c3a01292a0fe0884ea66644",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-09-23 14:46:55"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "283111a903eb9225aedb95e846bef876e006a688"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/283111a903eb9225aedb95e846bef876e006a688",
+                "reference": "283111a903eb9225aedb95e846bef876e006a688",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "~2.1",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": ">=1.0.6",
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "~1.3",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.8.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-08-07 03:57:43"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.3.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2015-10-02 06:51:40"
+        },
+        {
+            "name": "psy/psysh",
+            "version": "v0.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/psysh.git",
+                "reference": "0f04df0b23663799a8941fae13cd8e6299bde3ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/0f04df0b23663799a8941fae13cd8e6299bde3ed",
+                "reference": "0f04df0b23663799a8941fae13cd8e6299bde3ed",
+                "shasum": ""
+            },
+            "require": {
+                "dnoegel/php-xdg-base-dir": "0.1",
+                "jakub-onderka/php-console-highlighter": "0.3.*",
+                "nikic/php-parser": "^1.2.1|~2.0",
+                "php": ">=5.3.9",
+                "symfony/console": "~2.3.10|^2.4.2|~3.0",
+                "symfony/var-dumper": "~2.7|~3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "~1.5",
+                "phpunit/phpunit": "~3.7|~4.0|~5.0",
+                "squizlabs/php_codesniffer": "~2.0",
+                "symfony/finder": "~2.1|~3.0"
+            },
+            "suggest": {
+                "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
+                "ext-pdo-sqlite": "The doc command requires SQLite to work.",
+                "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well.",
+                "ext-readline": "Enables support for arrow-key history navigation, and showing and manipulating command history."
+            },
+            "bin": [
+                "bin/psysh"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "0.7.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Psy/functions.php"
+                ],
+                "psr-4": {
+                    "Psy\\": "src/Psy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info",
+                    "homepage": "http://justinhileman.com"
+                }
+            ],
+            "description": "An interactive shell for modern PHP.",
+            "homepage": "http://psysh.org",
+            "keywords": [
+                "REPL",
+                "console",
+                "interactive",
+                "shell"
+            ],
+            "time": "2015-11-12 16:18:56"
+        },
+        {
+            "name": "ramsey/array_column",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/array_column.git",
+                "reference": "f8e52eb28e67eb50e613b451dd916abcf783c1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/array_column/zipball/f8e52eb28e67eb50e613b451dd916abcf783c1db",
+                "reference": "f8e52eb28e67eb50e613b451dd916abcf783c1db",
+                "shasum": ""
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "0.8.*",
+                "phpunit/phpunit": "~4.5",
+                "satooshi/php-coveralls": "0.6.*",
+                "squizlabs/php_codesniffer": "~2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/array_column.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "homepage": "http://benramsey.com"
+                }
+            ],
+            "description": "Provides functionality for array_column() to projects using PHP earlier than version 5.5.",
+            "homepage": "https://github.com/ramsey/array_column",
+            "keywords": [
+                "array",
+                "array_column",
+                "column"
+            ],
+            "time": "2015-03-20 22:07:39"
+        },
+        {
+            "name": "rmccue/requests",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rmccue/Requests.git",
+                "reference": "6aac485666c2955077d77b796bbdd25f0013a4ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rmccue/Requests/zipball/6aac485666c2955077d77b796bbdd25f0013a4ea",
+                "reference": "6aac485666c2955077d77b796bbdd25f0013a4ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Requests": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Ryan McCue",
+                    "homepage": "http://ryanmccue.info"
+                }
+            ],
+            "description": "A HTTP library written in PHP, for human beings.",
+            "homepage": "http://github.com/rmccue/Requests",
+            "keywords": [
+                "curl",
+                "fsockopen",
+                "http",
+                "idna",
+                "ipv6",
+                "iri",
+                "sockets"
+            ],
+            "time": "2014-05-18 04:59:02"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-07-26 15:48:44"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-12-08 07:14:41"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "6e7133793a8e5a5714a551a8324337374be209df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e7133793a8e5a5714a551a8324337374be209df",
+                "reference": "6e7133793a8e5a5714a551a8324337374be209df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2015-12-02 08:37:27"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "f88f8936517d54ae6d589166810877fb2015d0a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f88f8936517d54ae6d589166810877fb2015d0a2",
+                "reference": "f88f8936517d54ae6d589166810877fb2015d0a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2015-08-09 04:23:41"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12 03:26:01"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-11-11 19:50:13"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2015-06-21 13:59:46"
+        },
+        {
+            "name": "symfony/console",
+            "version": "2.8.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "4e83844dead78e6e90b8b7dff862fa232fa228ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4e83844dead78e6e90b8b7dff862fa232fa228ad",
+                "reference": "4e83844dead78e6e90b8b7dff862fa232fa228ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-12-28 13:12:56"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "2.8.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "dd41ae57f4f737be271d944a0cc5f5f21203a7c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/dd41ae57f4f737be271d944a0cc5f5f21203a7c6",
+                "reference": "dd41ae57f4f737be271d944a0cc5f5f21203a7c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-12-05 11:09:21"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/49ff736bd5d41f45240cec77b44967d76e0c3d25",
+                "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2015-11-20 09:19:13"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "2.8.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "f943f29ae69c42511a2d85adee9d13d835b5c803"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/f943f29ae69c42511a2d85adee9d13d835b5c803",
+                "reference": "f943f29ae69c42511a2d85adee9d13d835b5c803",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "twig/twig": "~1.20|~2.0"
+            },
+            "suggest": {
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2015-12-05 11:09:21"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "2.8.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "cee3fdda8184add20a13eb666295dfd72e8031bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/cee3fdda8184add20a13eb666295dfd72e8031bd",
+                "reference": "cee3fdda8184add20a13eb666295dfd72e8031bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-12-28 13:12:56"
+        },
+        {
+            "name": "wp-cli/php-cli-tools",
+            "version": "v0.10.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/php-cli-tools.git",
+                "reference": "037a010441a5c220cd1df26cdc9b20ad73408356"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/037a010441a5c220cd1df26cdc9b20ad73408356",
+                "reference": "037a010441a5c220cd1df26cdc9b20ad73408356",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "cli": "lib/"
+                },
+                "files": [
+                    "lib/cli/cli.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "James Logsdon",
+                    "email": "jlogsdon@php.net",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Daniel Bachhuber",
+                    "email": "daniel@handbuilt.co",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Console utilities for PHP",
+            "homepage": "http://github.com/wp-cli/php-cli-tools",
+            "keywords": [
+                "cli",
+                "console"
+            ],
+            "time": "2015-08-10 12:46:19"
+        },
+        {
+            "name": "wp-cli/wp-cli",
+            "version": "v0.21.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/wp-cli.git",
+                "reference": "21da8b4ebf7f37f9ae55b45b037214f154a1b2ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/21da8b4ebf7f37f9ae55b45b037214f154a1b2ab",
+                "reference": "21da8b4ebf7f37f9ae55b45b037214f154a1b2ab",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "1.0.0",
+                "mustache/mustache": "~2.4",
+                "nb/oxymel": "0.1.0",
+                "php": ">=5.3.2",
+                "ramsey/array_column": "~1.1",
+                "rmccue/requests": "~1.6",
+                "symfony/finder": "~2.3",
+                "wp-cli/php-cli-tools": "0.10.5"
+            },
+            "require-dev": {
+                "behat/behat": "2.5.*",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "suggest": {
+                "psy/psysh": "Enhanced `wp shell` functionality"
+            },
+            "bin": [
+                "bin/wp.bat",
+                "bin/wp"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "WP_CLI": "php"
+                },
+                "files": [
+                    "php/Spyc.php"
+                ],
+                "classmap": [
+                    "php/export"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A command line interface for WordPress",
+            "homepage": "http://wp-cli.org",
+            "keywords": [
+                "cli",
+                "wordpress"
+            ],
+            "time": "2015-11-23 13:50:12"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="unit/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./unit/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/setup_test_env.sh
+++ b/tests/setup_test_env.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+rm -rf /tmp/wordpress-tests-lib > dev/null
+
+echo "Setting up the test env for zoninator. Checking dependencies";
+
+which svn > /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "cannot find subversion. please install subversion";
+    exit 1;
+fi
+
+which wget > /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "cannot find wget. please install wget";
+    exit 1;
+fi
+
+which composer > /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "cannot find composer. please install composer";
+    exit 1;
+fi
+
+echo "installing composer dependencies";
+
+composer install > /dev/null
+
+bash bin/install-wp-tests.sh zoninator_test root password localhost latest

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	$file = dirname( __FILE__ ) . '/../../zoninator.php';
+	require realpath( $file );
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';
+
+

--- a/tests/unit/test-zoninator-rest-api-controller.php
+++ b/tests/unit/test-zoninator-rest-api-controller.php
@@ -1,0 +1,314 @@
+<?php
+
+class Zoninator_Rest_Api_Controller_Test extends WP_UnitTestCase
+{
+    /**
+     * @var Zoninator_Zone_Gateway
+     */
+    private $_zone_gateway = null;
+
+    /**
+     * @var Zoninator_View_Renderer
+     */
+    private $_renderer = null;
+
+    /**
+     * @var Zoninator_Permissions
+     */
+    private $_permissions = null;
+
+    /**
+     * @var Zoninator_Rest_Api_Controller
+     */
+    private $_controller = null;
+
+    /**
+     * @var int
+     */
+    private $_post_id = 0;
+
+    function setUp()
+    {
+        parent::setUp();
+
+        $this->_zone_gateway = $this->getMockBuilder( 'Zoninator_Zone_Gateway' )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->_renderer = $this->getMockBuilder( 'Zoninator_View_Renderer' )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->_permissions = $this->getMockBuilder( 'Zoninator_Permissions' )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->_renderer->method('admin_page_zone_post')
+            ->willReturn('<p>Some content</p>');
+
+        $this->_controller = new Zoninator_Rest_Api_Controller( $this->_zone_gateway, $this->_permissions, $this->_renderer );
+        $this->_post_id = $this->_insert_a_post();
+    }
+
+    function test_add_post_to_zone_return_WP_Error_if_no_zone()
+    {
+        $post_id = $this->_insert_a_post();
+        $request = $this->_create_request( array( 'post_id' => $this->_post_id, 'zone_id' => 3 ) );
+
+        $this->_zone_gateway->method( 'get_zone' )->willReturn(null);
+        $response = $this->_controller->add_post( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+        $this->assertEquals( Zoninator_Rest_Api_Controller::INVALID_ZONE_ID, $response->get_error_code() );
+    }
+
+    function test_add_post_to_zone_return_WP_Error_if_no_post()
+    {
+        $request = $this->_create_request( array( 'post_id' => 0, 'zone_id' => 3 ) );
+
+        $response = $this->_controller->add_post( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+        $this->assertEquals( Zoninator_Rest_Api_Controller::INVALID_POST_ID,  $response->get_error_code() );
+    }
+
+    function test_add_post_to_zone_500_if_add_zone_posts_Fails()
+    {
+        $request = $this->_create_request( array( 'post_id' => $this->_post_id, 'zone_id' => 3 ) );
+
+        $this->_zone_gateway->method( 'get_zone' )->willReturn( new stdClass() );
+        $this->_zone_gateway->method( 'add_zone_posts' )->willReturn( new WP_Error( 'an-error' ) );
+        $response = $this->_controller->add_post( $request );
+        $this->assertInstanceOf( 'WP_REST_Response', $response );
+        $this->assertEquals( 500, $response->get_status() );
+    }
+
+    function test_add_post_to_zone_200_if_add_zone_posts_succeeds()
+    {
+        $request = $this->_create_request( array( 'post_id' => $this->_post_id, 'zone_id' => 3 ) );
+        $this->_zone_gateway->method( 'get_zone' )->willReturn( new stdClass() );
+        $this->_zone_gateway->method( 'add_zone_posts' )->willReturn( null );
+        $response = $this->_controller->add_post( $request );
+        $this->_assert_response_status($response, 200);
+    }
+
+    function test_remove_post_from_zone_return_WP_Error_if_no_post_id()
+    {
+        $request = $this->_create_request( array( 'post_id' => 0 ) );
+        $response = $this->_controller->remove_post( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+        $this->assertEquals( Zoninator_Rest_Api_Controller::ZONE_ID_POST_ID_REQUIRED,  $response->get_error_code() );
+    }
+
+    function test_remove_post_from_zone_return_WP_Error_if_no_zone_id()
+    {
+        $request = $this->_create_request( array( 'post_id' => $this->_post_id ) );
+
+        $this->_zone_gateway->method( 'get_zone' )->willReturn( null );
+        $response = $this->_controller->remove_post( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+        $this->assertEquals( Zoninator_Rest_Api_Controller::ZONE_ID_POST_ID_REQUIRED,  $response->get_error_code() );
+    }
+
+    function test_remove_post_from_zone_return_WP_REST_Response_200_if_successful()
+    {
+        $request = $this->_create_request( array( 'post_id' => $this->_post_id, 'zone_id' => 3 ) );
+        $this->_zone_gateway->method( 'remove_zone_posts' )->willReturn( null );
+        $response = $this->_controller->remove_post( $request );
+        $this->_assert_response_status($response, 200);
+    }
+
+    function test_reorder_posts_on_zone_return_WP_Error_if_post_ids_not_present()
+    {
+        $request = $this->_create_request( array( 'zone_id' => 3 ) );
+        $response = $this->_controller->reorder_posts( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+        $this->assertEquals( Zoninator_Rest_Api_Controller::ZONE_ID_POST_IDS_REQUIRED,  $response->get_error_code() );
+    }
+
+    function test_reorder_posts_on_zone_return_WP_Error_if_zone_id_not_present()
+    {
+        $request = $this->_create_request( array( 'posts' => array( 1, 3, 6 ) ) );
+        $response = $this->_controller->reorder_posts( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+        $this->assertEquals( Zoninator_Rest_Api_Controller::ZONE_ID_POST_IDS_REQUIRED,  $response->get_error_code() );
+    }
+
+    function test_reorder_posts_on_zone_return_200_if_zone_id_and_posts_present()
+    {
+        $request = $this->_create_request( array( 'zone_id' => 3, 'posts' => array( 1, 3, 6 ) ) );
+        $this->_zone_gateway->method( 'add_zone_posts' )->willReturn( new stdClass() );
+        $response = $this->_controller->reorder_posts( $request );
+        $this->_assert_response_status($response, 200);
+    }
+
+    function test_reorder_posts_on_zone_return_500_if_zone_id_and_posts_present_and_reordering_fails()
+    {
+        $request = $this->_create_request( array( 'zone_id' => 3, 'posts' => array( 1, 3, 6 ) ) );
+        $this->_zone_gateway->method( 'add_zone_posts' )->willReturn( new WP_Error('my-error') );
+        $response = $this->_controller->reorder_posts( $request );
+        $this->_assert_response_status($response, 500);
+    }
+
+    function test_get_zone_feed_errors_if_internal_error()
+    {
+        $request = $this->_create_request( array( 'zone_id' => 3 ) );
+        $this->_zone_gateway->method( 'get_zone_feed' )->willReturn( new WP_Error( 'en-error' ) );
+        $this->_zone_gateway->method( 'get_zone' )->willReturn( array(1) );
+        $response = $this->_controller->get_zone_feed( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+    }
+
+    function test_get_zone_feed_200()
+    {
+        $request = $this->_create_request( array( 'zone_id' => 3 ) );
+        $this->_zone_gateway->method( 'get_zone_feed' )->willReturn( array() );
+        $this->_zone_gateway->method( 'get_zone' )->willReturn( array(1) );
+        $response = $this->_controller->get_zone_feed( $request );
+        $this->_assert_response_status($response, 200);
+    }
+
+    function test_get_zone_feed_errors_if_no_zone_id()
+    {
+        $request = $this->_create_request( array(  ) );
+        $this->_zone_gateway->method( 'get_zone_feed' )->willReturn( array() );
+        $this->_zone_gateway->method( 'get_zone' )->willReturn( array() );
+        $response = $this->_controller->get_zone_feed( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+    }
+
+    function test_remove_post_200()
+    {
+        $this->_zone_gateway->method( 'remove_post' )->willReturn( null );
+        $request = $this->_create_request( array( 'post_id' => $this->_post_id, 'zone_id' => 3 ) );
+        $response = $this->_controller->remove_post( $request );
+        $this->_assert_response_status($response, 200);
+    }
+
+    function test_remove_post_fail_if_no_post_id()
+    {
+        $this->_zone_gateway->method( 'remove_post' )->willReturn( null );
+        $request = $this->_create_request( array( 'zone_id' => 3 ) );
+        $response = $this->_controller->remove_post( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+    }
+
+    function test_remove_post_fail_if_no_zone_id()
+    {
+        $this->_zone_gateway->method( 'remove_post' )->willReturn( null );
+        $request = $this->_create_request( array( 'post_id' => $this->_post_id ) );
+        $response = $this->_controller->remove_post( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+    }
+
+    function test_remove_post_500_if_removal_fails()
+    {
+        $this->_zone_gateway->method( 'remove_zone_posts' )->willReturn( new WP_Error('error') );
+        $request = $this->_create_request( array( 'post_id' => $this->_post_id, 'zone_id' => 3 ) );
+        $response = $this->_controller->remove_post( $request );
+        $this->_assert_response_status($response, 500);
+    }
+
+    function test_reorder_posts_200()
+    {
+        $this->_zone_gateway->method( 'add_zone_posts' )->willReturn( null );
+        $request = $this->_create_request( array( 'posts' => array( $this->_post_id ), 'zone_id' => 3 ) );
+        $response = $this->_controller->reorder_posts( $request );
+        $this->_assert_response_status($response, 200);
+    }
+
+    function test_reorder_posts_error_if_no_zone_id()
+    {
+        $this->_zone_gateway->method( 'add_zone_posts' )->willReturn( null );
+        $request = $this->_create_request( array( 'posts' => array( $this->_post_id ) ) );
+        $response = $this->_controller->reorder_posts( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+    }
+
+    function test_reorder_posts_error_if_no_posts()
+    {
+        $this->_zone_gateway->method( 'add_zone_posts' )->willReturn( null );
+        $request = $this->_create_request( array( 'zone_id' => 3 ) );
+        $response = $this->_controller->reorder_posts( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+    }
+
+    function test_reorder_500_if_internal_error()
+    {
+        $this->_zone_gateway->method( 'add_zone_posts' )->willReturn( new WP_Error('error') );
+        $request = $this->_create_request( array( 'posts' => array( $this->_post_id ), 'zone_id' => 3 ) );
+        $response = $this->_controller->reorder_posts( $request );
+        $this->_assert_response_status($response, 500);
+    }
+
+    function test_zone_update_lock_200()
+    {
+        $this->_zone_gateway->method( 'is_zone_locked' )->willReturn( false );
+        $request = $this->_create_request( array( 'zone_id' => 3 ) );
+        $response = $this->_controller->zone_update_lock( $request );
+        $this->_assert_response_status($response, 200);
+    }
+
+    function test_zone_update_lock_400_if_zone_already_locked()
+    {
+        $this->_zone_gateway->method( 'is_zone_locked' )->willReturn( true );
+        $request = $this->_create_request( array( 'zone_id' => 3 ) );
+        $response = $this->_controller->zone_update_lock( $request );
+        $this->_assert_response_status($response, 400);
+    }
+
+    function test_zone_update_error_if_no_zone_id()
+    {
+        $this->_zone_gateway->method( 'is_zone_locked' )->willReturn( false );
+        $request = $this->_create_request( array( ) );
+        $response = $this->_controller->zone_update_lock( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+    }
+
+    function test_search_posts_error_if_empty_term()
+    {
+//        $this->_zone_gateway->method( 'is_zone_locked' )->willReturn( false );
+        $request = $this->_create_request( array( 'term' => '' ) );
+        $response = $this->_controller->search_posts( $request );
+        $this->assertInstanceOf( 'WP_Error', $response );
+    }
+
+    /**
+     * @return int|WP_Error
+     */
+    private function _insert_a_post()
+    {
+        return wp_insert_post(array(
+            'post_content' => 'Content',
+            'post_title' => 'Title',
+            'post_excerpt' => 'Excerpt',
+            'post_status' => 'published',
+            'post_type' => 'post'
+        ));
+    }
+
+    /**
+     * @param array $params
+     * @return WP_REST_Request
+     */
+    private function _create_request(array $params = array())
+    {
+        $request = new WP_REST_Request(
+            WP_REST_Server::CREATABLE,
+            ''
+        );
+
+        foreach ($params as $key => $value) {
+            $request->set_param( $key, $value );
+        }
+        return $request;
+    }
+
+    /**
+     * @param $response
+     * @param int $status
+     */
+    private function _assert_response_status($response, $status = 200)
+    {
+        $this->assertInstanceOf('WP_REST_Response', $response);
+        $this->assertEquals($status, $response->get_status());
+    }
+}

--- a/zoninator.php
+++ b/zoninator.php
@@ -3,7 +3,7 @@
 Plugin Name: Zone Manager (Zoninator)
 Description: Curation made easy! Create "zones" then add and order your content!
 Author: Mohammad Jangda, Automattic
-Version: 0.6
+Version: 0.7
 Author URI: http://vip.wordpress.com
 Text Domain: zoninator
 Domain Path: /language/
@@ -37,27 +37,43 @@ define( 'ZONINATOR_PATH', dirname( __FILE__ ) );
 define( 'ZONINATOR_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 
 require_once( ZONINATOR_PATH . '/functions.php' );
-require_once( ZONINATOR_PATH . '/widget.zone-posts.php');
+require_once( ZONINATOR_PATH . '/widget.zone-posts.php' );
+require_once( ZONINATOR_PATH . '/class-zoninator-constants.php' );
+require_once( ZONINATOR_PATH . '/class-zoninator-zone-gateway.php' );
+require_once( ZONINATOR_PATH . '/class-zoninator-permissions.php' );
+require_once( ZONINATOR_PATH . '/class-zoninator-view-renderer.php' );
+require_once( ZONINATOR_PATH . '/class-zoninator-rest-api-controller.php' );
 
 class Zoninator
 {
-	var $key = 'zoninator';
-	var $zone_taxonomy = 'zoninator_zones';
-	var $zone_term_prefix = 'zone-';
-	var $zone_meta_prefix = '_zoninator_order_';
-	var $zone_nonce_prefix = 'zone-nonce';
-	var $zone_ajax_nonce_action = 'ajax-action';
-	var $zone_lock_period = 30; // number of seconds a lock is valid for
-	var $zone_max_lock_period = 600; // max number of seconds for all locks in a session
-	var $post_types = null;
-	var $zone_detail_defaults = array(
+	public $zone_detail_defaults = array(
 		'description' => ''
 		// Add additional properties here!
 	);
-	var $zone_messages = null;
-	var $posts_per_page = 10;
+
+	public $zone_messages = null;
+
+	/**
+	 * @var null|Zoninator_Zone_Gateway
+	 */
+	public $zone_gateway = null;
+
+	/**
+	 * @var null|Zoninator_Rest_Api_Controller
+	 */
+	public $rest_api_controller = null;
+
+	/**
+	 * @var null|Zoninator_Permissions
+	 */
+	public $permissions = null;
 
 	function __construct() {
+		$this->zone_gateway = new Zoninator_Zone_Gateway();
+		$this->permissions = new Zoninator_Permissions();
+		$this->_renderer = new Zoninator_View_Renderer( $this->zone_gateway );
+		$this->rest_api_controller = new Zoninator_Rest_Api_Controller( $this->zone_gateway, $this->permissions, $this->_renderer );
+
 		add_action( 'init', array( $this, 'init' ), 99 ); // init later after other post types have been registered
 
 		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
@@ -68,14 +84,16 @@ class Zoninator
 
 		add_action( 'template_redirect', array( $this, 'do_zoninator_feeds' ) );
 
-		add_action( 'split_shared_term', array( $this, 'split_shared_term' ), 10, 4 );
-
 		$this->default_post_types = array( 'post' );
 	}
 
+    function get_zone_gateway() {
+        return $this->zone_gateway;
+    }
+
 	function add_zone_feed() {
-		add_rewrite_tag( '%' . $this->zone_taxonomy . '%', '([^&]+)' );
-		add_rewrite_rule( '^zones/([^/]+)/feed.json/?$', 'index.php?' . $this->zone_taxonomy . '=$matches[1]', 'top' );
+		add_rewrite_tag( '%' . Zoninator_Constants::ZONE_TAXONOMY . '%', '([^&]+)' );
+		add_rewrite_rule( '^zones/([^/]+)/feed.json/?$', 'index.php?' . Zoninator_Constants::ZONE_TAXONOMY . '=$matches[1]', 'top' );
 	}
 
 	function init() {
@@ -88,27 +106,9 @@ class Zoninator
 			'error-zone-lock-max' => __( 'Sorry, you have reached the maximum idle limit and will now be redirected to the Dashboard.', 'zoninator' ),
 		);
 
-		$this->zone_lock_period 	= apply_filters( 'zoninator_zone_lock_period', 		$this->zone_lock_period );
-		$this->zone_max_lock_period = apply_filters( 'zoninator_zone_max_lock_period', 	$this->zone_max_lock_period );
-		$this->posts_per_page 		= apply_filters( 'zoninator_posts_per_page', 		$this->posts_per_page );
-
 		do_action( 'zoninator_pre_init' );
 
-		// Default post type support
-		foreach( $this->default_post_types as $post_type )
-			add_post_type_support( $post_type, $this->zone_taxonomy );
-
-		// Register taxonomy
-		if( ! taxonomy_exists( $this->zone_taxonomy ) ) {
-			register_taxonomy( $this->zone_taxonomy, $this->get_supported_post_types(), array(
-				'label' => __( 'Zones', 'zoninator' ),
-				'hierarchical' => false,
-				'query_var' => false,
-				'rewrite' => false,
-				'public' => false,
-
-			) );
-		}
+		$this->zone_gateway->init();
 
 		add_action( 'admin_init', array( $this, 'admin_controller' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
@@ -130,21 +130,7 @@ class Zoninator
 		register_widget( 'Zoninator_ZonePosts_Widget' );
 	}
 
-	// Add necessary AJAX actions
-	function admin_ajax_init( ) {
-		add_action( 'wp_ajax_zoninator_reorder_posts', array( $this, 'ajax_reorder_posts' ) );
-		add_action( 'wp_ajax_zoninator_add_post', array( $this, 'ajax_add_post' ) );
-		add_action( 'wp_ajax_zoninator_remove_post', array( $this, 'ajax_remove_post' ) );
-		add_action( 'wp_ajax_zoninator_search_posts', array( $this, 'ajax_search_posts' ) );
-		add_action( 'wp_ajax_zoninator_update_lock', array( $this, 'ajax_update_lock' ) );
-		add_action( 'wp_ajax_zoninator_update_recent', array( $this, 'ajax_recent_posts' ) );
-
-	}
-
 	function admin_init() {
-
-		$this->admin_ajax_init();
-
 		// Enqueue Scripts and Styles
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
@@ -152,7 +138,15 @@ class Zoninator
 
 	function admin_page_init() {
 		// Set up page
-		add_menu_page( __( 'Zoninator', 'zoninator' ), __( 'Zones', 'zoninator' ), $this->_get_manage_zones_cap(), $this->key, array( $this, 'admin_page' ), '', 11 );
+		add_menu_page( __( 'Zoninator', 'zoninator' ), __( 'Zones', 'zoninator' ), $this->permissions->get_manage_zones_cap(), Zoninator_Constants::KEY, array( $this, 'admin_page' ), '', 11 );
+	}
+
+	private function _get_rest_api_base_url() {
+		$namespace = 'zoninator/v1';
+		if ( is_multisite() ) {
+			return get_rest_url(get_current_blog_id(), $namespace);
+		}
+		return get_rest_url(null, $namespace);
 	}
 
 	function admin_enqueue_scripts() {
@@ -161,13 +155,15 @@ class Zoninator
 
 			$options = array(
 				'baseUrl' => $this->_get_zone_page_url(),
+				'restApiUrl' => $this->_get_rest_api_base_url(),
+				'restApiNonce' => wp_create_nonce( 'wp_rest' ),
 				'adminUrl' => admin_url(),
-				'ajaxNonceAction' => $this->_get_nonce_key( $this->zone_ajax_nonce_action ),
+				'ajaxNonceAction' => $this->_get_nonce_key( Zoninator_Constants::ZONE_AJAX_NONCE_ACTION ),
 				'errorGeneral' => $this->_get_message( 'error-general' ),
 				'errorZoneLock' => sprintf( $this->_get_message( 'error-zone-lock' ), __( 'another user', 'zoninator' ) ),
 				'errorZoneLockMax' => $this->_get_message( 'error-zone-lock-max' ),
-				'zoneLockPeriod' => $this->zone_lock_period,
-				'zoneLockPeriodMax' => $this->zone_max_lock_period,
+				'zoneLockPeriod' => $this->zone_gateway->zone_lock_period,
+				'zoneLockPeriodMax' => $this->zone_gateway->zone_max_lock_period,
 			);
 			wp_localize_script( 'zoninator-js', 'zoninatorOptions', $options );
 
@@ -206,14 +202,14 @@ class Zoninator
 
 					// TODO: handle additional properties
 					if( $zone_id ) {
-						$result = $this->update_zone( $zone_id, array(
+						$result = $this->zone_gateway->update_zone( $zone_id, array(
 							'name' => $name,
 							'slug' => $slug,
 							'details' => $details
 						) );
 
 					} else {
-						$result = $this->insert_zone( $slug, $name, $details );
+						$result = $this->zone_gateway->insert_zone( $slug, $name, $details );
 					}
 
 					if( is_wp_error( $result ) ) {
@@ -237,7 +233,9 @@ class Zoninator
 					$this->verify_access( $action, $zone_id );
 
 					if( $zone_id ) {
-						$result = $this->delete_zone( $zone_id );
+						$result = $this->zone_gateway->delete_zone( $zone_id );
+					} else {
+						//TODO 404
 					}
 
 					if( is_wp_error( $result ) ) {
@@ -259,16 +257,16 @@ class Zoninator
 		$view = sprintf( '%s/views/%s', ZONINATOR_PATH, $view );
 		$title = __( 'Zones', 'zoninator' );
 
-		$zones = $this->get_zones();
+		$zones = $this->zone_gateway->get_zones();
 
 		$default_active_zone = 0;
-		if( ! $this->_current_user_can_add_zones() ) {
+		if( ! $this->permissions->current_user_can_add_zones() ) {
 			if( ! empty( $zones ) )
 				$default_active_zone = $zones[0]->term_id;
 		}
 
 		$active_zone_id = $this->_get_request_var( 'zone_id', $default_active_zone, 'absint' );
-		$active_zone = ! empty( $active_zone_id ) ? $this->get_zone( $active_zone_id ) : array();
+		$active_zone = ! empty( $active_zone_id ) ? $this->zone_gateway->get_zone( $active_zone_id ) : array();
 		if ( ! empty( $active_zone ) )
 			$title = __( 'Edit Zone', 'zoninator' );
 
@@ -280,7 +278,7 @@ class Zoninator
 			<div id="icon-edit-pages" class="icon32"><br /></div>
 			<h2>
 				<?php echo esc_html( $title ); ?>
-				<?php if( $this->_current_user_can_add_zones() ) :
+				<?php if( $this->permissions->current_user_can_add_zones() ) :
 					$new_link = $this->_get_zone_page_url( array( 'action' => 'new' ) ); ?>
 					<?php if( $active_zone_id ) : ?>
 						<a href="<?php echo esc_url( $new_link ); ?>" class="add-new-h2 zone-button-add-new"><?php esc_html_e( 'Add New', 'zoninator' ); ?></a>
@@ -312,14 +310,14 @@ class Zoninator
 	}
 
 	function admin_page_zone_tabs( $zones, $active_zone_id = 0 ) {
-		$new_link = $this->_get_zone_page_url( array( 'action' => 'new' ) );
+//		$new_link = $this->_get_zone_page_url( array( 'action' => 'new' ) );
 		?>
 		<div class="nav-tabs-container zone-tabs-container">
 			<div class="nav-tabs-nav-wrapper zone-tabs-nav-wrapper">
 				<div class="nav-tabs-wrapper zone-tabs-wrapper">
 					<div class="nav-tabs zone-tabs">
 						<?php foreach( $zones as $zone ) : ?>
-							<?php $zone_id = $this->get_zone_id( $zone ); ?>
+							<?php $zone_id = $this->zone_gateway->get_zone_id( $zone ); ?>
 							<?php $zone_link = $this->_get_zone_page_url( array( 'action' => 'edit', 'zone_id' => $zone_id ) ); ?>
 
 							<?php if( $active_zone_id && $zone_id == $active_zone_id ) : ?>
@@ -341,15 +339,15 @@ class Zoninator
 		$zone_slug = $this->_get_value_or_default( 'slug', $zone, '', array( $this, 'get_unformatted_zone_slug' ) );
 		$zone_description = $this->_get_value_or_default( 'description', $zone );
 
-		$zone_posts = $zone_id ? $this->get_zone_posts( $zone ) : array();
+		$zone_posts = $zone_id ? $this->zone_gateway->get_zone_posts( $zone ) : array();
 
-		$zone_locked = $this->is_zone_locked( $zone_id );
+		$zone_locked = $this->zone_gateway->is_zone_locked( $zone_id );
 
 		$delete_link = $this->_get_zone_page_url( array( 'action' => 'delete', 'zone_id' => $zone_id ) );
 		$delete_link = wp_nonce_url( $delete_link, $this->_get_nonce_key( 'delete' ) );
 		?>
 		<div id="zone-edit-wrapper">
-			<?php if( ( $zone_id == 0 && $this->_current_user_can_add_zones() ) || ( $zone_id != 0 && $this->_current_user_can_manage_zones() ) ) : ?>
+			<?php if( ( $zone_id == 0 && $this->permissions->current_user_can_add_zones() ) || ( $zone_id != 0 && $this->permissions->current_user_can_manage_zones() ) ) : ?>
 				<?php if( $zone_locked ) : ?>
 					<?php $locking_user = get_userdata( $zone_locked ); ?>
 					<div class="updated below-h2">
@@ -360,7 +358,7 @@ class Zoninator
 				<div class="col-wrap zone-col zone-info-col">
 					<div class="form-wrap zone-form zone-info-form">
 
-						<?php if( $this->_current_user_can_edit_zones( $zone_id ) && ! $zone_locked ) : ?>
+						<?php if ( $this->permissions->current_user_can_edit_zones( $zone_id ) && ! $zone_locked ) : ?>
 
 							<form id="zone-info" method="post">
 
@@ -397,12 +395,12 @@ class Zoninator
 									<input type="submit" value="<?php esc_attr_e('Save', 'zoninator'); ?>" name="submit" class="button-primary" />
 
 									<?php if( $zone_id ) : ?>
-										<a href="<?php echo $delete_link ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( 'Are you sure you want to delete this zone?', 'zoninator' ); ?>')"><?php esc_html_e('Delete', 'zoninator') ?></a>
+										<a href="<?php echo $delete_link ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete this zone?', 'zoninator' ) ); ?>')"><?php esc_html_e('Delete', 'zoninator') ?></a>
 									<?php endif; ?>
 								</div>
 
 								<input type="hidden" name="action" value="<?php echo $zone_id ? 'update' : 'insert'; ?>">
-								<input type="hidden" name="page" value="<?php echo $this->key; ?>">
+								<input type="hidden" name="page" value="<?php echo Zoninator_Constants::KEY; ?>">
 
 							</form>
 						<?php else : ?>
@@ -433,25 +431,25 @@ class Zoninator
 						<?php endif; ?>
 
 						<?php // Ideally, we should seperate nonces for each action. But this will do for simplicity. ?>
-						<?php wp_nonce_field( $this->_get_nonce_key( $this->zone_ajax_nonce_action ), $this->_get_nonce_key( $this->zone_ajax_nonce_action ), false ); ?>
+						<?php wp_nonce_field( $this->_get_nonce_key( Zoninator_Constants::ZONE_AJAX_NONCE_ACTION ), $this->_get_nonce_key( Zoninator_Constants::ZONE_AJAX_NONCE_ACTION ), false ); ?>
 					</div>
 
 				</div>
 
 				<div class="col-wrap zone-col zone-posts-col">
-					<div class="zone-posts-wrapper <?php echo ! $this->_current_user_can_manage_zones( $zone_id ) || $zone_locked ? 'readonly' : ''; ?>">
+					<div class="zone-posts-wrapper <?php echo ! $this->permissions->current_user_can_manage_zones() || $zone_locked ? 'readonly' : ''; ?>">
 						<?php if( $zone_id ) : ?>
 							<h3><?php esc_html_e( 'Zone Content', 'zoninator' ); ?></h3>
 
-							<?php $this->zone_advanced_search_filters(); ?>
+							<?php $this->_renderer->zone_advanced_search_filters(); ?>
 
 							<?php $this->zone_admin_recent_posts_dropdown( $zone_id ); ?>
 
-							<?php $this->zone_admin_search_form(); ?>
+							<?php $this->_renderer->zone_admin_search_form(); ?>
 
 							<div class="zone-posts-list">
 								<?php foreach( $zone_posts as $post ) : ?>
-									<?php $this->admin_page_zone_post( $post, $zone ); ?>
+									<?php $this->_renderer->admin_page_zone_post( $post, $zone ); ?>
 								<?php endforeach; ?>
 							</div>
 
@@ -463,65 +461,6 @@ class Zoninator
 			<?php endif; ?>
 		</div>
 
-		<?php
-	}
-
-	function admin_page_zone_post( $post, $zone ) {
-		$columns = apply_filters( 'zoninator_zone_post_columns', array(
-			'position' => array( $this, 'admin_page_zone_post_col_position' ),
-			'info' => array( $this, 'admin_page_zone_post_col_info' )
-		), $post, $zone );
-		?>
-		<div id="zone-post-<?php echo $post->ID; ?>" class="zone-post" data-post-id="<?php echo $post->ID; ?>">
-			<table>
-				<tr>
-					<?php foreach( $columns as $column_key => $column_callback ) : ?>
-						<?php if( is_callable( $column_callback ) ) : ?>
-							<td class="zone-post-col zone-post-<?php echo $column_key; ?>">
-								<?php call_user_func( $column_callback, $post, $zone ); ?>
-							</td>
-						<?php endif; ?>
-					<?php endforeach; ?>
-				</tr>
-			</table>
-			<input type="hidden" name="zone-post-id" value="<?php echo $post->ID; ?>" />
-		</div>
-		<?php
-	}
-
-	function admin_page_zone_post_col_position( $post, $zone ) {
-		$current_position = $this->get_post_order( $post->ID, $zone );
-		?>
-		<span title="<?php esc_attr_e( 'Click and drag to change the position of this item.', 'zoninator' ); ?>">
-			<?php echo esc_html( $current_position ); ?>
-		</span>
-		<?php
-	}
-	function admin_page_zone_post_col_info( $post, $zone ) {
-		$action_links = array(
-			sprintf( '<a href="%s" class="edit" target="_blank" title="%s">%s</a>', get_edit_post_link( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'Edit', 'zoninator' ) ),
-			sprintf( '<a href="#" class="delete" title="%s">%s</a>', __( 'Remove this item from the zone', 'zoninator' ), __( 'Remove', 'zoninator' ) ),
-			sprintf( '<a href="%s" class="view" target="_blank" title="%s">%s</a>', get_permalink( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'View', 'zoninator' ) ),
-			// Move To
-			// Copy To
-		);
-		?>
-		<?php echo sprintf( '%s <span class="zone-post-status">(%s)</span>', esc_html( $post->post_title ), esc_html( $post->post_status ) ); ?>
-
-		<div class="row-actions">
-			<?php echo implode( ' | ', $action_links ); ?>
-		</div>
-		<?php
-	}
-
-	function zone_advanced_search_filters() {
-		?>
-		<div class="zone-advanced-search-filters-heading">
-			<span class="zone-toggle-advanced-search" data-alt-label="<?php esc_attr_e( 'Hide', 'zoninator' ); ?>"><?php esc_html_e( 'Show Filters', 'zoninator' ); ?></span>
-		</div>
-		<div class="zone-advanced-search-filters-wrapper">
-			<?php do_action( 'zoninator_advanced_search_fields' ); ?>
-		</div>
 		<?php
 	}
 
@@ -556,75 +495,11 @@ class Zoninator
 		<?php
 	}
 
-	function ajax_recent_posts() {
-
-		$cat = $this->_get_post_var( 'cat', '', 'absint' );
-		$date = $this->_get_post_var( 'date', '', 'striptags' );
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
-
-		$limit = $this->posts_per_page;
-		$post_types = $this->get_supported_post_types();
-		$zone_posts = $this->get_zone_posts( $zone_id );
-		$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
-
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		if( is_wp_error( $zone_posts ) ) {
-			$status = 0;
-			$content = $zone_posts->get_error_message();
-		} else {
-			$args = apply_filters( 'zoninator_recent_posts_args', array(
-				'posts_per_page' => $limit,
-				'order' => 'DESC',
-				'orderby' => 'post_date',
-				'post_type' => $post_types,
-				'ignore_sticky_posts' => true,
-				'post_status' => array( 'publish', 'future' ),
-				'post__not_in' => $zone_post_ids,
-			) );
-
-			if ( $this->_validate_category_filter( $cat ) ) {
-				$args['cat'] = $cat;
-			}
-
-			if ( $this->_validate_date_filter( $date ) ) {
-				$filter_date_parts = explode( '-', $date );
-				$args['year'] = $filter_date_parts[0];
-				$args['monthnum'] = $filter_date_parts[1];
-				$args['day'] = $filter_date_parts[2];
-			}
-
-			$content = '';
-			$recent_posts = get_posts( $args );
-			foreach ( $recent_posts as $post ) :
-				$content .= sprintf( '<option value="%d">%s</option>', $post->ID, get_the_title( $post->ID ) . ' (' . $post->post_status . ')' );
-			endforeach;
-			wp_reset_postdata();
-			$status = 1;
-		}
-
-		$empty_label = '';
-		if ( ! $content ) {
-			$empty_label =  __( 'No results found', 'zoninator' );
-		} elseif ( $cat ) {
-			$empty_label = sprintf( __( 'Choose post from %s', 'zoninator' ), get_the_category_by_ID( $cat ) );
-		} else {
-			$empty_label = __( 'Choose a post', 'zoninator' );
-		}
-
-		$content = '<option value="">' . esc_html( $empty_label ) . '</option>' . $content;
-
-		$this->ajax_return( $status, $content );
-	}
-
 	function zone_admin_recent_posts_dropdown( $zone_id ) {
 
-		$limit = $this->posts_per_page;
-		$post_types = $this->get_supported_post_types();
-		$zone_posts = $this->get_zone_posts( $zone_id );
+		$limit = $this->zone_gateway->posts_per_page;
+		$post_types = $this->zone_gateway->get_supported_post_types();
+		$zone_posts = $this->zone_gateway->get_zone_posts( $zone_id );
 		$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
 
 		$args = apply_filters( 'zoninator_recent_posts_args', array(
@@ -656,16 +531,6 @@ class Zoninator
 		<?php
 	}
 
-	function zone_admin_search_form() {
-		?>
-		<div class="zone-search-wrapper">
-			<label for="zone-post-search"><?php esc_html_e( 'Search for content', 'zoninator' );?></label>
-			<input type="text" id="zone-post-search" name="search" />
-			<p class="description"><?php esc_html_e( 'Enter a term or phrase in the text box above to search for and add content to this zone.', 'zoninator' ); ?></p>
-		</div>
-		<?php
-	}
-
 	function is_zoninator_page() {
 		global $current_screen;
 
@@ -673,104 +538,10 @@ class Zoninator
 			$screen = get_current_screen();
 
 		if( empty( $screen ) ) {
-			return ! empty( $_REQUEST['page'] ) && sanitize_key( $_REQUEST['page'] ) == $this->key;
+			return ! empty( $_REQUEST['page'] ) && sanitize_key( $_REQUEST['page'] ) == Zoninator_Constants::KEY;
 		} else {
-			return ! empty( $screen->id ) && strstr( $screen->id, $this->key );
+			return ! empty( $screen->id ) && strstr( $screen->id, Zoninator_Constants::KEY );
 		}
-	}
-
-	function ajax_return( $status, $content = '', $action = '' ) {
-		$action = ! empty( $action ) ? $action : $this->zone_ajax_nonce_action;
-		$nonce = wp_create_nonce( $this->_get_nonce_key( $action ) );
-
-		echo json_encode( array(
-			'status' => $status,
-			'content' => $content,
-			'nonce' => $nonce,
-		) );
-		exit;
-	}
-
-	function ajax_add_post() {
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
-		$post_id = $this->_get_post_var( 'post_id', 0, 'absint' );
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		// Validate
-		if( ! $zone_id || ! $post_id )
-			$this->ajax_return( 0 );
-
-		$result = $this->add_zone_posts( $zone_id, $post_id, true );
-
-		if( is_wp_error( $result ) ) {
-			$status = 0;
-			$content = $result->get_error_message();
-		} else {
-			$post = get_post( $post_id );
-			$zone = $this->get_zone( $zone_id );
-
-			ob_start();
-			$this->admin_page_zone_post( $post, $zone );
-			$content = ob_get_contents();
-			ob_end_clean();
-
-			$status = 1;
-		}
-
-		$this->ajax_return( $status, $content );
-	}
-
-	function ajax_remove_post() {
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
-		$post_id = $this->_get_post_var( 'post_id', 0, 'absint' );
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		// Validate
-		if( ! $zone_id || ! $post_id )
-			$this->ajax_return( 0 );
-
-		$result = $this->remove_zone_posts( $zone_id, $post_id );
-
-		if( is_wp_error( $result ) ) {
-			$status = 0;
-			$content = $result->get_error_message();
-		} else {
-			$status = 1;
-			$content = '';
-		}
-
-		$this->ajax_return( $status, $content );
-	}
-
-	function ajax_reorder_posts() {
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
-		$post_ids = (array) $this->_get_post_var( 'posts', array(), 'absint' );
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		// validate
-		if( ! $zone_id || empty( $post_ids ) )
-			$this->ajax_return( 0 );
-
-		$result = $this->add_zone_posts( $zone_id, $post_ids, false );
-
-		if( is_wp_error( $result ) ) {
-			$status = 0;
-			$content = $result->get_error_message();
-		} else {
-			$status = 1;
-			$content = '';
-		}
-
-		$this->ajax_return( $status, $content );
 	}
 
 	// TODO: implement in front-end
@@ -778,530 +549,34 @@ class Zoninator
 		$from_zone_id = $this->_get_post_var( 'from_zone_id', 0, 'absint' );
 		$to_zone_id = $this->_get_post_var( 'to_zone_id', 0, 'absint' );
 
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
+		$this->verify_nonce( Zoninator_Constants::ZONE_AJAX_NONCE_ACTION );
 
 		// TODO: validate both zones exist, post exists
 
 		// Add to new zone
-		$this->add_zone_posts( $to_zone_id, $post_id, true );
+		$this->zone_gateway->add_zone_posts( $to_zone_id, $post_id, true );
 
 		// Remove from old zone
-		$this->remove_zone_posts( $from_zone_id, $post_id );
-	}
-
-	function ajax_search_posts() {
-
-		$q = $this->_get_request_var( 'term', '', 'stripslashes' );
-
-		if( ! empty( $q ) ) {
-
-			$filter_cat = $this->_get_request_var( 'cat', '', 'absint' );
-			$filter_date = $this->_get_request_var( 'date', '', 'striptags' );
-
-			$post_types = $this->get_supported_post_types();
-			$limit = $this->_get_request_var( 'limit', $this->posts_per_page );
-			if( $limit <= 0 )
-				$limit = $this->posts_per_page;
-			$exclude = (array) $this->_get_request_var( 'exclude', array(), 'absint' );
-
-			$args = apply_filters( 'zoninator_search_args', array(
-				's' => $q,
-				'post__not_in' => $exclude,
-				'posts_per_page' => $limit,
-				'post_type' => $post_types,
-				'post_status' => array( 'publish', 'future' ),
-				'order' => 'DESC',
-				'orderby' => 'post_date',
-				'suppress_filters' => true,
-			) );
-
-			if ( $this->_validate_category_filter( $filter_cat ) ) {
-				$args['cat'] = $filter_cat;
-			}
-
-			if ( $this->_validate_date_filter( $filter_date ) ) {
-				$filter_date_parts = explode( '-', $filter_date );
-				$args['year'] = $filter_date_parts[0];
-				$args['monthnum'] = $filter_date_parts[1];
-				$args['day'] = $filter_date_parts[2];
-			}
-
-			$query = new WP_Query( $args );
-			$stripped_posts = array();
-
-			if ( ! $query->have_posts() )
-				exit;
-
-			foreach( $query->posts as $post ) {
-				$stripped_posts[] = apply_filters( 'zoninator_search_results_post', array(
-					'title' => ! empty( $post->post_title ) ? $post->post_title : __( '(no title)', 'zoninator' ),
-					'post_id' => $post->ID,
-					'date' => get_the_time( get_option( 'date_format' ), $post ),
-					'post_type' => $post->post_type,
-					'post_status' => $post->post_status,
-				), $post );
-			}
-
-			echo json_encode( $stripped_posts );
-			exit;
-		}
-	}
-
-	function ajax_update_lock() {
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
-
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		if( ! $zone_id )
-			exit;
-
-		if( ! $this->is_zone_locked( $zone_id ) ) {
-			$this->lock_zone( $zone_id );
-			$this->ajax_return( 1, '' );
-		}
-	}
-
-	function get_supported_post_types() {
-		if( isset( $this->post_types ) )
-			return $this->post_types;
-
-		$this->post_types = array();
-
-		foreach( get_post_types() as $post_type ) {
-			if( post_type_supports( $post_type, $this->zone_taxonomy ) )
-				array_push( $this->post_types, $post_type );
-		}
-
-		return $this->post_types;
-	}
-
-	function insert_zone( $slug, $name = '', $details = array() ) {
-
-		// slug cannot be empty
-		if( empty( $slug ) )
-			return new WP_Error( 'zone-empty-slug', __( 'Slug is a required field.', 'zoninator' ) );
-
-		$slug = $this->get_formatted_zone_slug( $slug );
-		$name = ! empty( $name ) ? $name : $slug;
-
-		$details = wp_parse_args( $details, $this->zone_detail_defaults );
-		$details = maybe_serialize( stripslashes_deep( $details ) );
-
-		$args = array(
-			'slug' => $slug,
-			'description' => $details,
-		);
-
-		// Filterize to allow other inputs
-		$args = apply_filters( 'zoninator_insert_zone', $args );
-
-		return wp_insert_term( $name, $this->zone_taxonomy, $args );
-	}
-
-	function update_zone( $zone, $data = array() ) {
-		$zone_id = $this->get_zone_id( $zone );
-
-		if( $this->zone_exists( $zone_id ) ) {
-			$zone = $this->get_zone( $zone );
-
-			$name = $this->_get_value_or_default( 'name', $data, $zone->name );
-			$slug = $this->_get_value_or_default( 'slug', $data, $zone->slug, array( $this, 'get_formatted_zone_slug' ) );
-			$details = $this->_get_value_or_default( 'details', $data, array() );
-
-			// TODO: Back-fill current zone details
-			//$details = wp_parse_args( $details, $this->zone_detail_defaults );
-			$details = wp_parse_args( $details, $this->zone_detail_defaults );
-			$details = maybe_serialize( stripslashes_deep( $details ) );
-
-			$args = array(
-				'name' => $name,
-				'slug' => $slug,
-				'description' => $details
-			);
-
-			// Filterize to allow other inputs
-			$args = apply_filters( 'zoninator_update_zone', $args, $zone_id, $zone );
-
-			return wp_update_term( $zone_id, $this->zone_taxonomy, $args );
-		}
-		return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
-	}
-
-	function delete_zone( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-		$meta_key = $this->get_zone_meta_key( $zone );
-
-		$this->_empty_zone_posts_cache( $meta_key );
-
-		if( $this->zone_exists( $zone_id ) ) {
-			// Delete all post associations for the zone
-			$this->remove_zone_posts( $zone_id );
-
-			// Delete the term
-			$delete = wp_delete_term( $zone_id, $this->zone_taxonomy );
-
-			if( ! $delete ) {
-				return new WP_Error( 'delete-zone', __( 'Sorry, we couldn\'t delete the zone.', 'zoninator' ) );
-			} else {
-				do_action( 'zoninator_delete_zone', $zone_id );
-				return $delete;
-			}
-		}
-		return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
-	}
-
-	function add_zone_posts( $zone, $posts, $append = false ) {
-		$zone = $this->get_zone( $zone );
-		$meta_key = $this->get_zone_meta_key( $zone );
-
-		$this->_empty_zone_posts_cache( $meta_key );
-
-		if( $append ) {
-			// Order should be the highest post order
-			$last_post = $this->get_last_post_in_zone( $zone );
-			if( $last_post )
-				$order = $this->get_post_order( $last_post, $zone );
-			else
-				$order = 0;
-		} else {
-			$order = 0;
-			$this->remove_zone_posts( $zone );
-		}
-
-		foreach( (array) $posts as $post ) {
-			$post_id = $this->get_post_id( $post );
-			if( $post_id ) {
-				$order++;
-				update_metadata( 'post', $post_id, $meta_key, $order, true );
-			}
-			// TODO: remove_object_terms -- but need remove object terms function :(
-		}
-
-		clean_term_cache( $this->get_zone_id( $zone ), $this->zone_taxonomy ); // flush cache for our zone term and related APC caches
-
-		do_action( 'zoninator_add_zone_posts', $posts, $zone );
-	}
-
-	function remove_zone_posts( $zone, $posts = null ) {
-		$zone = $this->get_zone( $zone );
-		$meta_key = $this->get_zone_meta_key( $zone );
-
-		$this->_empty_zone_posts_cache( $meta_key );
-
-		// if null, delete all
-		if( ! $posts )
-			$posts = $this->get_zone_posts( $zone );
-
-		foreach( (array) $posts as $post ) {
-			$post_id = $this->get_post_id( $post );
-			if( $post_id )
-				delete_metadata( 'post', $post_id, $meta_key );
-		}
-
-		clean_term_cache( $this->get_zone_id( $zone ), $this->zone_taxonomy ); // flush cache for our zone term and related APC caches
-
-		do_action( 'zoninator_remove_zone_posts', $posts, $zone );
-	}
-
-	function get_zone_posts( $zone, $args = array() ) {
-		// Check cache first
-		if( $posts = $this->get_zone_posts_from_cache( $zone, $args ) )
-			return $posts;
-
-		$query = $this->get_zone_query( $zone, $args );
-		$posts = $query->posts;
-
-		// Add posts to cache
-		$this->add_zone_posts_to_cache( $posts, $zone, $args );
-
-		return $posts;
-	}
-
-	function get_zone_query( $zone, $args = array() ) {
-		$meta_key = $this->get_zone_meta_key( $zone );
-
-		$defaults = array(
-			'order' => 'ASC',
-			'posts_per_page' => -1,
-			'post_type' => $this->get_supported_post_types(),
-			'ignore_sticky_posts' => '1', // don't want sticky posts messing up our order
-		);
-
-		// Default to published posts on the front-end
-		if ( ! is_admin() )
-			$defaults['post_status'] = array( 'publish' );
-
-		if ( is_admin() ) // skip APC in the admin
-			$defaults['suppress_filters'] = true;
-
-		$args = wp_parse_args( $args, $defaults );
-
-		// Un-overridable args
-		$args['orderby'] = 'meta_value_num';
-		$args['meta_key'] = $meta_key;
-
-		/* // 3.1-friendly, though missing sort support which is why we're using the old way
-		if( function_exists( 'get_post_format' ) ) {
-			$args['meta_query'] = array(
-				array(
-					'key' => $meta_key,
-					'type' => 'NUMERIC'
-				)
-			);
-		} else {
-			$args['meta_key'] = $meta_key;
-		}
-		*/
-		return new WP_Query( $args );
-	}
-
-	function get_last_post_in_zone( $zone ) {
-		return $this->get_single_post_in_zone( $zone, array(
-			'order' => 'DESC',
-		) );
-	}
-
-	function get_first_post_in_zone( $zone ) {
-		return $this->get_single_post_in_zone( $zone );
-	}
-
-	function get_prev_post_in_zone( $zone, $post_id ) {
-		// TODO: test this works
-		$order = $this->get_post_order_in_zone( $zone, $post_id );
-
-		return $this->get_single_post_in_zone( $zone, array(
-			'meta_value' => $order,
-			'meta_compare' => '<='
-		) );
-	}
-
-	function get_next_post_in_zone( $zone, $post_id ) {
-		// TODO: test this works
-		$order = $this->get_post_order_in_zone( $zone, $post_id );
-
-		return $this->get_single_post_in_zone( $zone, array(
-			'meta_value' => $order,
-			'meta_compare' => '>='
-		) );
-
-	}
-
-	function get_single_post_in_zone( $zone, $args = array() ) {
-
-		$args = wp_parse_args( $args, array(
-			'posts_per_page' => 1,
-			'showposts' => 1,
-		) );
-
-		$post = $this->get_zone_posts( $zone, $args );
-
-		if( is_array( $post ) && ! empty( $post ) )
-			return array_pop( $post );
-
-		return false;
-	}
-
-	function get_zones_for_post( $post_id ) {
-		// TODO: build this out
-
-		// get_object_terms
-		// get_terms
-
-		// OR
-
-		// get all meta_keys that match the prefix
-		// strip the prefix
-
-		// OR
-
-		// get all zones and see if there's a matching meta entry
-		// strip the prefix from keys
-
-		// array_map( 'absint', $zone_ids )
-		// $zones = array();
-		// foreach( $zone_ids as $zone_id ) {
-			// $zones[] = get_zone( $zone_id );
-		//}
-		//return $zones;
-	}
-
-	function get_zones( $args = array() ) {
-
-		$args = wp_parse_args( $args, array(
-			'orderby' => 'id',
-			'order' => 'ASC',
-			'hide_empty' => 0,
-		) );
-
-		$zones = get_terms( $this->zone_taxonomy, $args );
-
-		// Add extra fields in description as properties
-		foreach( $zones as $zone ) {
-			$zone = $this->_fill_zone_details( $zone );
-		}
-
-		return $zones;
-	}
-
-	function get_zone( $zone ) {
-		if( is_int( $zone ) ) {
-			$field = 'id';
-		} elseif( is_string( $zone ) ) {
-			$field = 'slug';
-			$zone = $this->get_zone_slug( $zone );
-		} elseif( is_object( $zone ) ) {
-			return $zone;
-		} else {
-			return false;
-		}
-
-		$zone = get_term_by( $field, $zone, $this->zone_taxonomy );
-
-		if( ! $zone )
-			return false;
-
-		return $this->_fill_zone_details( $zone );
-	}
-
-	function lock_zone( $zone, $user_id = 0 ) {
-		$zone_id = $this->get_zone_id( $zone );
-
-		if( ! $zone_id )
-			return false;
-
-		if( ! $user_id ) {
-			$user = wp_get_current_user();
-			$user_id = $user->ID;
-		}
-
-		$lock_key = $this->get_zone_meta_key( $zone );
-		$expiry = $this->zone_lock_period + 1; // Add a one to avoid most race condition issues between lock expiry and ajax call
-		set_transient( $lock_key, $user->ID, $expiry );
-
-		// Possible alternative: set zone lock as property with time and user
-	}
-
-	// Not really needed with transients...
-	function unlock_zone( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-
-		if( ! $zone_id )
-			return false;
-
-		$lock_key = $this->get_zone_meta_key( $zone );
-
-		delete_transient( $lock_key );
-	}
-
-	function is_zone_locked( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-		if( ! $zone_id )
-			return false;
-
-		$user = wp_get_current_user();
-		$lock_key = $this->get_zone_meta_key( $zone );
-
-		$lock = get_transient( $lock_key );
-
-		// If lock doesn't exist, or check if current user same as lock user
-		if( ! $lock || absint( $lock ) === absint( $user->ID ) )
-			return false;
-		else
-			// return user_id of locking user
-			return absint( $lock );
-	}
-
-	function zone_exists( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-
-		if( term_exists( $zone_id, $this->zone_taxonomy ) )
-			return true;
-
-		return false;
-	}
-
-	function get_zone_id( $zone ) {
-		if( is_int( $zone ) )
-			return $zone;
-
-		$zone = $this->get_zone( $zone );
-		if( is_object( $zone ) )
-			$zone = $zone->term_id;
-
-		return (int)$zone;
-	}
-
-	function get_zone_meta_key( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-		return $this->zone_meta_prefix . $zone_id;
-	}
-
-	function get_zone_slug( $zone ) {
-		if( is_int( $zone ) )
-			$zone = $this->get_zone( $zone );
-
-		if( is_object( $zone ) )
-			$zone = $zone->slug;
-
-		return $this->get_formatted_zone_slug( $zone );
-	}
-
-	function get_formatted_zone_slug( $slug ) {
-		return $slug; // legacy function -- slugs can no longer be changed
-	}
-	function get_unformatted_zone_slug( $slug ) {
-		return $slug; // legacy function -- slugs can no longer be changed
-	}
-
-	function get_post_id( $post ) {
-		if( is_int( $post ) )
-			return $post;
-		elseif( is_array( $post ) )
-			return absint( $post['ID'] );
-		elseif( is_object( $post ) )
-			return $post->ID;
-
-		return false;
-	}
-
-	function get_post_order( $post, $zone ) {
-		$post_id = $this->get_post_id( $post );
-		$meta_key = $this->get_zone_meta_key( $zone );
-
-		return get_metadata( 'post', $post_id, $meta_key, true );
+		$this->zone_gateway->remove_zone_posts( $from_zone_id, $post_id );
 	}
 
 	function verify_nonce( $action ) {
 		$action = $this->_get_nonce_key( $action );
 		$nonce = $this->_get_request_var( $action );
 
-		if( empty( $nonce ) )
+		if( empty( $nonce ) ) {
 			$nonce = $this->_get_request_var( '_wpnonce' );
+		}
 
-		if( ! wp_verify_nonce( $nonce, $action ) )
+		if( ! wp_verify_nonce( $nonce, $action ) ) {
 			$this->_unauthorized_access();
+		}
 	}
 
 	function verify_access( $action = '', $zone_id = null ) {
-		// TODO: should check if zone locked
-
-		$verify_function = '';
-		switch( $action ) {
-			case 'insert':
-				$verify_function = '_current_user_can_add_zones';
-				break;
-			case 'update':
-			case 'delete':
-				$verify_function = '_current_user_can_edit_zones';
-				break;
-			default:
-				$verify_function = '_current_user_can_manage_zones';
-				break;
-		}
-
-		if( ! call_user_func( array( $this, $verify_function ), $zone_id ) )
+		if( ! $this->permissions->check( $action, $zone_id ) ) {
 			$this->_unauthorized_access();
+		}
 	}
 
 	function _unauthorized_access() {
@@ -1332,51 +607,29 @@ class Zoninator
 
 		global $wp_query;
 
-		$query_var = get_query_var( $this->zone_taxonomy );
+		$query_var = get_query_var( Zoninator_Constants::ZONE_TAXONOMY );
 
 		if ( ! empty( $query_var ) ) {
-			$zone_slug = get_query_var( $this->zone_taxonomy );
-			$zone_id = $this->get_zone( $zone_slug );
+			$zone_slug = get_query_var( Zoninator_Constants::ZONE_TAXONOMY );
 
-			if ( empty( $zone_id ) ) {
-				$this->send_user_error( __( 'Invalid zone supplied', 'zoninator' ) );
+			$results = $this->zone_gateway->get_zone_feed( $zone_slug );
+
+			if ( is_wp_error( $results ) ) {
+				$this->send_user_error( $results->get_error_message() );
 			}
 
-			$results = $this->get_zone_posts( $zone_id, apply_filters( 'zoninator_json_feed_fields', array(), $zone_slug ) );
-
-			if ( empty( $results ) ) {
-				$this->send_user_error( __( 'No zone posts found', 'zoninator' ) );
-			}
-
-			$filtered_results = $this->filter_zone_feed_fields( $results );
-
-			$this->json_return( apply_filters( 'zoninator_json_feed_results', $filtered_results, $zone_slug ), false );
+			$this->json_return( $results );
 		}
 
 		return;
 
 	}
 
-	private function filter_zone_feed_fields( $results ) {
-
-		$whitelisted_fields = array( 'ID', 'post_date', 'post_title', 'post_content', 'post_excerpt', 'post_status', 'guid' );
-
-		$i = 0;
-		foreach ( $results as $result ) {
-			foreach( $whitelisted_fields as $field ) {
-					$filtered_results[$i]->$field = $result->$field;
-			}
-			$i++;
-		}
-
-
-		return $filtered_results;
-	}
-
 	/**
 	 * Encode some data and echo it (possibly without cached headers)
 	 *
 	 * @param array $data
+	 * @return bool
 	 */
 	private function json_return( $data ) {
 
@@ -1412,57 +665,7 @@ class Zoninator
 		$wp_header_to_desc[$status] = $official_message;
 	}
 
-
-
-
-	// TODO: Caching needs to be testing properly before being implemented!
-	function get_zone_cache_key( $zone, $args = array() ) {
-		return '';
-
-		$meta_key = $this->get_zone_meta_key( $zone );
-		$hash = md5( serialize( $args ) );
-		return $meta_key . $hash;
-	}
-
-	function get_zone_posts_from_cache( $zone, $args = array() ) {
-		return false; // TODO: implement
-
-		$meta_key = $this->get_zone_meta_key( $zone );
-		$cache_key = $this->get_zone_cache_key( $zone, $args );
-		if( $posts = wp_cache_get( $cache_key, $meta_key ) )
-			return $posts;
-		return false;
-	}
-
-	function add_zone_posts_to_cache( $posts, $zone, $args = array() ) {
-		return; // TODO: implement
-
-		$meta_key = $this->get_zone_meta_key( $zone );
-		$cache_key = $this->get_zone_cache_key( $zone, $args );
-		wp_cache_set( $cache_key, $posts, $meta_key );
-	}
-
-	// Handle 4.2 term-splitting
-	function split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
-		if ( $this->zone_taxonomy === $taxonomy ) {
-			do_action( 'zoninator_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
-
-			// Quick, easy switcheroo; add posts to new zone id and remove from the old one.
-			$posts = $this->get_zone_posts( $old_term_id );
-			if ( ! empty( $posts ) ) {
-				$this->add_zone_posts( $new_term_id, $posts );
-				$this->remove_zone_posts( $old_term_id );
-			}
-
-			do_action( 'zoninator_did_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
-		}
-	}
-
-	function _empty_zone_posts_cache( $meta_key ) {
-		return; // TODO: implement
-	}
-
-	function _get_message( $message_id, $encode = false ) {
+	private function _get_message( $message_id, $encode = false ) {
 		$message = '';
 
 		if( ! empty( $this->zone_messages[$message_id] ) )
@@ -1474,37 +677,12 @@ class Zoninator
 		return $message;
 	}
 
-	function _get_nonce_key( $action ) {
-		return sprintf( '%s-%s', $this->zone_nonce_prefix, $action );
+	private function _get_nonce_key( $action ) {
+		return sprintf( '%s-%s', Zoninator_Constants::NONCE_PREFIX, $action );
 	}
 
-	function _current_user_can_add_zones() {
-		return current_user_can( $this->_get_add_zones_cap() );
-	}
-
-	function _current_user_can_edit_zones( $zone_id ) {
-		$has_cap = current_user_can( $this->_get_edit_zones_cap() );
-		return apply_filters( 'zoninator_current_user_can_edit_zone', $has_cap, $zone_id );
-	}
-
-	function _current_user_can_manage_zones() {
-		return current_user_can( $this->_get_manage_zones_cap() );
-	}
-
-	function _get_add_zones_cap() {
-		return apply_filters( 'zoninator_add_zone_cap', 'edit_others_posts' );
-	}
-
-	function _get_edit_zones_cap() {
-		return apply_filters( 'zoninator_edit_zone_cap', 'edit_others_posts' );
-	}
-
-	function _get_manage_zones_cap() {
-		return apply_filters( 'zoninator_manage_zone_cap', 'edit_others_posts' );
-	}
-
-	function _get_zone_page_url( $args = array() ) {
-		$url = menu_page_url( $this->key, false );
+	private function _get_zone_page_url( $args = array() ) {
+		$url = menu_page_url( Zoninator_Constants::KEY, false );
 
 		foreach( $args as $arg_key => $arg_value ) {
 			$url = add_query_arg( $arg_key, $arg_value, $url );
@@ -1513,15 +691,7 @@ class Zoninator
 		return $url;
 	}
 
-	function _validate_date_filter( $date ) {
-		return preg_match( '/([0-9]{4})-([0-9]{2})-([0-9]{2})/', $date );
-	}
-
-	function _validate_category_filter( $cat ) {
-		return $cat && get_term_by( 'id', $cat, 'category' );
-	}
-
-	function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {
+	private function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {
 		if( is_object( $object ) )
 			$value = ! empty( $object->$var ) ? $object->$var : $default;
 		elseif( is_array( $object ) )
@@ -1539,14 +709,15 @@ class Zoninator
 		return $value;
 	}
 
-	function _get_request_var( $var, $default = '', $sanitize_callback = '' ) {
+	private function _get_request_var( $var, $default = '', $sanitize_callback = '' ) {
 		return $this->_get_value_or_default( $var, $_REQUEST, $default, $sanitize_callback );
 	}
 
-	function _get_get_var( $var, $default = '', $sanitize_callback = '' ) {
+	private function _get_get_var( $var, $default = '', $sanitize_callback = '' ) {
 		return $this->_get_value_or_default( $var, $_GET, $default, $sanitize_callback );
 	}
-	function _get_post_var( $var, $default = '', $sanitize_callback = '' ) {
+
+	private function _get_post_var( $var, $default = '', $sanitize_callback = '' ) {
 		return $this->_get_value_or_default( $var, $_POST, $default, $sanitize_callback );
 	}
 }


### PR DESCRIPTION
Refs #40: Convert admin AJAX endpoints and zone feed to WP-API endpoints

Created `Zoninator_Rest_Api_Controller` class to represent the new rest API. Amended js code to use the new endpoints.

### Endpoints

The following endpoints where created

* `POST /zoninator/v1/zones/:zone_id/posts` (add post to zone)
* `GET /zoninator/v1/zones/:zone_id/posts` (get zone feed)
* `GET /zoninator/v1/posts/search?term=:term` (search term)
* `DELETE /zoninator/v1/zones/:zone_id/posts/:post_id` (remove post from zone)
* `PUT /zoninator/v1/zones/:zone_id/posts/order` (reorder posts)
* `PUT /zoninator/v1/zones/:zone_id/lock` (lock zone)
* `GET /zoninator/v1/zones/:zone_id/posts/recent` (recent posts for select box)

NOTE: Supplemented the zone feed endpoint with a RESTful endpoint. Did keep the
old zone feed rewrite rule though, as it might be used by third parties.

### Other

Refactored `Zoninator` class in the following ways

- extracted [zone_gateway](http://martinfowler.com/eaaCatalog/gateway.html) class
- extracted common aspects of view rendering into separate class
- extracted permission checking used both by `Zoninator_Rest_Api_Controller` and `Zoninator` into separate class
- Created PHPUnit tests for `Zoninator_Rest_Api_Controller`
- Created a script to automate the test env setup (assumes Ubuntu and bash)
- removed warnings, did some style fixes