### PR TITLE
Increase autocomplete timeout

### DIFF
--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -89,7 +89,7 @@ var zoninator = {};
 				})
 				.autocomplete({
 					minLength: 3
-					// the default timeout (300ms) doesn't allow much time between keystrokes, increasing it to avoid request floodingnga 
+					// the default timeout (300ms) doesn't allow much time between keystrokes, increasing it to avoid request flooding 
 					, delay: 600
 					// Remote source with caching
 					, source : function(request, response) {

--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -89,6 +89,8 @@ var zoninator = {};
 				})
 				.autocomplete({
 					minLength: 3
+					// the default timeout (300ms) doesn't allow much time between keystrokes, increasing it to avoid request floodingnga 
+					, delay: 600
 					// Remote source with caching
 					, source : function(request, response) {
 						var term = request.term;


### PR DESCRIPTION
By default, jquery UI has a 300ms timeout, by increasing it to 600ms it reduces the potential to flood the server with requests.