### PR TITLE
Correctly position cloned sortable element on mobile

### DIFF
--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -38,6 +38,12 @@ var zoninator = {};
 				, placeholder         : 'ui-state-highlight'
 				, forcePlaceholderSize: true
 				//, handle: '.zone-post-handle'
+				// This helper function addresses #41 (Drag and Drop on Mobile Issue) and corrects the placement of the cloned sortable item on Chrome/Safari iOS
+				, helper              : function(event, ui) {
+					var clone = $(ui).clone();
+					clone.css('position','absolute');
+					return clone.get(0);
+				}
 			});
 		}
 


### PR DESCRIPTION
Zoninator #41 

Added a helper function to the jQuery UI Sortable call to fix the positioning of the cloned sortable element when dragging on mobile.

Tested on latest Chrome/Safari on iOS 11.3, and latest Chrome on Android via BrowserStack.