### PR TITLE
CI: Use valid runs-on value, and fix some issues

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -13,10 +13,7 @@ on:
 jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
-    # Ubuntu-20.x includes MySQL 8.0, which causes `caching_sha2_password` issues with PHP < 7.4
-    # https://www.php.net/manual/en/mysqli.requirements.php
-    # TODO: change to ubuntu-latest when we no longer support PHP < 7.4
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     env:
       WP_VERSION: ${{ matrix.wordpress }}

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -70,7 +70,7 @@ jobs:
         run: sudo systemctl start mysql.service
 
       - name: Prepare environment for integration tests
-        run: composer prepare-ci
+        run: composer prepare-ci ${{ matrix.wordpress }}
 
       - name: Run integration tests (single site)
         if: ${{ matrix.php != 8.0 }}

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -69,6 +69,10 @@ jobs:
       - name: Start MySQL Service
         run: sudo systemctl start mysql.service
 
+      - name: Setting mysql_native_password for PHP <= 7.3
+        if: ${{ matrix.php <= 7.3 }}
+        run: mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'";
+
       - name: Prepare environment for integration tests
         run: composer prepare-ci ${{ matrix.wordpress }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3.0",
-		"yoast/phpunit-polyfills": "^0.2.0"
+		"yoast/phpunit-polyfills": "^0.2.0 || ^1"
 	},
 	"scripts": {
 		"cbf": [


### PR DESCRIPTION
Updates the `runs-on` value to an image version still available on GitHub CI.

It also updates some issues that are stopping some of the WP + PHP jobs from running.

Note that some jobs, like those using PHP 5.6 and PHP 7.0, still fail, but these will be redundant and removed when the minimum supported version of PHP is increased in a separate PR.