### PR TITLE
Issue/12 add method to add post type to zoninator

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -916,12 +916,12 @@ class Zoninator
 
 		$did_register_post_types = false;
 
-		if ( ! is_array( $post_types) ) {
+		if ( ! is_array( $post_types ) ) {
 			$post_types = array( $post_types );
 		}
 
-		foreach( $post_types as $post_type ) {
-			
+		foreach ( $post_types as $post_type ) {
+
 			if ( ! post_type_exists( $post_type ) ) {
 				continue;
 			}

--- a/zoninator.php
+++ b/zoninator.php
@@ -910,7 +910,7 @@ class Zoninator
 	 * Registers a post type to be available for zones
 	 *
 	 * @param string|array $post_types A post type string or array of post type strings to register.
-	 * @return bool
+	 * @return bool True if any post types were added, false if not.
 	 */
 	function register_zone_post_type( $post_types = '' ) {
 

--- a/zoninator.php
+++ b/zoninator.php
@@ -906,6 +906,40 @@ class Zoninator
 		return $this->post_types;
 	}
 
+	/**
+	 * Registers a post type to be available for zones
+	 *
+	 * @param string|array $post_types A post type string or array of post type strings to register.
+	 * @return bool
+	 */
+	function register_zone_post_type( $post_types = '' ) {
+
+		$did_register_post_types = false;
+
+		if ( ! is_array( $post_types) ) {
+			$post_types = array( $post_types );
+		}
+
+		foreach( $post_types as $post_type ) {
+			
+			if ( '' === $post_type || ! post_type_exists( $post_type ) ) {
+				continue;
+			}
+
+			add_post_type_support( $post_type, $this->zone_taxonomy );
+			register_taxonomy_for_object_type( $this->zone_taxonomy, $post_type );
+
+			// Clear Zoninator supported post types cache
+			unset( $this->post_types );
+
+			$did_register_post_types = true;
+
+		}
+
+		return $did_register_post_types;
+
+	}
+
 	function insert_zone( $slug, $name = '', $details = array() ) {
 
 		// slug cannot be empty

--- a/zoninator.php
+++ b/zoninator.php
@@ -922,7 +922,7 @@ class Zoninator
 
 		foreach( $post_types as $post_type ) {
 			
-			if ( '' === $post_type || ! post_type_exists( $post_type ) ) {
+			if ( ! post_type_exists( $post_type ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Zoninator #12

Added a `register_zone_post_type` method to the `Zoninator` class. It more easily allows users to add additional post types to zones.

It accepts one parameter, `$post_types`, and it can be either a string of the post type slug, or an array of post type slugs.

The method returns a boolean: true if any post types were registered, false if not.