### PR TITLE
Remove unused REST endpoints

### DIFF
--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -80,27 +80,16 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 			);
 
 		$this->add_route( 'zones/(?P<zone_id>[\d]+)/posts' )
-			->add_action( $this->action( 'index', 'get_zone_posts' )
-				->permissions( 'get_zone_posts_permissions_check' )
-				->args( '_get_zone_id_param' )
+			->add_action(
+				$this->action( 'index', 'get_zone_posts' )
+					->permissions( 'get_zone_posts_permissions_check' )
+					->args( '_get_zone_id_param' )
 			)
-			->add_action( $this->action( 'update', 'update_zone_posts' )
-				->permissions( 'update_zone_permissions_check' )
-				->args( '_get_zone_post_rest_route_params' )
+			->add_action(
+				$this->action( 'update', 'update_zone_posts' )
+					->permissions( 'update_zone_permissions_check' )
+					->args( '_get_zone_post_rest_route_params' )
 			);
-
-		$this->add_route( 'zones/(?P<zone_id>[\d]+)/lock' )
-			->add_action( $this->action( 'update', 'zone_update_lock' )
-				->permissions( 'update_zone_permissions_check' )
-				->args( '_get_zone_id_param' ) );
-
-		$this->add_route( 'posts/search' )
-			->add_action( $this->action( 'index', 'search_posts' )
-				->args( '_params_for_search_posts' ) );
-
-		$this->add_route( 'posts/recent' )
-			->add_action( $this->action( 'index', 'get_recent_posts' )
-				->args( '_params_for_get_recent_posts' ) );
 	}
 
 	/**
@@ -271,173 +260,6 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	}
 
 	/**
-	 * Update the zone's lock
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
-	 */
-	function zone_update_lock( $request ) {
-		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
-
-		if (! $zone_id ) {
-			return $this->_bad_request(self::ZONE_ID_REQUIRED, __('zone id required', 'zoninator'));
-		}
-
-		if ( ! $this->instance->is_zone_locked( $zone_id ) ) {
-			$this->instance->lock_zone( $zone_id );
-			return new WP_REST_Response(array(
-				'zone_id' => $zone_id,
-				'status' => 1,
-			), 200);
-		}
-
-		return new WP_REST_Response(array(
-			'zone_id' => $zone_id,
-			'status' => 0), 400);
-	}
-
-	/**
-	 * Search posts for "term"
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|WP_REST_Response
-	 */
-	function search_posts( $request ) {
-		$search_filter_definition = $this->environment()->model( 'Zoninator_Api_Filter_Search' );
-		$search_filter = $search_filter_definition->new_from_array( $request->get_params() );
-
-		$validation_error = $search_filter->validate();
-		if ( is_wp_error( $validation_error ) ) {
-			return $this->respond( $validation_error, 400 );
-		}
-
-		$filter_cat = $search_filter->get( 'cat' );
-		$filter_date = $search_filter->get( 'date' );
-
-		$post_types = $this->instance->get_supported_post_types();
-		$limit = $this->_get_param( $request, 'limit', $this->instance->posts_per_page );
-
-		if ( 0 >= $limit ) {
-			$limit = $this->instance->posts_per_page;
-		}
-
-		$exclude = (array)$search_filter->get( 'exclude' );
-
-		$args = apply_filters('zoninator_search_args', array(
-			's' => $search_filter->get( 'term' ),
-			'post__not_in' => $exclude,
-			'posts_per_page' => $limit,
-			'post_type' => $post_types,
-			'post_status' => array('publish', 'future'),
-			'order' => 'DESC',
-			'orderby' => 'post_date',
-			'suppress_filters' => true,
-		));
-
-		if ( $this->instance->_validate_category_filter( $filter_cat ) ) {
-			$args['cat'] = $filter_cat;
-		}
-
-		if ( $this->instance->_validate_date_filter( $filter_date ) ) {
-			$filter_date_parts = explode( '-', $filter_date );
-			$args['year'] = $filter_date_parts[0];
-			$args['monthnum'] = $filter_date_parts[1];
-			$args['day'] = $filter_date_parts[2];
-		}
-
-		$query = new WP_Query($args);
-
-		$stripped_posts = array();
-
-		if ( $query->have_posts() ) {
-			foreach ( $query->posts as $post ) {
-				$stripped_posts[] = apply_filters( 'zoninator_search_results_post', array(
-					'title' => !empty( $post->post_title ) ? $post->post_title : __( '(no title)', 'zoninator' ),
-					'post_id' => $post->ID,
-					'date' => get_the_time( get_option( 'date_format' ), $post ),
-					'post_type' => $post->post_type,
-					'post_status' => $post->post_status,
-				), $post );
-			}
-		}
-
-		return new WP_REST_Response( $stripped_posts, 200 );
-	}
-
-	/**
-	 * Get recent posts, excluding the ones that are already part of the zone provided
-	 * Recent posts can be filtered by category and date
-	 *
-	 * @param WP_REST_Request $request
-	 * @return WP_Error|WP_REST_Response
-	 */
-	public function get_recent_posts( $request ) {
-		$cat = $this->_get_param( $request, 'cat', '', 'absint' );
-		$date = $this->_get_param( $request, 'date', '', 'striptags' );
-		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
-
-		$limit = $this->instance->posts_per_page;
-		$post_types = $this->instance->get_supported_post_types();
-		$zone_posts = $this->instance->get_zone_posts( $zone_id );
-		$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
-
-		$http_status = 200;
-
-		if ( is_wp_error( $zone_posts ) ) {
-			$status = 0;
-			$content = $zone_posts->get_error_message();
-			$http_status = 500;
-		} else {
-			$args = apply_filters( 'zoninator_recent_posts_args', array(
-				'posts_per_page' => $limit,
-				'order' => 'DESC',
-				'orderby' => 'post_date',
-				'post_type' => $post_types,
-				'ignore_sticky_posts' => true,
-				'post_status' => array( 'publish', 'future' ),
-				'post__not_in' => $zone_post_ids,
-			) );
-
-			if ( $this->instance->_validate_category_filter( $cat ) ) {
-				$args['cat'] = $cat;
-			}
-
-			if ( $this->instance->_validate_date_filter( $date ) ) {
-				$filter_date_parts = explode( '-', $date );
-				$args['year'] = $filter_date_parts[0];
-				$args['monthnum'] = $filter_date_parts[1];
-				$args['day'] = $filter_date_parts[2];
-			}
-
-			$content = '';
-			$recent_posts = get_posts( $args );
-			foreach ( $recent_posts as $post ) {
-				$content .= sprintf('<option value="%d">%s</option>', $post->ID, get_the_title($post->ID) . ' (' . $post->post_status . ')');
-			}
-
-			wp_reset_postdata();
-			$status = 1;
-		}
-
-		if ( ! $content ) {
-			$empty_label = __( 'No results found', 'zoninator' );
-		} elseif ( $cat ) {
-			$empty_label = sprintf(__('Choose post from %s', 'zoninator'), get_the_category_by_ID($cat));
-		} else {
-			$empty_label = __( 'Choose a post', 'zoninator' );
-		}
-
-		$content = '<option value="">' . esc_html( $empty_label ) . '</option>' . $content;
-
-		$response = new WP_REST_Response( array(
-			'zone_id' => $zone_id,
-			'content' => $content,
-			'status' => $status ) );
-		$response->set_status( $http_status );
-		return $response;
-	}
-
-	/**
 	 * Check if a given request has access to the zones index.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
@@ -465,17 +287,6 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 */
 	public function get_zone_posts_permissions_check( $request ) {
 		return true;
-	}
-
-	/**
-	 * Check if a given request has access to remove a post from zone.
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
-	 */
-	public function remove_post_from_zone_permissions_check( $request ) {
-		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
-		return $this->_permissions_check( 'update', $zone_id );
 	}
 
 	/**
@@ -591,69 +402,6 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 				'items'				=> array( 'type' => 'integer' ),
 			),
 		), $zone_params );
-	}
-
-	public function _params_for_get_recent_posts()
-	{
-		$zone_params = $this->_get_zone_id_param();
-		return array_merge(array(
-			'cat' => array(
-				'description'       => __( 'only recent posts from this category id', 'zoninator' ),
-				'type'              => 'integer',
-				'validate_callback' => array( $this, 'is_numeric' ),
-				'sanitize_callback' => 'absint',
-				'default'           => 0,
-				'required'          => false
-			),
-			'date' => array(
-				'description'       => __( 'only get posts after this date (format YYYY-mm-dd)', 'zoninator' ),
-				'type'              => 'string',
-				'sanitize_callback' => array( $this, 'strip_slashes' ),
-				'default'           => '',
-				'required'          => false
-			)
-		), $zone_params);
-	}
-
-	public function _params_for_search_posts() {
-		$search_filter = $this->environment()->model( 'Zoninator_Api_Filter_Search' );
-		$schema_converter = new Zoninator_Api_Schema_Converter();
-		return $schema_converter->as_args( $search_filter );
-//		return array(
-//			'term' => array(
-//				'description'       => __( 'search term', 'zoninator' ),
-//				'type'              => 'string',
-//				'sanitize_callback' => array( $this, 'strip_slashes' ),
-//				'default'           => '',
-//				'required'          => true
-//			),
-//			'cat' => array(
-//				'description'       => __( 'filter by category', 'zoninator' ),
-//				'type'              => 'integer',
-//				'validate_callback' => array( $this, 'is_numeric' ),
-//				'sanitize_callback' => 'absint',
-//				'default'           => 0,
-//				'required'          => false
-//			),
-//			'date' => array(
-//				'description'       => __( 'only get posts after this date (format YYYY-mm-dd)', 'zoninator' ),
-//				'type'              => 'string',
-//				'sanitize_callback' => array( $this, 'strip_slashes' ),
-//				'default'           => '',
-//				'required'          => false
-//			),
-//			'limit' => array(
-//				'description'       => __( 'limit results', 'zoninator' ),
-//				'type'              => 'integer',
-//				'sanitize_callback' => 'absint',
-//				'default'           => $this->instance->posts_per_page,
-//				'required'          => false
-//			),
-//			'exclude' => array(
-//				'description'       => __( 'post_ids to exclude', 'zoninator' ),
-//				'required'          => false
-//			)
-//		);
 	}
 
 	public function _filter_zone_properties( $zone ) {

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -211,7 +211,6 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	function test_create_zone_fail_if_invalid_data() {
 		$this->login_as_admin();
 		$response = $this->post( '/zoninator/v1/zones', array(
-			'name' => 'Test zone',
 			'description' => 'No slug provided.'
 		) );
 		$this->assertResponseStatus( $response, 400 );
@@ -372,59 +371,6 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 
 		$response = $this->get( '/zoninator/v1/zones/' . ( $zone_id + 3 ) );
 		$this->assertResponseStatus( $response, 404 );
-	}
-
-//
-//    function test_zone_update_lock_200()
-//    {
-//        $this->_zoninator->method( 'is_zone_locked' )->willReturn( false );
-//        $request = $this->_create_request( array( 'zone_id' => 3 ) );
-//        $response = $this->_controller->zone_update_lock( $request );
-//        $this->_assert_response_status($response, 200);
-//    }
-//
-//    function test_zone_update_lock_400_if_zone_already_locked()
-//    {
-//        $this->_zoninator->method( 'is_zone_locked' )->willReturn( true );
-//        $request = $this->_create_request( array( 'zone_id' => 3 ) );
-//        $response = $this->_controller->zone_update_lock( $request );
-//        $this->_assert_response_status($response, 400);
-//    }
-//
-//    function test_zone_update_error_if_no_zone_id()
-//    {
-//        $this->_zoninator->method( 'is_zone_locked' )->willReturn( false );
-//        $request = $this->_create_request( array( ) );
-//        $response = $this->_controller->zone_update_lock( $request );
-//        $this->assertInstanceOf( 'WP_Error', $response );
-//    }
-//
-	/**
-	 * Test test_search_posts_error_if_empty_term
-	 */
-    function test_search_posts_return_results() {
-		self::factory()->post->create_many( 5 );
-		$query = new WP_Query();
-		$posts = $query->query( array() );
-		$first = $posts[0];
-        $data = array( 'term' => $first->post_title );
-		$response = $this->get( '/zoninator/v1/posts/search', $data );
-		$this->assertResponseStatus( $response, 200 );
-		$data = $response->get_data();
-		$first_result = $data[0];
-		$this->assertEquals( $first->ID, $first_result['post_id'] );
-    }
-
-	/**
-	 * Test test_search_posts_error_if_empty_term
-	 */
-	function test_search_posts_error_if_empty_term() {
-		self::factory()->post->create_many( 5 );
-		$query = new WP_Query();
-		$posts = $query->query( array() );
-		$data = array( 'term' => '' );
-		$response = $this->get( '/zoninator/v1/posts/search', $data );
-		$this->assertResponseStatus( $response, 400 );
 	}
 
     /**


### PR DESCRIPTION
This PR removes the endpoints unused by the calypso extension so we don't accidentally force ourselves into supporting them in the future.  
The removed endpoints are:

- `PUT /zones/{zoneId}/lock`
- `GET /posts/search`
- `GET /posts/recent`