### PR TITLE
Add ability to search limited timeframe

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -821,6 +821,7 @@ class Zoninator
 				'order' => 'DESC',
 				'orderby' => 'post_date',
 				'suppress_filters' => true,
+				'no_found_rows' => true,
 			) );
 
 			if ( $this->_validate_category_filter( $filter_cat ) ) {

--- a/zoninator.php
+++ b/zoninator.php
@@ -540,7 +540,7 @@ class Zoninator
 	}
 
 	function zone_advanced_search_date_filter() {
-		$current_date = $this->_get_post_var( 'zone_advanced_filter_date', '', 'striptags' );
+		$current_date = $this->_get_post_var( 'zone_advanced_filter_date', apply_filters( 'zoninator_advanced_filter_date_default', '' ), 'striptags' );
 		$date_filters = apply_filters( 'zoninator_advanced_filter_date', array( 'all', 'today', 'yesterday') );
 		?>
 		<select name="zone_advanced_filter_date" id="zone_advanced_filter_date">

--- a/zoninator.php
+++ b/zoninator.php
@@ -547,9 +547,15 @@ class Zoninator
 			<?php
 			// Convert string dates into actual dates
 			foreach( $date_filters as $date ) :
-				$timestamp = strtotime( $date );
-				$output = ( $timestamp ) ? date( 'Y-m-d', $timestamp ) : 0;
-				echo sprintf( '<option value="%s" %s>%s</option>', esc_attr( $output ), selected( $output, $current_date, false ), esc_html( $date ) );
+				if ( true === is_array( $date ) ) {
+					$output = array_key_exists( 'value', $date ) ? $date['value'] : 0;
+					$label = array_key_exists( 'label', $date ) ? $date['label'] : $output;
+				} else {
+					$timestamp = strtotime( $date );
+					$output = ( $timestamp ) ? date( 'Y-m-d', $timestamp ) : 0;
+					$label = $date;
+				}
+				echo sprintf( '<option value="%s" %s>%s</option>', esc_attr( $output ), selected( $output, $current_date, false ), esc_html( $label ) );
 			endforeach;
 			?>
 		</select>


### PR DESCRIPTION
This PR is adding a new filter for filtering the default value of the date filter and is adding a support for arrays inside the `$date_filters` array, which in turn allows developers to provide advanced date filtering of the results.

Together with the `zoninator_search_args` filters, developers could limit the search, by default, to past 60 days only, making the queries on the backend more performant, than the default full table scan search.

Example implementation of default time filtering limited to past 60 days:

```
add_filter( 'zoninator_advanced_filter_date', function( $date_filters ) {
	return array_merge( (array) $date_filters, array(
		array(
			'value' => 'past60days',
			'label' => 'Past 60 days'
		)
	) );
} );

add_filter( 'zoninator_advanced_filter_date_default', function( $default ) {
	return 'past60days';
} );

add_filter( 'zoninator_search_args', function( $args ) {
	global $zoninator;
	$date = $zoninator->_get_get_var( 'date', '', 'striptags' );
	if ( 'past60days' === $date ) {
		$args['date_query'] = array(
			array(
				'after' => '-60 days'
			)
		);
	}
	return $args;
}, 10 );
```