### PR TITLE
Send empty set when search yields no results

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -859,8 +859,10 @@ class Zoninator
 			$query = new WP_Query( $args );
 			$stripped_posts = array();
 
-			if ( ! $query->have_posts() )
+			if ( ! $query->have_posts() ) {
+				echo json_encode( array() );
 				exit;
+			}
 
 			foreach( $query->posts as $post ) {
 				$stripped_posts[] = apply_filters( 'zoninator_search_results_post', array(


### PR DESCRIPTION
When a search for content yields no results, Zoninator exits without sending a response. jQuery interprets this response to represent a failed request (I believe because it interprets it as malformed JSON) and never fires the "success" callback that removes the loading spinner, making it look to the user as though they're still waiting for search results. Sending an empty array back to the browser appears to address this issue.