### PR TITLE
Added check for instantiation in filter_zone_feed_fields

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -1379,11 +1379,12 @@ class Zoninator
 
 		$whitelisted_fields = array( 'ID', 'post_date', 'post_title', 'post_content', 'post_excerpt', 'post_status', 'guid' );
 
+		$filtered_results = array();
 		$i = 0;
 		foreach ( $results as $result ) {
 			foreach( $whitelisted_fields as $field ) {
-				if ( ! is_object( $filtered_results[$i] ) ) {
-					$filtered_results[$i] = new stdClass();
+				if ( ! isset ( $filtered_results[$i] ) ) {
+					$filtered_results[$i] = new stdClass;
 				}
 				$filtered_results[$i]->$field = $result->$field;
 			}

--- a/zoninator.php
+++ b/zoninator.php
@@ -1382,7 +1382,10 @@ class Zoninator
 		$i = 0;
 		foreach ( $results as $result ) {
 			foreach( $whitelisted_fields as $field ) {
-					$filtered_results[$i]->$field = $result->$field;
+				if ( ! is_object( $filtered_results[$i] ) ) {
+					$filtered_results[$i] = new stdClass();
+				}
+				$filtered_results[$i]->$field = $result->$field;
 			}
 			$i++;
 		}


### PR DESCRIPTION
`Warning: Creating default object from empty value` was occurring due to no instantiation of `$filtered_results[$i]`.  Added check in this PR.
VIP Reference: #70678-z  