### PR TITLE
Add default_post_types property to Zoninator class

### DIFF
--- a/zoninator.php
+++ b/zoninator.php
@@ -60,6 +60,10 @@ class Zoninator
 	 * @var Zoninator_Api
 	 */
 	public $rest_api = null;
+	/**
+	 * @var array|string[] Default post types that support zones.
+	 */
+	public $default_post_types = array( 'post' );
 
 	function __construct() {
 		add_action( 'init', array( $this, 'init' ), 99 ); // init later after other post types have been registered
@@ -75,8 +79,6 @@ class Zoninator
 		add_action( 'split_shared_term', array( $this, 'split_shared_term' ), 10, 4 );
 
 		$this->maybe_add_rest_api();
-
-		$this->default_post_types = array( 'post' );
 	}
 
 	public function maybe_add_rest_api() {


### PR DESCRIPTION
Declare the `default_post_types` property to ensure PHP 8.2 compatibility without throwing a `Deprecated: Creation of dynamic property` notice by defining the property upon class instantiation rather than at runtime.

Background on the change in PHP: https://php.watch/versions/8.2/dynamic-properties-deprecated