### PR TITLE
Add filter to control fields included in Zoninator zone feed responses

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -1428,7 +1428,10 @@ class Zoninator
 
 	private function filter_zone_feed_fields( $results ) {
 		$filtered_results = array();
-		$whitelisted_fields = array( 'ID', 'post_date', 'post_title', 'post_content', 'post_excerpt', 'post_status', 'guid' );
+		$whitelisted_fields = apply_filters(
+			'zoninator_zone_feed_fields',
+			array( 'ID', 'post_date', 'post_title', 'post_content', 'post_excerpt', 'post_status', 'guid' )
+		);
 
 		$filtered_results = array();
 		$i = 0;


### PR DESCRIPTION
Sometimes you may want just the ID, sometimes you may want a fuller representation of the post. First pass at a filter, could potentially be extended later with additional arguments.