### PR TITLE
Use name as the default for slug on create_zone

### DIFF
--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -123,7 +123,9 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 			) );
 		}
 
-		return $this->ok( $results );
+		$zones = array_map( array( $this, '_filter_zone_properties' ), $results );
+
+		return $this->ok( $zones );
 	}
 
 	/**
@@ -678,6 +680,17 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 //				'required'          => false
 //			)
 //		);
+	}
+
+	public function _filter_zone_properties( $zone ) {
+		$data = $zone->to_array();
+
+		return array(
+			'term_id'		=> $data[ 'term_id' ],
+			'slug'			=> $data[ 'slug' ],
+			'name'			=> $data[ 'name' ],
+			'description'	=> $data[ 'description' ],
+		);
 	}
 
 	private function _bad_request($code, $message) {

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -565,7 +565,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 */
 	private function _get_param( $object, $var, $default = '', $sanitize_callback = '' ) {
 		$value = $object->get_param( $var );
-		$value = ( $value !== null ) ? $value : $default;
+		$value = empty( $value ) ? $default : $value;
 
 
 		if ( is_callable( $sanitize_callback ) ) {

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -134,7 +134,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 */
 	function create_zone( $request ) {
 		$name = $this->_get_param( $request, 'name', '' );
-		$slug = $this->_get_param( $request, 'slug', '' );
+		$slug = $this->_get_param( $request, 'slug', $name );
 		$description = $this->_get_param( $request, 'description', '', 'strip_tags' );
 
 		$result = $this->instance->insert_zone( $slug, $name, array(
@@ -149,7 +149,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 
 		$zone = $this->instance->get_zone( $result[ 'term_id' ] );
 
-		return $this->created( $zone );
+		return $this->created( $this->_filter_zone_properties( $zone ) );
 	}
 
 	/**
@@ -586,7 +586,8 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 			'slug' => array(
 				'type' => 'string',
 				'sanitize_callback' => array( $this, 'strip_slashes' ),
-				'required' => true,
+				'default' => '',
+				'required' => false,
 			),
 			'description' => array(
 				'type' => 'string',


### PR DESCRIPTION
This PR allows creating a zone through `create_zone` endpoint given just the `name` param instead of `slug`.
The goal is to simplify things for the client side, as the exact slug is generated and returned from the plugin anyway.