### PR TITLE
Serializes the description field after apply filters

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -916,7 +916,6 @@ class Zoninator
 		$name = ! empty( $name ) ? $name : $slug;
 
 		$details = wp_parse_args( $details, $this->zone_detail_defaults );
-		$details = maybe_serialize( stripslashes_deep( $details ) );
 
 		$args = array(
 			'slug' => $slug,
@@ -925,6 +924,9 @@ class Zoninator
 
 		// Filterize to allow other inputs
 		$args = apply_filters( 'zoninator_insert_zone', $args );
+
+		// Serialize the description.
+		$args['description'] = maybe_serialize( stripslashes_deep( $args['description'] ) );
 
 		return wp_insert_term( $name, $this->zone_taxonomy, $args );
 	}
@@ -940,9 +942,7 @@ class Zoninator
 			$details = $this->_get_value_or_default( 'details', $data, array() );
 
 			// TODO: Back-fill current zone details
-			//$details = wp_parse_args( $details, $this->zone_detail_defaults );
 			$details = wp_parse_args( $details, $this->zone_detail_defaults );
-			$details = maybe_serialize( stripslashes_deep( $details ) );
 
 			$args = array(
 				'name' => $name,
@@ -952,6 +952,9 @@ class Zoninator
 
 			// Filterize to allow other inputs
 			$args = apply_filters( 'zoninator_update_zone', $args, $zone_id, $zone );
+
+			// Serialize the description.
+			$args['description'] = maybe_serialize( stripslashes_deep( $args['description'] ) );
 
 			return wp_update_term( $zone_id, $this->zone_taxonomy, $args );
 		}


### PR DESCRIPTION
The `zoninator_insert_zone` and `zoninator_update_zone` hook sends the serialized description data and it requires additional code to unserialize, add additional fields and serialize data again. The PR addresses the problem by serializing the data after the `apply_filters` hook so that we can make sure the data is serialized always.