### PR TITLE
Remove unnecessary properties from zones index response.

### DIFF
--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -123,7 +123,9 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 			) );
 		}
 
-		return $this->ok( $results );
+		$zones = array_map( array( $this, '_filter_zone_properties' ), $results );
+
+		return $this->ok( $zones );
 	}
 
 	/**
@@ -678,6 +680,17 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 //				'required'          => false
 //			)
 //		);
+	}
+
+	public function _filter_zone_properties( $zone ) {
+		$data = $zone->to_array();
+
+		return array(
+			'term_id'		=> $data[ 'term_id' ],
+			'slug'			=> $data[ 'slug' ],
+			'name'			=> $data[ 'name' ],
+			'description'	=> $data[ 'description' ],
+		);
 	}
 
 	private function _bad_request($code, $message) {


### PR DESCRIPTION
This PR aims to narrow down the properties returned as part of the zones index, to prevent unnecessary dependencies.

The zone properties returned by the endpoint are now limited to:

- `term_id` ( Zone ID )
- `slug`
- `name`
- `description`
