### PR TITLE
Prevent characters from being removed from name & description during validation

### DIFF
--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -121,7 +121,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	function create_zone( $request ) {
 		$name = $this->_get_param( $request, 'name', '' );
 		$slug = $this->_get_param( $request, 'slug', $name );
-		$description = $this->_get_param( $request, 'description', '', 'strip_tags' );
+		$description = $this->_get_param( $request, 'description', '' );
 
 		$result = $this->instance->insert_zone( $slug, $name, array(
 			'description' => $description,
@@ -309,14 +309,8 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		return count( $items ) === count( array_filter( $items, 'is_numeric') );
 	}
 
-	public function strip_slashes( $item ) {
-		// see https://github.com/WP-API/WP-API/issues/1520 on why we do not use stripslashes directly.
-		return stripslashes( $item );
-	}
-
-	public function strip_tags( $item ) {
-		// see https://github.com/WP-API/WP-API/issues/1520 on why we do not use strip_tags directly.
-		return strip_tags( $item );
+	public function sanitize_string( $item ) {
+		return htmlentities( stripslashes( $item ) );
 	}
 
 	/**
@@ -342,19 +336,19 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		return array(
 			'name' => array(
 				'type' => 'string',
-				'sanitize_callback' => array( $this, 'strip_slashes' ),
+				'sanitize_callback' => array( $this, 'sanitize_string' ),
 				'default' => '',
 				'required' => false
 			),
 			'slug' => array(
 				'type' => 'string',
-				'sanitize_callback' => array( $this, 'strip_slashes' ),
+				'sanitize_callback' => array( $this, 'sanitize_string' ),
 				'default' => '',
 				'required' => false,
 			),
 			'description' => array(
 				'type' => 'string',
-				'sanitize_callback' => array( $this, 'strip_tags' ),
+				'sanitize_callback' => array( $this, 'sanitize_string' ),
 				'default' => '',
 				'required' => false,
 			)
@@ -365,17 +359,17 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		return array(
 			'name' => array(
 				'type' => 'string',
-				'sanitize_callback' => array( $this, 'strip_slashes' ),
+				'sanitize_callback' => array( $this, 'sanitize_string' ),
 				'required' => false
 			),
 			'slug' => array(
 				'type' => 'string',
-				'sanitize_callback' => array( $this, 'strip_slashes' ),
+				'sanitize_callback' => array( $this, 'sanitize_string' ),
 				'required' => false,
 			),
 			'description' => array(
 				'type' => 'string',
-				'sanitize_callback' => array( $this, 'strip_tags' ),
+				'sanitize_callback' => array( $this, 'sanitize_string' ),
 				'required' => false,
 			)
 		);

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -217,6 +217,24 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * T test_create_zone_with_special_chars
+	 *
+	 * @throws Exception E
+	 */
+	function test_create_zone_with_special_chars() {
+		$this->login_as_admin();
+		$response = $this->post( '/zoninator/v1/zones', array(
+			'name' => '&<>!@#(',
+			'slug' => 'test-zone',
+			'description' => '&<>!@#('
+		) );
+		$data = $response->get_data();
+		$this->assertResponseStatus( $response, 201 );
+		$this->assertEquals( $data['name'], '&amp;&lt;&gt;!@#(' );
+		$this->assertEquals( $data['description'], '&amp;&lt;&gt;!@#(' );
+	}
+
+	/**
 	 * T test_update_zone_responds_with_success_when_method_put
 	 *
 	 * @throws Exception E.

--- a/zoninator.php
+++ b/zoninator.php
@@ -214,10 +214,10 @@ class Zoninator
 					$this->verify_nonce( $action );
 					$this->verify_access( $action, $zone_id );
 
-					$name = $this->_get_post_var( 'name' );
+					$name = $this->_get_post_var( 'name', '', array( $this, '_sanitize_value' ) );
 					$slug = $this->_get_post_var( 'slug', sanitize_title( $name ) );
 					$details = array(
-						'description' => $this->_get_post_var( 'description', '', 'strip_tags' )
+						'description' => $this->_get_post_var( 'description', '', array( $this, '_sanitize_value' ) )
 					);
 
 					// TODO: handle additional properties
@@ -1557,6 +1557,10 @@ class Zoninator
 
 	function _validate_category_filter( $cat ) {
 		return $cat && get_term_by( 'id', $cat, 'category' );
+	}
+
+	function _sanitize_value( $var ) {
+		return htmlentities( stripslashes( $var ) );
 	}
 
 	function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {


### PR DESCRIPTION
This PR encodes malicious characters as html entities when parsing REST API input for zone name & description. This allows for the whole content to be persisted safely.

Right now, the plugin discards a name or description if it contains any of `&`, `<`, `>`.

Affected endpoints:

- `POST /zones`
- `PUT /zones/{zoneId}`