### PR TITLE
Add get_zones & create_zone REST API endpints

### DIFF
--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -60,6 +60,9 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 			self::ZONE_ID_POST_ID_REQUIRED => __( 'post id and zone id required', 'zoninator' ),
 		);
 
+		$this->add_route( 'zones' )
+			->add_action( $this->action( 'index', 'get_zones' ) );
+
 		$this->add_route( 'zones/(?P<zone_id>[\d]+)' )
 			->add_action( $this->action( 'index', 'get_zone_posts' )
 				->permissions( 'get_zone_posts_permissions_check' )
@@ -98,6 +101,22 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		$this->add_route( 'posts/recent' )
 			->add_action( $this->action( 'index', 'get_recent_posts' )
 				->args( '_params_for_get_recent_posts' ) );
+	}
+
+	/**
+	 * Get the list of all zones
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	function get_zones( $request ) {
+		$results = $this->instance->get_zones();
+
+		if ( is_wp_error( $results ) ) {
+			return $this->_bad_request( self::ZONE_FEED_ERROR, $results->get_error_message() );
+		}
+
+		return new WP_REST_Response( $results, 200 );
 	}
 
 	/**

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -523,7 +523,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 */
 	public function add_post_to_zone_permissions_check( $request ) {
 		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
-		return $this->_permissions_check( 'insert', $zone_id );
+		return $this->_permissions_check( 'update', $zone_id );
 	}
 
 	/**

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -123,7 +123,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 			) );
 		}
 
-		return new WP_REST_Response( $results, 200 );
+		return $this->ok( $results );
 	}
 
 	/**
@@ -135,7 +135,9 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		$slug = $this->_get_param( $request, 'slug', '' );
 		$description = $this->_get_param( $request, 'description', '', 'strip_tags' );
 
-		$result = $this->instance->insert_zone( $slug, $name, array( 'description' => $description ) );
+		$result = $this->instance->insert_zone( $slug, $name, array(
+			'description' => $description,
+		) );
 
 		if ( is_wp_error( $result ) ) {
 			return $this->bad_request( array(
@@ -548,7 +550,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	}
 
 	public function strip_tags( $item ) {
-		// see https://github.com/WP-API/WP-API/issues/1520 on why we do not use stripslashes directly
+		// see https://github.com/WP-API/WP-API/issues/1520 on why we do not use strip_tags directly
 		return strip_tags( $item );
 	}
 

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @packae Zoninator/Rest
+ * @package Zoninator/Rest
  */
 
 

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -49,7 +49,6 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		return $this->login_as( $this->admin_id );
 	}
 
-
 	/**
 	 * Login as
 	 *
@@ -190,6 +189,33 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		do_action( 'rest_api_init' );
 		$this->environment = Zoninator()->rest_api->bootstrap->environment();
 	}
+
+	/**
+	 * T test_create_zone_responds_with_created_when_method_post
+	 *
+	 * @throws Exception E.
+	 */
+	function test_create_zone_responds_with_created_when_method_post() {
+		$this->login_as_admin();
+		$response = $this->post( '/zoninator/v1/zones', array(
+			'slug' => 'test-zone',
+		) );
+		$this->assertResponseStatus( $response, 201 );
+	}
+
+	/**
+	 * T test_create_zone_fail_if_invalid_data
+	 *
+	 * @throws Exception E.
+	 */
+	function test_create_zone_fail_if_invalid_data() {
+		$this->login_as_admin();
+		$response = $this->post( '/zoninator/v1/zones', array(
+			'name' => 'Test zone',
+			'description' => 'No slug provided.'
+		) );
+		$this->assertResponseStatus( $response, 400 );
+	}	
 
 	/**
 	 * T test_add_post_to_zone_responds_with_created_when_method_post


### PR DESCRIPTION
This PR adds `get_zones` & `create_zones` endpoints to the REST API.

## Endpoints

- `GET /zoninator/v1/zones` ( get a list with all zones )
- `POST /zoniantor/v1/zones` ( create a new zone )

## Other

Changed permissions for `add_post_to_zone` to `update` as it falls under editing a zone rather than creating one.