### PR TITLE
Add and apply Rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpunit": "^9",
 		"wp-coding-standards/wpcs": "^3",
-		"yoast/phpunit-polyfills": "^1"
+		"yoast/phpunit-polyfills": "^1",
+		"rector/rector": "^1.2"
 	},
 	"scripts": {
 		"cbf": [

--- a/functions.php
+++ b/functions.php
@@ -75,6 +75,7 @@ function z_get_loop_post_id_or_default( $post_id = 0 ) {
 			$post_id = $post->ID;
 		}
 	}
+
 	return $post_id;
 }
 

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,7 @@ function z_get_zoninator() {
 
 /**
  * Get a list of all zones
+ *
  * @return array List of all zones
  */
 function z_get_zones() {
@@ -68,9 +69,11 @@ function z_get_post_zones( $post_id = 0 ) {
 }
 
 function z_get_loop_post_id_or_default( $post_id = 0 ) {
-	if( ! $post_id ) {
+	if ( ! $post_id ) {
 		global $post;
-		if( $post && isset( $post->ID ) ) $post_id = $post->ID;
+		if ( $post && isset( $post->ID ) ) {
+			$post_id = $post->ID;
+		}
 	}
 	return $post_id;
 }

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -7,21 +7,21 @@
  * Class Zoninator_Api_Controller
  */
 class Zoninator_Api_Controller extends Zoninator_REST_Controller {
-	const ZONE_ITEM_URL_REGEX = '/zones/(?P<zone_id>[\d]+)';
-	const ZONE_ITEM_POSTS_URL_REGEX = '/zones/(?P<zone_id>[\d]+)/posts';
+	const ZONE_ITEM_URL_REGEX        = '/zones/(?P<zone_id>[\d]+)';
+	const ZONE_ITEM_POSTS_URL_REGEX  = '/zones/(?P<zone_id>[\d]+)/posts';
 	const ZONE_ITEM_POSTS_POST_REGEX = '/zones/(?P<zone_id>[\d]+)/posts/(?P<post_id>\d+)';
 
-	const INVALID_ZONE_ID = 'invalid-zone-id';
-	const INVALID_POST_ID = 'invalid-post-id';
-	const ZONE_ID_POST_ID_REQUIRED = 'zone-id-post-id-required';
+	const INVALID_ZONE_ID           = 'invalid-zone-id';
+	const INVALID_POST_ID           = 'invalid-post-id';
+	const ZONE_ID_POST_ID_REQUIRED  = 'zone-id-post-id-required';
 	const ZONE_ID_POST_IDS_REQUIRED = 'zone-id-post-ids-required';
-	const ZONE_ID_REQUIRED = 'zone-id-required';
-	const ZONE_FEED_ERROR = 'zone-feed-error';
-	const TERM_REQUIRED = 'term-required';
-	const PERMISSION_DENIED = 'permission-denied';
-	const ZONE_NOT_FOUND = 'zone-not-found';
-	const POST_NOT_FOUND = 'post-not-found';
-	const INVALID_ZONE_SETTINGS = 'invalid-zone-settings';
+	const ZONE_ID_REQUIRED          = 'zone-id-required';
+	const ZONE_FEED_ERROR           = 'zone-feed-error';
+	const TERM_REQUIRED             = 'term-required';
+	const PERMISSION_DENIED         = 'permission-denied';
+	const ZONE_NOT_FOUND            = 'zone-not-found';
+	const POST_NOT_FOUND            = 'post-not-found';
+	const INVALID_ZONE_SETTINGS     = 'invalid-zone-settings';
 	/**
 	 * Instance
 	 *
@@ -43,7 +43,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 */
 	function __construct( $instance ) {
 		$this->instance = $instance;
-		$this->base = '/';
+		$this->base     = '/';
 	}
 
 	/**
@@ -109,9 +109,11 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		$results = $this->instance->get_zones();
 
 		if ( is_wp_error( $results ) ) {
-			return $this->bad_request( array(
-				'message' => $results->get_error_message(),
-			) );
+			return $this->bad_request(
+				array(
+					'message' => $results->get_error_message(),
+				) 
+			);
 		}
 
 		$zones = array_map( array( $this, '_filter_zone_properties' ), $results );
@@ -126,21 +128,27 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	function create_zone( $request ) {
-		$name = $this->_get_param( $request, 'name', '' );
-		$slug = $this->_get_param( $request, 'slug', $name );
+		$name        = $this->_get_param( $request, 'name', '' );
+		$slug        = $this->_get_param( $request, 'slug', $name );
 		$description = $this->_get_param( $request, 'description', '' );
 
-		$result = $this->instance->insert_zone( $slug, $name, array(
-			'description' => $description,
-		) );
+		$result = $this->instance->insert_zone(
+			$slug,
+			$name,
+			array(
+				'description' => $description,
+			) 
+		);
 
 		if ( is_wp_error( $result ) ) {
-			return $this->bad_request( array(
-				'message' => $result->get_error_message(),
-			) );
+			return $this->bad_request(
+				array(
+					'message' => $result->get_error_message(),
+				) 
+			);
 		}
 
-		$zone = $this->instance->get_zone( $result[ 'term_id' ] );
+		$zone = $this->instance->get_zone( $result['term_id'] );
 
 		return $this->created( $this->_filter_zone_properties( $zone ) );
 	}
@@ -152,12 +160,12 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	function update_zone( $request ) {
-		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
-		$name = $this->_get_param( $request, 'name', '' );
-		$slug = $this->_get_param( $request, 'slug', '' );
+		$zone_id     = $this->_get_param( $request, 'zone_id', 0, 'absint' );
+		$name        = $this->_get_param( $request, 'name', '' );
+		$slug        = $this->_get_param( $request, 'slug', '' );
 		$description = $this->_get_param( $request, 'description', '', 'strip_tags' );
 
-		$zone = $this->instance->get_zone( $zone_id );
+		$zone          = $this->instance->get_zone( $zone_id );
 		$update_params = array();
 
 		if ( ! $zone ) {
@@ -165,23 +173,25 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		}
 
 		if ( $name ) {
-			$update_params[ 'name' ] = $name;
+			$update_params['name'] = $name;
 		}
 
 		if ( $slug ) {
-			$update_params[ 'slug' ] = $slug;
+			$update_params['slug'] = $slug;
 		}
 
 		if ( $description ) {
-			$update_params[ 'details' ] = array( 'description' => $description );
+			$update_params['details'] = array( 'description' => $description );
 		}
 
 		$result = $this->instance->update_zone( $zone, $update_params );
 
 		if ( is_wp_error( $result ) ) {
-			return $this->bad_request( array(
-				'message' => $result->get_error_message(),
-			) );
+			return $this->bad_request(
+				array(
+					'message' => $result->get_error_message(),
+				) 
+			);
 		}
 
 		return $this->ok( array( 'success' => true ) );
@@ -205,9 +215,11 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		$result = $this->instance->delete_zone( $zone );
 
 		if ( is_wp_error( $result ) ) {
-			return $this->bad_request( array(
-				'message' => $result->get_error_message(),
-			) );
+			return $this->bad_request(
+				array(
+					'message' => $result->get_error_message(),
+				) 
+			);
 		}
 
 		return $this->ok( array( 'success' => true ) );
@@ -242,7 +254,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	function update_zone_posts( $request ) {
-		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
+		$zone_id  = $this->_get_param( $request, 'zone_id', 0, 'absint' );
 		$post_ids = $this->_get_param( $request, 'post_ids', array() );
 
 		if ( ! $this->instance->get_zone( $zone_id ) ) {
@@ -252,9 +264,11 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		$posts = array_map( 'get_post', $post_ids );
 
 		if ( count( $posts ) !== count( array_filter( $posts ) ) ) {
-			return $this->bad_request( array(
-				'message' => $this->translations[ self::INVALID_POST_ID ],
-			) );
+			return $this->bad_request(
+				array(
+					'message' => $this->translations[ self::INVALID_POST_ID ],
+				) 
+			);
 		}
 
 		$result = $this->instance->add_zone_posts( $zone_id, $posts );
@@ -275,7 +289,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	function zone_update_lock( $request ) {
 		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
 		if ( ! $zone_id ) {
-			return $this->_bad_request(self::ZONE_ID_REQUIRED, __('zone id required', 'zoninator'));
+			return $this->_bad_request( self::ZONE_ID_REQUIRED, __( 'zone id required', 'zoninator' ) );
 		}
 
 		$zone = $this->instance->get_zone( $zone_id );
@@ -286,18 +300,24 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		$zone_locked = $this->instance->is_zone_locked( $zone );
 		if ( $zone_locked ) {
 			$locking_user = get_userdata( $zone_locked );
-			return new WP_REST_Response( array(
-				'zone_id' => $this->instance->get_zone_id( $zone ),
-				'blocked' => true,
-			), 400);
+			return new WP_REST_Response(
+				array(
+					'zone_id' => $this->instance->get_zone_id( $zone ),
+					'blocked' => true,
+				),
+				400
+			);
 		}
 
 		$this->instance->lock_zone( $zone_id );
-		return new WP_REST_Response( array(
-			'zone_id' => $this->instance->get_zone_id( $zone ),
-			'timeout' => $this->instance->zone_lock_period,
-			'max_lock_period' => $this->instance->zone_max_lock_period,
-		), 200 );
+		return new WP_REST_Response(
+			array(
+				'zone_id'         => $this->instance->get_zone_id( $zone ),
+				'timeout'         => $this->instance->zone_lock_period,
+				'max_lock_period' => $this->instance->zone_max_lock_period,
+			),
+			200 
+		);
 	}
 
 	/**
@@ -347,7 +367,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	}
 
 	public function is_numeric_array( $items ) {
-		return count( $items ) === count( array_filter( $items, 'is_numeric') );
+		return count( $items ) === count( array_filter( $items, 'is_numeric' ) );
 	}
 
 	public function sanitize_string( $item ) {
@@ -357,8 +377,8 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	/**
 	 * @param WP_REST_Request $object
 	 * @param $var
-	 * @param string $default
-	 * @param string $sanitize_callback
+	 * @param string          $default
+	 * @param string          $sanitize_callback
 	 * @return array|mixed|null|string
 	 */
 	private function _get_param( $object, $var, $default = '', $sanitize_callback = '' ) {
@@ -374,44 +394,44 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 
 	public function _params_for_create_zone() {
 		return array(
-			'name' => array(
-				'type' => 'string',
+			'name'        => array(
+				'type'              => 'string',
 				'sanitize_callback' => array( $this, 'sanitize_string' ),
-				'default' => '',
-				'required' => false
+				'default'           => '',
+				'required'          => false,
 			),
-			'slug' => array(
-				'type' => 'string',
+			'slug'        => array(
+				'type'              => 'string',
 				'sanitize_callback' => array( $this, 'sanitize_string' ),
-				'default' => '',
-				'required' => false,
+				'default'           => '',
+				'required'          => false,
 			),
 			'description' => array(
-				'type' => 'string',
+				'type'              => 'string',
 				'sanitize_callback' => array( $this, 'sanitize_string' ),
-				'default' => '',
-				'required' => false,
-			)
+				'default'           => '',
+				'required'          => false,
+			),
 		);
 	}
 
 	public function _params_for_update_zone() {
 		return array(
-			'name' => array(
-				'type' => 'string',
+			'name'        => array(
+				'type'              => 'string',
 				'sanitize_callback' => array( $this, 'sanitize_string' ),
-				'required' => false
+				'required'          => false,
 			),
-			'slug' => array(
-				'type' => 'string',
+			'slug'        => array(
+				'type'              => 'string',
 				'sanitize_callback' => array( $this, 'sanitize_string' ),
-				'required' => false,
+				'required'          => false,
 			),
 			'description' => array(
-				'type' => 'string',
+				'type'              => 'string',
 				'sanitize_callback' => array( $this, 'sanitize_string' ),
-				'required' => false,
-			)
+				'required'          => false,
+			),
 		);
 	}
 
@@ -421,35 +441,38 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 				'type'              => 'integer',
 				'validate_callback' => array( $this, 'is_numeric' ),
 				'sanitize_callback' => 'absint',
-				'required'          => true
-			)
+				'required'          => true,
+			),
 		);
 	}
 
 	public function _get_zone_post_rest_route_params() {
 		$zone_params = $this->_get_zone_id_param();
-		return array_merge( array(
-			'post_ids' => array(
-				'type'              => 'array',
-				'validate_callback' => array( $this, 'is_numeric_array' ),
-				'required'          => true,
-				'items'				=> array( 'type' => 'integer' ),
+		return array_merge(
+			array(
+				'post_ids' => array(
+					'type'              => 'array',
+					'validate_callback' => array( $this, 'is_numeric_array' ),
+					'required'          => true,
+					'items'             => array( 'type' => 'integer' ),
+				),
 			),
-		), $zone_params );
+			$zone_params 
+		);
 	}
 
 	public function _filter_zone_properties( $zone ) {
 		$data = $zone->to_array();
 
 		return array(
-			'term_id'		=> $data[ 'term_id' ],
-			'slug'			=> $data[ 'slug' ],
-			'name'			=> $data[ 'name' ],
-			'description'	=> $data[ 'description' ],
+			'term_id'     => $data['term_id'],
+			'slug'        => $data['slug'],
+			'name'        => $data['name'],
+			'description' => $data['description'],
 		);
 	}
 
-	private function _bad_request($code, $message) {
+	private function _bad_request( $code, $message ) {
 		return new WP_Error( $code, $message, array( 'status' => 400 ) );
 	}
 
@@ -457,9 +480,9 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @param $zone_id
 	 * @return bool|WP_Error
 	 */
-	private function _permissions_check($action, $zone_id = null ) {
+	private function _permissions_check( $action, $zone_id = null ) {
 		if ( ! $this->instance->check( $action, $zone_id ) ) {
-			return new WP_Error( self::PERMISSION_DENIED, __('Sorry, you\'re not supposed to do that...', 'zoninator' ) );
+			return new WP_Error( self::PERMISSION_DENIED, __( 'Sorry, you\'re not supposed to do that...', 'zoninator' ) );
 		}
 		return true;
 	}

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -7,27 +7,41 @@
  * Class Zoninator_Api_Controller
  */
 class Zoninator_Api_Controller extends Zoninator_REST_Controller {
-	public const ZONE_ITEM_URL_REGEX        = '/zones/(?P<zone_id>[\d]+)';
-	public const ZONE_ITEM_POSTS_URL_REGEX  = '/zones/(?P<zone_id>[\d]+)/posts';
+	public const ZONE_ITEM_URL_REGEX = '/zones/(?P<zone_id>[\d]+)';
+
+	public const ZONE_ITEM_POSTS_URL_REGEX = '/zones/(?P<zone_id>[\d]+)/posts';
+
 	public const ZONE_ITEM_POSTS_POST_REGEX = '/zones/(?P<zone_id>[\d]+)/posts/(?P<post_id>\d+)';
 
-	public const INVALID_ZONE_ID           = 'invalid-zone-id';
-	public const INVALID_POST_ID           = 'invalid-post-id';
-	public const ZONE_ID_POST_ID_REQUIRED  = 'zone-id-post-id-required';
+	public const INVALID_ZONE_ID = 'invalid-zone-id';
+
+	public const INVALID_POST_ID = 'invalid-post-id';
+
+	public const ZONE_ID_POST_ID_REQUIRED = 'zone-id-post-id-required';
+
 	public const ZONE_ID_POST_IDS_REQUIRED = 'zone-id-post-ids-required';
-	public const ZONE_ID_REQUIRED          = 'zone-id-required';
-	public const ZONE_FEED_ERROR           = 'zone-feed-error';
-	public const TERM_REQUIRED             = 'term-required';
-	public const PERMISSION_DENIED         = 'permission-denied';
-	public const ZONE_NOT_FOUND            = 'zone-not-found';
-	public const POST_NOT_FOUND            = 'post-not-found';
-	public const INVALID_ZONE_SETTINGS     = 'invalid-zone-settings';
+
+	public const ZONE_ID_REQUIRED = 'zone-id-required';
+
+	public const ZONE_FEED_ERROR = 'zone-feed-error';
+
+	public const TERM_REQUIRED = 'term-required';
+
+	public const PERMISSION_DENIED = 'permission-denied';
+
+	public const ZONE_NOT_FOUND = 'zone-not-found';
+
+	public const POST_NOT_FOUND = 'post-not-found';
+
+	public const INVALID_ZONE_SETTINGS = 'invalid-zone-settings';
+
 	/**
 	 * Instance
 	 *
 	 * @var Zoninator
 	 */
 	private $instance;
+
 	/**
 	 * Key Value Translation array
 	 *
@@ -484,6 +498,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		if ( ! $this->instance->check( $action, $zone_id ) ) {
 			return new WP_Error( self::PERMISSION_DENIED, __( "Sorry, you're not supposed to do that...", 'zoninator' ) );
 		}
+
 		return true;
 	}
 }

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -41,7 +41,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @param string    $base Base.
 	 * @param Zoninator $instance Instance.
 	 */
-	function __construct( $instance ) {
+	public function __construct( $instance ) {
 		$this->instance = $instance;
 		$this->base     = '/';
 	}
@@ -49,7 +49,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	/**
 	 * Set up this controller
 	 */
-	function setup() {
+	public function setup() {
 		$this->translations = array(
 			self::ZONE_NOT_FOUND           => __( 'Zone not found', 'zoninator' ),
 			self::INVALID_POST_ID          => __( 'Invalid post id', 'zoninator' ),
@@ -105,7 +105,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	function get_zones( $request ) {
+	public function get_zones( $request ) {
 		$results = $this->instance->get_zones();
 
 		if ( is_wp_error( $results ) ) {
@@ -127,7 +127,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	function create_zone( $request ) {
+	public function create_zone( $request ) {
 		$name        = $this->_get_param( $request, 'name', '' );
 		$slug        = $this->_get_param( $request, 'slug', $name );
 		$description = $this->_get_param( $request, 'description', '' );
@@ -159,7 +159,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	function update_zone( $request ) {
+	public function update_zone( $request ) {
 		$zone_id     = $this->_get_param( $request, 'zone_id', 0, 'absint' );
 		$name        = $this->_get_param( $request, 'name', '' );
 		$slug        = $this->_get_param( $request, 'slug', '' );
@@ -203,7 +203,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	function delete_zone( $request ) {
+	public function delete_zone( $request ) {
 		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
 
 		$zone = $this->instance->get_zone( $zone_id );
@@ -253,7 +253,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.]
 	 * @return WP_Error|WP_REST_Response
 	 */
-	function update_zone_posts( $request ) {
+	public function update_zone_posts( $request ) {
 		$zone_id  = $this->_get_param( $request, 'zone_id', 0, 'absint' );
 		$post_ids = $this->_get_param( $request, 'post_ids', array() );
 
@@ -286,7 +286,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	function zone_update_lock( $request ) {
+	public function zone_update_lock( $request ) {
 		$zone_id = $this->_get_param( $request, 'zone_id', 0, 'absint' );
 		if ( ! $zone_id ) {
 			return $this->_bad_request( self::ZONE_ID_REQUIRED, __( 'zone id required', 'zoninator' ) );

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -7,21 +7,21 @@
  * Class Zoninator_Api_Controller
  */
 class Zoninator_Api_Controller extends Zoninator_REST_Controller {
-	const ZONE_ITEM_URL_REGEX        = '/zones/(?P<zone_id>[\d]+)';
-	const ZONE_ITEM_POSTS_URL_REGEX  = '/zones/(?P<zone_id>[\d]+)/posts';
-	const ZONE_ITEM_POSTS_POST_REGEX = '/zones/(?P<zone_id>[\d]+)/posts/(?P<post_id>\d+)';
+	public const ZONE_ITEM_URL_REGEX        = '/zones/(?P<zone_id>[\d]+)';
+	public const ZONE_ITEM_POSTS_URL_REGEX  = '/zones/(?P<zone_id>[\d]+)/posts';
+	public const ZONE_ITEM_POSTS_POST_REGEX = '/zones/(?P<zone_id>[\d]+)/posts/(?P<post_id>\d+)';
 
-	const INVALID_ZONE_ID           = 'invalid-zone-id';
-	const INVALID_POST_ID           = 'invalid-post-id';
-	const ZONE_ID_POST_ID_REQUIRED  = 'zone-id-post-id-required';
-	const ZONE_ID_POST_IDS_REQUIRED = 'zone-id-post-ids-required';
-	const ZONE_ID_REQUIRED          = 'zone-id-required';
-	const ZONE_FEED_ERROR           = 'zone-feed-error';
-	const TERM_REQUIRED             = 'term-required';
-	const PERMISSION_DENIED         = 'permission-denied';
-	const ZONE_NOT_FOUND            = 'zone-not-found';
-	const POST_NOT_FOUND            = 'post-not-found';
-	const INVALID_ZONE_SETTINGS     = 'invalid-zone-settings';
+	public const INVALID_ZONE_ID           = 'invalid-zone-id';
+	public const INVALID_POST_ID           = 'invalid-post-id';
+	public const ZONE_ID_POST_ID_REQUIRED  = 'zone-id-post-id-required';
+	public const ZONE_ID_POST_IDS_REQUIRED = 'zone-id-post-ids-required';
+	public const ZONE_ID_REQUIRED          = 'zone-id-required';
+	public const ZONE_FEED_ERROR           = 'zone-feed-error';
+	public const TERM_REQUIRED             = 'term-required';
+	public const PERMISSION_DENIED         = 'permission-denied';
+	public const ZONE_NOT_FOUND            = 'zone-not-found';
+	public const POST_NOT_FOUND            = 'post-not-found';
+	public const INVALID_ZONE_SETTINGS     = 'invalid-zone-settings';
 	/**
 	 * Instance
 	 *

--- a/includes/class-zoninator-api-controller.php
+++ b/includes/class-zoninator-api-controller.php
@@ -482,7 +482,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	 */
 	private function _permissions_check( $action, $zone_id = null ) {
 		if ( ! $this->instance->check( $action, $zone_id ) ) {
-			return new WP_Error( self::PERMISSION_DENIED, __( 'Sorry, you\'re not supposed to do that...', 'zoninator' ) );
+			return new WP_Error( self::PERMISSION_DENIED, __( "Sorry, you're not supposed to do that...", 'zoninator' ) );
 		}
 		return true;
 	}

--- a/includes/class-zoninator-api-filter-search.php
+++ b/includes/class-zoninator-api-filter-search.php
@@ -71,7 +71,7 @@ class Zoninator_Api_Filter_Search extends Zoninator_REST_Model {
 		return strip_tags( $item );
 	}
 
-	function date_before_set( $model, $item ) {
+	public function date_before_set( $model, $item ) {
 		return $this->strip_tags( $this->strip_slashes( $item ) );
 	}
 }

--- a/includes/class-zoninator-api-filter-search.php
+++ b/includes/class-zoninator-api-filter-search.php
@@ -75,4 +75,3 @@ class Zoninator_Api_Filter_Search extends Zoninator_REST_Model {
 		return $this->strip_tags( $this->strip_slashes( $item ) );
 	}
 }
-

--- a/includes/class-zoninator-api-schema-converter.php
+++ b/includes/class-zoninator-api-schema-converter.php
@@ -29,7 +29,7 @@ class Zoninator_Api_Schema_Converter {
 			'properties' => (array) apply_filters( 'rest_api_schema_properties', $properties, $model_definition ),
 		);
 
-		if ( ! empty( $required ) ) {
+		if ( $required !== array() ) {
 			$schema['required'] = $required;
 		}
 

--- a/includes/class-zoninator-api-schema-converter.php
+++ b/includes/class-zoninator-api-schema-converter.php
@@ -8,9 +8,9 @@ class Zoninator_Api_Schema_Converter {
 	 * @return mixed
 	 */
 	public function as_schema( $model_definition ) {
-		$fields = $model_definition->get_fields();
+		$fields     = $model_definition->get_fields();
 		$properties = array();
-		$required = array();
+		$required   = array();
 		foreach ( $fields as $field_declaration ) {
 			/**
 			 * Our declaration
@@ -23,9 +23,9 @@ class Zoninator_Api_Schema_Converter {
 			}
 		}
 		$schema = array(
-			'$schema' => 'http://json-schema.org/schema#',
-			'title' => $model_definition->get_name(),
-			'type' => 'object',
+			'$schema'    => 'http://json-schema.org/schema#',
+			'title'      => $model_definition->get_name(),
+			'type'       => 'object',
 			'properties' => (array) apply_filters( 'rest_api_schema_properties', $properties, $model_definition ),
 		);
 
@@ -53,9 +53,9 @@ class Zoninator_Api_Schema_Converter {
 			 * @var Zoninator_REST_Field_Declaration $field_declaration
 			 */
 			$arg = array(
-				'description'       => $field_declaration->get_description(),
-				'type'              => $type_schema['type'],
-				'required'          => $field_declaration->is_required(),
+				'description' => $field_declaration->get_description(),
+				'type'        => $type_schema['type'],
+				'required'    => $field_declaration->is_required(),
 			);
 
 			if ( ! $field_declaration->is_required() ) {

--- a/includes/class-zoninator-api-schema-converter.php
+++ b/includes/class-zoninator-api-schema-converter.php
@@ -22,6 +22,7 @@ class Zoninator_Api_Schema_Converter {
 				$required[] = $field_declaration->get_data_transfer_name();
 			}
 		}
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/schema#',
 			'title'      => $model_definition->get_name(),
@@ -64,6 +65,7 @@ class Zoninator_Api_Schema_Converter {
 
 			$result[ $field_declaration->get_data_transfer_name() ] = $arg;
 		}
+
 		return $result;
 	}
 }

--- a/includes/class-zoninator-api.php
+++ b/includes/class-zoninator-api.php
@@ -27,7 +27,7 @@ class Zoninator_Api {
 	/**
 	 * Rest Api.
 	 */
-	function rest_api() {
+	public function rest_api() {
 		include_once ZONINATOR_PATH . '/lib/zoninator_rest/class-zoninator-rest-bootstrap.php';
 		$this->bootstrap = Zoninator_REST_Bootstrap::create()->load();
 		include_once __DIR__ . '/class-zoninator-api-schema-converter.php';

--- a/includes/class-zoninator-api.php
+++ b/includes/class-zoninator-api.php
@@ -30,9 +30,9 @@ class Zoninator_Api {
 	function rest_api() {
 		include_once ZONINATOR_PATH . '/lib/zoninator_rest/class-zoninator-rest-bootstrap.php';
 		$this->bootstrap = Zoninator_REST_Bootstrap::create()->load();
-		include_once 'class-zoninator-api-schema-converter.php';
-		include_once 'class-zoninator-api-filter-search.php';
-		include_once 'class-zoninator-api-controller.php';
+		include_once __DIR__ . '/class-zoninator-api-schema-converter.php';
+		include_once __DIR__ . '/class-zoninator-api-filter-search.php';
+		include_once __DIR__ . '/class-zoninator-api-controller.php';
 		$env = $this->bootstrap->environment();
 
 		$env->define_model( 'Zoninator_Api_Filter_Search' );

--- a/includes/class-zoninator-api.php
+++ b/includes/class-zoninator-api.php
@@ -7,6 +7,7 @@ class Zoninator_Api {
 	 * @var Zoninator
 	 */
 	private $instance;
+
 	/**
 	 * Bootstrap
 	 *

--- a/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
+++ b/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
@@ -58,7 +58,7 @@ class Zoninator_REST_Bootstrap {
 	 * @return string
 	 */
 	public static function get_base_dir() {
-		return untrailingslashit( dirname( __FILE__ ) );
+		return untrailingslashit( __DIR__ );
 	}
 
 	/**
@@ -69,10 +69,10 @@ class Zoninator_REST_Bootstrap {
 	 */
 	public static function create( $class_loader = null ) {
 		if ( empty( $class_loader ) ) {
-			include_once( 'interfaces/class-zoninator-rest-interfaces-classloader.php' );
-			include_once( 'class-zoninator-rest-classloader.php' );
-			$prefix = str_replace( '_Bootstrap', '', __CLASS__ );
-			$base_dir = self::get_base_dir();
+			include_once 'interfaces/class-zoninator-rest-interfaces-classloader.php';
+			include_once 'class-zoninator-rest-classloader.php';
+			$prefix       = str_replace( '_Bootstrap', '', __CLASS__ );
+			$base_dir     = self::get_base_dir();
 			$class_loader = new Zoninator_REST_Classloader( $prefix, $base_dir );
 		}
 		return new self( $class_loader );

--- a/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
+++ b/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
@@ -71,7 +71,7 @@ class Zoninator_REST_Bootstrap {
 		if ( empty( $class_loader ) ) {
 			include_once 'interfaces/class-zoninator-rest-interfaces-classloader.php';
 			include_once 'class-zoninator-rest-classloader.php';
-			$prefix       = str_replace( '_Bootstrap', '', __CLASS__ );
+			$prefix       = str_replace( '_Bootstrap', '', self::class );
 			$base_dir     = self::get_base_dir();
 			$class_loader = new Zoninator_REST_Classloader( $prefix, $base_dir );
 		}

--- a/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
+++ b/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
@@ -25,14 +25,14 @@ class Zoninator_REST_Bootstrap {
 	 *
 	 * @var null|object the Environment implementation.
 	 */
-	private $environment = null;
+	private $environment;
 
 	/**
 	 * The class loader we will use
 	 *
 	 * @var null|Zoninator_REST_Classloader
 	 */
-	private $class_loader = null;
+	private $class_loader;
 
 	/**
 	 * Construct a new Bootstrap

--- a/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
+++ b/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
@@ -69,8 +69,8 @@ class Zoninator_REST_Bootstrap {
 	 */
 	public static function create( $class_loader = null ) {
 		if ( empty( $class_loader ) ) {
-			include_once 'interfaces/class-zoninator-rest-interfaces-classloader.php';
-			include_once 'class-zoninator-rest-classloader.php';
+			include_once __DIR__ . '/interfaces/class-zoninator-rest-interfaces-classloader.php';
+			include_once __DIR__ . '/class-zoninator-rest-classloader.php';
 			$prefix       = str_replace( '_Bootstrap', '', self::class );
 			$base_dir     = self::get_base_dir();
 			$class_loader = new Zoninator_REST_Classloader( $prefix, $base_dir );

--- a/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
+++ b/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
@@ -98,7 +98,7 @@ class Zoninator_REST_Bootstrap {
 	 *
 	 * @return Zoninator_REST_Bootstrap $this
 	 */
-	function register_autoload() {
+	public function register_autoload() {
 		if ( function_exists( 'spl_autoload_register' ) ) {
 			spl_autoload_register( array( $this->class_loader(), 'load_class' ), true );
 		}
@@ -111,7 +111,7 @@ class Zoninator_REST_Bootstrap {
 	 * @return Zoninator_REST_Bootstrap $this
 	 * @throws Exception In case a class/file is not found.
 	 */
-	function load() {
+	public function load() {
 		$this->class_loader()
 			->load_class( 'Interfaces_Data_Store' )
 			->load_class( 'Interfaces_Registrable' )
@@ -162,7 +162,7 @@ class Zoninator_REST_Bootstrap {
 	 *
 	 * @return Zoninator_REST_Bootstrap $this
 	 */
-	function load_testing_classes() {
+	public function load_testing_classes() {
 		$this->class_loader()
 			->load_class( 'Testing_TestCase' )
 			->load_class( 'Testing_Model_TestCase' )
@@ -175,7 +175,7 @@ class Zoninator_REST_Bootstrap {
 	 *
 	 * @return Zoninator_REST_Classloader
 	 */
-	function class_loader() {
+	public function class_loader() {
 		return $this->class_loader;
 	}
 

--- a/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
+++ b/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This is the entry point for.
  */
 class Zoninator_REST_Bootstrap {
-	const MINIMUM_PHP_VERSION = '5.2.0';
+	public const MINIMUM_PHP_VERSION = '5.2.0';
 
 	/**
 	 * The Environment we will use

--- a/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
+++ b/lib/zoninator_rest/class-zoninator-rest-bootstrap.php
@@ -75,6 +75,7 @@ class Zoninator_REST_Bootstrap {
 			$base_dir     = self::get_base_dir();
 			$class_loader = new Zoninator_REST_Classloader( $prefix, $base_dir );
 		}
+
 		return new self( $class_loader );
 	}
 
@@ -87,6 +88,7 @@ class Zoninator_REST_Bootstrap {
 		if ( ! self::is_compatible() ) {
 			return false;
 		}
+
 		$this->load()
 			->environment()->start();
 		return true;
@@ -102,6 +104,7 @@ class Zoninator_REST_Bootstrap {
 		if ( function_exists( 'spl_autoload_register' ) ) {
 			spl_autoload_register( array( $this->class_loader(), 'load_class' ), true );
 		}
+
 		return $this;
 	}
 
@@ -188,6 +191,7 @@ class Zoninator_REST_Bootstrap {
 		if ( null === $this->environment ) {
 			$this->environment = new Zoninator_REST_Environment( $this );
 		}
+
 		return $this->environment;
 	}
 }

--- a/lib/zoninator_rest/class-zoninator-rest-classloader.php
+++ b/lib/zoninator_rest/class-zoninator-rest-classloader.php
@@ -105,6 +105,7 @@ class Zoninator_REST_Classloader implements Zoninator_REST_Interfaces_Classloade
 		if ( empty( $prefix ) ) {
 			$prefix = $this->prefix;
 		}
+
 		return $prefix . '_' . $this->strip_prefix( $class_name, $prefix );
 	}
 
@@ -120,6 +121,7 @@ class Zoninator_REST_Classloader implements Zoninator_REST_Interfaces_Classloade
 		if ( empty( $prefix ) ) {
 			$prefix = $this->prefix;
 		}
+
 		return str_replace( $prefix, '', $class_name );
 	}
 
@@ -135,9 +137,11 @@ class Zoninator_REST_Classloader implements Zoninator_REST_Interfaces_Classloade
 		if ( isset( $this->loaded_classes[ $path_to_the_class ] ) ) {
 			return $this;
 		}
+
 		if ( ! file_exists( $path_to_the_class ) ) {
 			throw new Exception( $path_to_the_class . ' not found' );
 		}
+
 		$included                                   = include_once $path_to_the_class;
 		$this->loaded_classes[ $path_to_the_class ] = $included;
 

--- a/lib/zoninator_rest/class-zoninator-rest-classloader.php
+++ b/lib/zoninator_rest/class-zoninator-rest-classloader.php
@@ -43,9 +43,9 @@ class Zoninator_REST_Classloader implements Zoninator_REST_Interfaces_Classloade
 	 * @throws Exception Throws if an invalid directory is provided.
 	 */
 	public function __construct( $prefix, $base_dir ) {
-		$this->loaded_classes  = array();
-		$this->prefix          = $prefix;
-		$this->base_dir        = $base_dir;
+		$this->loaded_classes = array();
+		$this->prefix         = $prefix;
+		$this->base_dir       = $base_dir;
 		if ( ! is_dir( $this->base_dir ) ) {
 			throw new Exception( 'base_dir does not exist: ' . $this->base_dir );
 		}
@@ -86,7 +86,7 @@ class Zoninator_REST_Classloader implements Zoninator_REST_Interfaces_Classloade
 	public function class_name_to_relative_path( $class_name, $prefix = null ) {
 		$lowercase = strtolower( $this->prefixed_class_name( $class_name, $prefix ) );
 		$file_name = 'class-' . str_replace( '_', '-', $lowercase ) . '.php';
-		$parts = explode( '_', strtolower( $this->strip_prefix( $class_name, $prefix ) ) );
+		$parts     = explode( '_', strtolower( $this->strip_prefix( $class_name, $prefix ) ) );
 		array_pop( $parts );
 		$parts[] = $file_name;
 		return implode( DIRECTORY_SEPARATOR, $parts );
@@ -137,7 +137,7 @@ class Zoninator_REST_Classloader implements Zoninator_REST_Interfaces_Classloade
 		if ( ! file_exists( $path_to_the_class ) ) {
 			throw new Exception( $path_to_the_class . ' not found' );
 		}
-		$included = include_once( $path_to_the_class );
+		$included                                   = include_once $path_to_the_class;
 		$this->loaded_classes[ $path_to_the_class ] = $included;
 
 		return $this;

--- a/lib/zoninator_rest/class-zoninator-rest-classloader.php
+++ b/lib/zoninator_rest/class-zoninator-rest-classloader.php
@@ -20,13 +20,15 @@ class Zoninator_REST_Classloader implements Zoninator_REST_Interfaces_Classloade
 	 *
 	 * @var array The loaded class map.
 	 */
-	private $loaded_classes;
+	private $loaded_classes = array();
+
 	/**
 	 * The prefix to use (e.g. Mixtape)
 	 *
 	 * @var string
 	 */
 	private $prefix;
+
 	/**
 	 * The directory the loader looks for classes.
 	 *
@@ -43,9 +45,8 @@ class Zoninator_REST_Classloader implements Zoninator_REST_Interfaces_Classloade
 	 * @throws Exception Throws if an invalid directory is provided.
 	 */
 	public function __construct( $prefix, $base_dir ) {
-		$this->loaded_classes = array();
-		$this->prefix         = $prefix;
-		$this->base_dir       = $base_dir;
+		$this->prefix   = $prefix;
+		$this->base_dir = $base_dir;
 		if ( ! is_dir( $this->base_dir ) ) {
 			throw new Exception( 'base_dir does not exist: ' . $this->base_dir );
 		}

--- a/lib/zoninator_rest/class-zoninator-rest-controller.php
+++ b/lib/zoninator_rest/class-zoninator-rest-controller.php
@@ -30,7 +30,7 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 	 *
 	 * @var string
 	 */
-	protected $base = null;
+	protected $base;
 	/**
 	 * Our Handlers
 	 *
@@ -43,7 +43,7 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 	 *
 	 * @var null|Zoninator_REST_Environment
 	 */
-	protected $environment = null;
+	protected $environment;
 
 	/**
 	 * Zoninator_REST_Rest_Api_Controller constructor.

--- a/lib/zoninator_rest/class-zoninator-rest-controller.php
+++ b/lib/zoninator_rest/class-zoninator-rest-controller.php
@@ -252,7 +252,7 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 	 * @param string          $action One of (index, show, create, update, delete, any).
 	 * @return bool
 	 */
-	function permissions_check( $request, $action = 'any' ) {
+	public function permissions_check( $request, $action = 'any' ) {
 		return true;
 	}
 
@@ -262,7 +262,7 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 	 * @param string $pattern The route pattern (e.g. '/').
 	 * @return Zoninator_REST_Controller_Route
 	 */
-	function add_route( $pattern = '' ) {
+	public function add_route( $pattern = '' ) {
 		$route                    = new Zoninator_REST_Controller_Route( $this, $pattern );
 		$this->routes[ $pattern ] = $route;
 		return $this->routes[ $pattern ];
@@ -282,7 +282,7 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 	 *
 	 * @return string
 	 */
-	function get_base() {
+	public function get_base() {
 		return rest_url( $this->controller_bundle->get_prefix() . $this->base );
 	}
 }

--- a/lib/zoninator_rest/class-zoninator-rest-controller.php
+++ b/lib/zoninator_rest/class-zoninator-rest-controller.php
@@ -13,10 +13,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Zoninator_REST_Controller
  */
 class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_REST_Interfaces_Controller {
-	const HTTP_CREATED     = 201;
-	const HTTP_OK          = 200;
-	const HTTP_BAD_REQUEST = 400;
-	const HTTP_NOT_FOUND   = 404;
+	public const HTTP_CREATED     = 201;
+	public const HTTP_OK          = 200;
+	public const HTTP_BAD_REQUEST = 400;
+	public const HTTP_NOT_FOUND   = 404;
 
 	/**
 	 * The bundle this belongs to.

--- a/lib/zoninator_rest/class-zoninator-rest-controller.php
+++ b/lib/zoninator_rest/class-zoninator-rest-controller.php
@@ -13,10 +13,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Zoninator_REST_Controller
  */
 class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_REST_Interfaces_Controller {
-	public const HTTP_CREATED     = 201;
-	public const HTTP_OK          = 200;
+	public const HTTP_CREATED = 201;
+
+	public const HTTP_OK = 200;
+
 	public const HTTP_BAD_REQUEST = 400;
-	public const HTTP_NOT_FOUND   = 404;
+
+	public const HTTP_NOT_FOUND = 404;
 
 	/**
 	 * The bundle this belongs to.
@@ -31,6 +34,7 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 	 * @var string
 	 */
 	protected $base;
+
 	/**
 	 * Our Handlers
 	 *

--- a/lib/zoninator_rest/class-zoninator-rest-controller.php
+++ b/lib/zoninator_rest/class-zoninator-rest-controller.php
@@ -171,9 +171,12 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 	 * @return WP_REST_Response
 	 */
 	public function not_found( $message ) {
-		return $this->respond( array(
-			'message' => $message,
-		), self::HTTP_NOT_FOUND );
+		return $this->respond(
+			array(
+				'message' => $message,
+			),
+			self::HTTP_NOT_FOUND 
+		);
 	}
 
 	/**
@@ -260,7 +263,7 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 	 * @return Zoninator_REST_Controller_Route
 	 */
 	function add_route( $pattern = '' ) {
-		$route = new Zoninator_REST_Controller_Route( $this, $pattern );
+		$route                    = new Zoninator_REST_Controller_Route( $this, $pattern );
 		$this->routes[ $pattern ] = $route;
 		return $this->routes[ $pattern ];
 	}

--- a/lib/zoninator_rest/class-zoninator-rest-controller.php
+++ b/lib/zoninator_rest/class-zoninator-rest-controller.php
@@ -89,7 +89,7 @@ class Zoninator_REST_Controller extends WP_REST_Controller implements Zoninator_
 		$this->setup();
 		Zoninator_REST_Expect::that( ! empty( $this->base ), 'Need to put a string with a backslash in $base' );
 		$prefix = $this->controller_bundle->get_prefix();
-		foreach ( $this->routes as $pattern => $route ) {
+		foreach ( $this->routes as $route ) {
 			/**
 			 * The route we want to register.
 			 *

--- a/lib/zoninator_rest/class-zoninator-rest-environment.php
+++ b/lib/zoninator_rest/class-zoninator-rest-environment.php
@@ -32,14 +32,14 @@ class Zoninator_REST_Environment {
 	 *
 	 * @var array
 	 */
-	protected $rest_apis;
+	protected $rest_apis = array();
 
 	/**
 	 * This environment's model definitions
 	 *
 	 * @var array
 	 */
-	protected $model_definitions;
+	protected $model_definitions = array();
 
 	/**
 	 * The Environment Variables
@@ -48,14 +48,14 @@ class Zoninator_REST_Environment {
 	 *
 	 * @var array
 	 */
-	protected $variables;
+	protected $variables = array();
 
 	/**
 	 * Did this Environment start?
 	 *
 	 * @var bool
 	 */
-	private $has_started;
+	private $has_started = false;
 
 	/**
 	 * Our Bootstrap
@@ -78,10 +78,6 @@ class Zoninator_REST_Environment {
 	 */
 	public function __construct( $bootstrap ) {
 		$this->bootstrap         = $bootstrap;
-		$this->has_started       = false;
-		$this->rest_apis         = array();
-		$this->variables         = array();
-		$this->model_definitions = array();
 		$this->type_registry     = new Zoninator_REST_Type_Registry();
 		$this->type_registry->initialize( $this );
 		// initialize our array vars.

--- a/lib/zoninator_rest/class-zoninator-rest-environment.php
+++ b/lib/zoninator_rest/class-zoninator-rest-environment.php
@@ -20,8 +20,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Zoninator_REST_Environment {
 	const REGISTRABLE = 'IRegistrable';
-	const BUNDLES = 'Bundles';
-	const MODELS = 'Models';
+	const BUNDLES     = 'Bundles';
+	const MODELS      = 'Models';
 
 	/**
 	 * This environment's registered REST bundles
@@ -75,12 +75,12 @@ class Zoninator_REST_Environment {
 	 * @param Zoninator_REST_Bootstrap $bootstrap The bootstrap.
 	 */
 	public function __construct( $bootstrap ) {
-		$this->bootstrap = $bootstrap;
-		$this->has_started = false;
-		$this->rest_apis = array();
-		$this->variables = array();
+		$this->bootstrap         = $bootstrap;
+		$this->has_started       = false;
+		$this->rest_apis         = array();
+		$this->variables         = array();
 		$this->model_definitions = array();
-		$this->type_registry = new Zoninator_REST_Type_Registry();
+		$this->type_registry     = new Zoninator_REST_Type_Registry();
 		$this->type_registry->initialize( $this );
 		// initialize our array vars.
 		$this->array_var( self::MODELS )
@@ -93,7 +93,7 @@ class Zoninator_REST_Environment {
 	 *
 	 * All builders are evaluated lazily when needed
 	 *
-	 * @param string                $where The queue to push the builder to.
+	 * @param string                            $where The queue to push the builder to.
 	 * @param Zoninator_REST_Interfaces_Builder $builder The builder to push.
 	 *
 	 * @return Zoninator_REST_Environment $this
@@ -402,7 +402,7 @@ class Zoninator_REST_Environment {
 	 */
 	private function add_rest_bundle( $bundle ) {
 		Zoninator_REST_Expect::is_a( $bundle, 'Zoninator_REST_Interfaces_Controller_Bundle' );
-		$key = $bundle->get_prefix();
+		$key                     = $bundle->get_prefix();
 		$this->rest_apis[ $key ] = $bundle;
 		return $this;
 	}

--- a/lib/zoninator_rest/class-zoninator-rest-environment.php
+++ b/lib/zoninator_rest/class-zoninator-rest-environment.php
@@ -373,7 +373,7 @@ class Zoninator_REST_Environment {
 	 *
 	 * @return Zoninator_REST_Model
 	 */
-	function define_model( $declaration ) {
+	public function define_model( $declaration ) {
 		Zoninator_REST_Expect::that( class_exists( $declaration ), '$declaration string should be an existing class' );
 		Zoninator_REST_Expect::that( in_array( 'Zoninator_REST_Interfaces_Model', class_implements( $declaration ), true ), '$declaration does not implement Zoninator_REST_Interfaces_Model' );
 

--- a/lib/zoninator_rest/class-zoninator-rest-environment.php
+++ b/lib/zoninator_rest/class-zoninator-rest-environment.php
@@ -183,7 +183,7 @@ class Zoninator_REST_Environment {
 			 */
 			$rest_apis = (array) apply_filters( 'mt_environment_get_rest_apis', $this->rest_apis, $this );
 
-			foreach ( $rest_apis as $k => $bundle ) {
+			foreach ( $rest_apis as $bundle ) {
 				/**
 				 * Register this bundle
 				 *

--- a/lib/zoninator_rest/class-zoninator-rest-environment.php
+++ b/lib/zoninator_rest/class-zoninator-rest-environment.php
@@ -20,8 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Zoninator_REST_Environment {
 	public const REGISTRABLE = 'IRegistrable';
-	public const BUNDLES     = 'Bundles';
-	public const MODELS      = 'Models';
+
+	public const BUNDLES = 'Bundles';
+
+	public const MODELS = 'Models';
 
 	/**
 	 * This environment's registered REST bundles
@@ -116,6 +118,7 @@ class Zoninator_REST_Environment {
 		if ( ! class_exists( $class ) ) {
 			throw new Zoninator_REST_Exception( $class . ' does not exist' );
 		}
+
 		Zoninator_REST_Expect::that( isset( $this->model_definitions[ $class ] ), $class . ' definition does not exist' );
 		return $this->model_definitions[ $class ];
 	}
@@ -189,6 +192,7 @@ class Zoninator_REST_Environment {
 				 */
 				$bundle->register( $this );
 			}
+
 			$this->has_started = true;
 			do_action( 'mt_environment_after_start', $this );
 		}
@@ -269,6 +273,7 @@ class Zoninator_REST_Environment {
 		if ( $append && ! $this->has_variable( $name ) ) {
 			$this->variables[ $name ] = array();
 		}
+
 		if ( null !== $thing ) {
 			if ( $append ) {
 				$this->variables[ $name ][] = $thing;
@@ -276,6 +281,7 @@ class Zoninator_REST_Environment {
 				$this->variables[ $name ] = $thing;
 			}
 		}
+
 		return $this;
 	}
 
@@ -359,6 +365,7 @@ class Zoninator_REST_Environment {
 			if ( is_string( $maybe_bundle_or_prefix ) ) {
 				$builder->with_prefix( $maybe_bundle_or_prefix );
 			}
+
 			$builder->with_environment( $this );
 		}
 

--- a/lib/zoninator_rest/class-zoninator-rest-environment.php
+++ b/lib/zoninator_rest/class-zoninator-rest-environment.php
@@ -19,9 +19,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @package Mixtape
  */
 class Zoninator_REST_Environment {
-	const REGISTRABLE = 'IRegistrable';
-	const BUNDLES     = 'Bundles';
-	const MODELS      = 'Models';
+	public const REGISTRABLE = 'IRegistrable';
+	public const BUNDLES     = 'Bundles';
+	public const MODELS      = 'Models';
 
 	/**
 	 * This environment's registered REST bundles

--- a/lib/zoninator_rest/class-zoninator-rest-environment.php
+++ b/lib/zoninator_rest/class-zoninator-rest-environment.php
@@ -186,8 +186,6 @@ class Zoninator_REST_Environment {
 			foreach ( $rest_apis as $bundle ) {
 				/**
 				 * Register this bundle
-				 *
-				 * @var Zoninator_REST_Interfaces_Controller_Bundle
 				 */
 				$bundle->register( $this );
 			}

--- a/lib/zoninator_rest/class-zoninator-rest-environment.php
+++ b/lib/zoninator_rest/class-zoninator-rest-environment.php
@@ -165,7 +165,7 @@ class Zoninator_REST_Environment {
 			do_action( 'mt_environment_before_start', $this, get_class( $this ) );
 			$this->load_pending_builders( self::MODELS );
 			$this->load_pending_builders( self::BUNDLES );
-			$registrables = $this->get( self::REGISTRABLE ) ? $this->get( self::REGISTRABLE ) : array();
+			$registrables = $this->get( self::REGISTRABLE ) ?: array();
 			foreach ( $registrables as $registrable ) {
 				/**
 				 * A Registrable

--- a/lib/zoninator_rest/class-zoninator-rest-expect.php
+++ b/lib/zoninator_rest/class-zoninator-rest-expect.php
@@ -23,7 +23,7 @@ class Zoninator_REST_Expect {
 	 *
 	 * @throws Zoninator_REST_Exception Fail if we got an unexpected class.
 	 */
-	static function is_a( $thing, $class_name ) {
+	public static function is_a( $thing, $class_name ) {
 		self::is_object( $thing );
 		self::that( is_a( $thing, $class_name ), 'Expected ' . $class_name . ', got ' . get_class( $thing ) );
 	}
@@ -34,7 +34,7 @@ class Zoninator_REST_Expect {
 	 * @param mixed $thing The thing.
 	 * @throws Zoninator_REST_Exception Throw if not an object.
 	 */
-	static function is_object( $thing ) {
+	public static function is_object( $thing ) {
 		self::that( is_object( $thing ), 'Variable is is not an Object' );
 	}
 
@@ -46,7 +46,7 @@ class Zoninator_REST_Expect {
 	 *
 	 * @throws Zoninator_REST_Exception Fail if condition doesn't hold.
 	 */
-	static function that( $cond, $fail_message ) {
+	public static function that( $cond, $fail_message ) {
 		if ( ! $cond ) {
 			throw new Zoninator_REST_Exception( $fail_message );
 		}
@@ -59,7 +59,7 @@ class Zoninator_REST_Expect {
 	 *
 	 * @throws Zoninator_REST_Exception To Override this.
 	 */
-	static function should_override( $method ) {
+	public static function should_override( $method ) {
 		throw new Zoninator_REST_Exception( $method . ' should be overridden' );
 	}
 }

--- a/lib/zoninator_rest/class-zoninator-rest-model.php
+++ b/lib/zoninator_rest/class-zoninator-rest-model.php
@@ -49,7 +49,7 @@ class Zoninator_REST_Model implements
 	 *
 	 * @var array
 	 */
-	private $data;
+	private $data = array();
 
 	/**
 	 * Our raw data
@@ -68,7 +68,6 @@ class Zoninator_REST_Model implements
 	 */
 	public function __construct( $data = array(), $args = array() ) {
 		Zoninator_REST_Expect::that( is_array( $data ), '$data should be an array' );
-		$this->data = array();
 
 		if ( isset( $args['deserialize'] ) && true === $args['deserialize'] ) {
 			unset( $args['deserialize'] );

--- a/lib/zoninator_rest/class-zoninator-rest-model.php
+++ b/lib/zoninator_rest/class-zoninator-rest-model.php
@@ -66,7 +66,7 @@ class Zoninator_REST_Model implements
 	 *
 	 * @throws Zoninator_REST_Exception Throws when data is not an array.
 	 */
-	function __construct( $data = array(), $args = array() ) {
+	public function __construct( $data = array(), $args = array() ) {
 		Zoninator_REST_Expect::that( is_array( $data ), '$data should be an array' );
 		$this->data = array();
 
@@ -403,7 +403,7 @@ class Zoninator_REST_Model implements
 	 * @return Zoninator_REST_Interfaces_Model|WP_Error
 	 * @throws Zoninator_REST_Exception Throws.
 	 */
-	function update_from_array( $data, $updating = false ) {
+	public function update_from_array( $data, $updating = false ) {
 		$mapped_data = self::map_data( $data, $updating );
 		foreach ( $mapped_data as $name => $value ) {
 			$this->set( $name, $value );
@@ -449,7 +449,7 @@ class Zoninator_REST_Model implements
 	 *
 	 * @return array
 	 */
-	function to_dto() {
+	public function to_dto() {
 		$result = array();
 		foreach ( $this->get_dto_field_mappings() as $mapping_name => $field_name ) {
 			$value                   = $this->get( $field_name );
@@ -529,7 +529,7 @@ class Zoninator_REST_Model implements
 	 *
 	 * @return mixed|null
 	 */
-	function get_id() {
+	public function get_id() {
 		return $this->get( 'id' );
 	}
 
@@ -540,7 +540,7 @@ class Zoninator_REST_Model implements
 	 *
 	 * @return mixed|null
 	 */
-	function set_id( $new_id ) {
+	public function set_id( $new_id ) {
 		return $this->set( 'id', $new_id );
 	}
 
@@ -610,7 +610,7 @@ class Zoninator_REST_Model implements
 	 *
 	 * @return array
 	 */
-	function serialize( $field_type = null ) {
+	public function serialize( $field_type = null ) {
 		$field_values_to_insert = array();
 		foreach ( $this->get_fields( $field_type ) as $field_declaration ) {
 			/**

--- a/lib/zoninator_rest/class-zoninator-rest-model.php
+++ b/lib/zoninator_rest/class-zoninator-rest-model.php
@@ -75,7 +75,7 @@ class Zoninator_REST_Model implements
 			$data = $this->deserialize( $data );
 		}
 		$this->raw_data = $data;
-		$data_keys = array_keys( $data );
+		$data_keys      = array_keys( $data );
 
 		foreach ( $data_keys as $key ) {
 			$this->set( $key, $this->raw_data[ $key ] );
@@ -93,7 +93,7 @@ class Zoninator_REST_Model implements
 	 */
 	public function get( $field_name, $args = array() ) {
 		Zoninator_REST_Expect::that( $this->has( $field_name ), 'Field ' . $field_name . 'is not defined' );
-		$fields = $this->get_fields();
+		$fields            = $this->get_fields();
 		$field_declaration = $fields[ $field_name ];
 		$this->set_field_if_unset( $field_declaration );
 
@@ -148,7 +148,7 @@ class Zoninator_REST_Model implements
 	 */
 	public function validate() {
 		$validation_errors = array();
-		$fields = self::get_fields();
+		$fields            = self::get_fields();
 		foreach ( $fields as $key => $field_declaration ) {
 			$is_valid = $this->run_field_validations( $field_declaration );
 			if ( is_wp_error( $is_valid ) ) {
@@ -174,8 +174,8 @@ class Zoninator_REST_Model implements
 			 *
 			 * @var Zoninator_REST_Field_Declaration $field_declaration
 			 */
-			$field_name = $field_declaration->get_name();
-			$value = $this->get( $field_name );
+			$field_name          = $field_declaration->get_name();
+			$value               = $this->get( $field_name );
 			$custom_sanitization = $field_declaration->get_sanitizer();
 			if ( ! empty( $custom_sanitization ) ) {
 				$value = $this->call( $custom_sanitization, array( $this, $value ) );
@@ -217,11 +217,13 @@ class Zoninator_REST_Model implements
 			foreach ( $field_declaration->get_validations() as $validation ) {
 				$result = $this->call( $validation, array( $value ) );
 				if ( is_wp_error( $result ) ) {
-					$result->add_data(array(
-						'reason' => $result->get_error_messages(),
-						'field' => $field_declaration->get_data_transfer_name(),
-						'value' => $value,
-					) );
+					$result->add_data(
+						array(
+							'reason' => $result->get_error_messages(),
+							'field'  => $field_declaration->get_data_transfer_name(),
+							'value'  => $value,
+						) 
+					);
 					return $result;
 				}
 			}
@@ -236,8 +238,8 @@ class Zoninator_REST_Model implements
 	 * @return mixed
 	 */
 	private function prepare_value( $field_declaration ) {
-		$key = $field_declaration->get_name();
-		$value = $this->data[ $key ];
+		$key           = $field_declaration->get_name();
+		$value         = $this->data[ $key ];
 		$before_return = $field_declaration->before_get();
 		if ( isset( $before_return ) && ! empty( $before_return ) ) {
 			$value = $this->call( $before_return, array( $value, $key ) );
@@ -279,7 +281,7 @@ class Zoninator_REST_Model implements
 		 */
 		$instance = new $class_name();
 		if ( ! isset( self::$fields_by_class_name[ $class_name ] ) ) {
-			$fields = $instance->declare_fields();
+			$fields                                    = $instance->declare_fields();
 			self::$fields_by_class_name[ $class_name ] = self::initialize_field_map( $fields );
 		}
 
@@ -317,7 +319,7 @@ class Zoninator_REST_Model implements
 			 *
 			 * @var Zoninator_REST_Field_Declaration $field Field Builder.
 			 */
-			$field = $field_builder->build();
+			$field                        = $field_builder->build();
 			$fields[ $field->get_name() ] = $field;
 		}
 		return $fields;
@@ -373,7 +375,7 @@ class Zoninator_REST_Model implements
 	 */
 	public function with_environment( $environment ) {
 		Zoninator_REST_Expect::is_a( $environment, 'Zoninator_REST_Environment' );
-		$class_name = get_class( $this );
+		$class_name                                      = get_class( $this );
 		self::$environments_by_class_name[ $class_name ] = $environment;
 		return $this;
 	}
@@ -453,7 +455,7 @@ class Zoninator_REST_Model implements
 	function to_dto() {
 		$result = array();
 		foreach ( $this->get_dto_field_mappings() as $mapping_name => $field_name ) {
-			$value = $this->get( $field_name );
+			$value                   = $this->get( $field_name );
 			$result[ $mapping_name ] = $value;
 		}
 
@@ -469,7 +471,7 @@ class Zoninator_REST_Model implements
 	 */
 	private function map_data( $data, $updating = false ) {
 		$request_data = array();
-		$fields = $this->get_fields();
+		$fields       = $this->get_fields();
 		foreach ( $fields as $field ) {
 			/**
 			 * Field
@@ -479,10 +481,10 @@ class Zoninator_REST_Model implements
 			if ( $field->is_kind( Zoninator_REST_Field_Declaration::DERIVED ) ) {
 				continue;
 			}
-			$dto_name = $field->get_data_transfer_name();
+			$dto_name   = $field->get_data_transfer_name();
 			$field_name = $field->get_name();
 			if ( isset( $data[ $dto_name ] ) && ! ( $updating && $field->is_primary() ) ) {
-				$value = $data[ $dto_name ];
+				$value                       = $data[ $dto_name ];
 				$request_data[ $field_name ] = $value;
 			}
 		}
@@ -562,9 +564,12 @@ class Zoninator_REST_Model implements
 		}
 		$merged_data = array_merge( $raw_post_data, $flattened_meta );
 
-		return self::create( $merged_data, array(
-			'deserialize' => true,
-		) );
+		return self::create(
+			$merged_data,
+			array(
+				'deserialize' => true,
+			) 
+		);
 	}
 
 	/**
@@ -575,17 +580,17 @@ class Zoninator_REST_Model implements
 	 */
 	public function deserialize( $data ) {
 		$field_declarations = $this->get_fields();
-		$raw_data = array();
-		$post_array_keys = array_keys( $data );
+		$raw_data           = array();
+		$post_array_keys    = array_keys( $data );
 		foreach ( $field_declarations as $declaration ) {
 			/**
 			 * Declaration
 			 *
 			 * @var Zoninator_REST_Field_Declaration $declaration
 			 */
-			$key = $declaration->get_name();
+			$key     = $declaration->get_name();
 			$mapping = $declaration->get_map_from();
-			$value = null;
+			$value   = null;
 			if ( in_array( $key, $post_array_keys, true ) ) {
 				// simplest case: we got a $key for this, so just map it.
 				$value = $this->deserialize_field( $declaration, $data[ $key ] );
@@ -616,8 +621,8 @@ class Zoninator_REST_Model implements
 			 *
 			 * @var Zoninator_REST_Field_Declaration $field_declaration
 			 */
-			$what_to_map_to = $field_declaration->get_map_from();
-			$value = $this->get( $field_declaration->get_name() );
+			$what_to_map_to                            = $field_declaration->get_map_from();
+			$value                                     = $this->get( $field_declaration->get_name() );
 			$field_values_to_insert[ $what_to_map_to ] = $this->serialize_field( $field_declaration, $value );
 		}
 
@@ -628,7 +633,7 @@ class Zoninator_REST_Model implements
 	 * Deserialize
 	 *
 	 * @param Zoninator_REST_Field_Declaration $field_declaration Declaration.
-	 * @param mixed                $value Value.
+	 * @param mixed                            $value Value.
 	 * @return mixed the deserialized value
 	 */
 	private function deserialize_field( $field_declaration, $value ) {
@@ -643,7 +648,7 @@ class Zoninator_REST_Model implements
 	 * Serialize
 	 *
 	 * @param  Zoninator_REST_Field_Declaration $field_declaration Declaration.
-	 * @param mixed                $value Value.
+	 * @param mixed                            $value Value.
 	 * @return mixed
 	 * @throws Zoninator_REST_Exception If call fails.
 	 */

--- a/lib/zoninator_rest/class-zoninator-rest-model.php
+++ b/lib/zoninator_rest/class-zoninator-rest-model.php
@@ -282,7 +282,7 @@ class Zoninator_REST_Model implements
 		$instance = new $class_name();
 		if ( ! isset( self::$fields_by_class_name[ $class_name ] ) ) {
 			$fields                                    = $instance->declare_fields();
-			self::$fields_by_class_name[ $class_name ] = self::initialize_field_map( $fields );
+			self::$fields_by_class_name[ $class_name ] = $this->initialize_field_map( $fields );
 		}
 
 		if ( null === $filter_by_type ) {
@@ -311,7 +311,7 @@ class Zoninator_REST_Model implements
 	 *
 	 * @return array
 	 */
-	private static function initialize_field_map( $declared_field_builders ) {
+	private function initialize_field_map( $declared_field_builders ) {
 		$fields = array();
 		foreach ( $declared_field_builders as $field_builder ) {
 			/**

--- a/lib/zoninator_rest/class-zoninator-rest-model.php
+++ b/lib/zoninator_rest/class-zoninator-rest-model.php
@@ -149,7 +149,7 @@ class Zoninator_REST_Model implements
 	public function validate() {
 		$validation_errors = array();
 		$fields            = self::get_fields();
-		foreach ( $fields as $key => $field_declaration ) {
+		foreach ( $fields as $field_declaration ) {
 			$is_valid = $this->run_field_validations( $field_declaration );
 			if ( is_wp_error( $is_valid ) ) {
 				$validation_errors[] = $is_valid->get_error_data();
@@ -168,7 +168,7 @@ class Zoninator_REST_Model implements
 	 */
 	public function sanitize() {
 		$fields = self::get_fields();
-		foreach ( $fields as $key => $field_declaration ) {
+		foreach ( $fields as $field_declaration ) {
 			/**
 			 * Field Declaration.
 			 *

--- a/lib/zoninator_rest/class-zoninator-rest-model.php
+++ b/lib/zoninator_rest/class-zoninator-rest-model.php
@@ -74,6 +74,7 @@ class Zoninator_REST_Model implements
 			unset( $args['deserialize'] );
 			$data = $this->deserialize( $data );
 		}
+
 		$this->raw_data = $data;
 		$data_keys      = array_keys( $data );
 
@@ -121,11 +122,13 @@ class Zoninator_REST_Model implements
 		if ( isset( $args['deserializing'] ) && $args['deserializing'] ) {
 			$value = $this->deserialize_field( $field_declaration, $value );
 		}
+
 		if ( null !== $field_declaration->before_set() ) {
 			$val = $this->call( $field_declaration->before_set(), array( $value, $field_declaration->get_name() ) );
 		} else {
 			$val = $field_declaration->cast_value( $value );
 		}
+
 		$this->data[ $field_declaration->get_name() ] = $val;
 		return $this;
 	}
@@ -155,9 +158,11 @@ class Zoninator_REST_Model implements
 				$validation_errors[] = $is_valid->get_error_data();
 			}
 		}
+
 		if ( $validation_errors !== array() ) {
 			return $this->validation_error( $validation_errors );
 		}
+
 		return true;
 	}
 
@@ -182,8 +187,10 @@ class Zoninator_REST_Model implements
 			} else {
 				$value = $field_declaration->get_type()->sanitize( $value );
 			}
+
 			$this->set( $field_name, $value );
 		}
+
 		return $this;
 	}
 
@@ -208,6 +215,7 @@ class Zoninator_REST_Model implements
 		if ( $field_declaration->is_kind( Zoninator_REST_Field_Declaration::DERIVED ) ) {
 			return true;
 		}
+
 		$value = $this->get( $field_declaration->get_name() );
 		if ( $field_declaration->is_required() && empty( $value ) ) {
 			// translators: %s is usually a field name.
@@ -228,6 +236,7 @@ class Zoninator_REST_Model implements
 				}
 			}
 		}
+
 		return true;
 	}
 
@@ -301,6 +310,7 @@ class Zoninator_REST_Model implements
 				$filtered[] = $field_declaration;
 			}
 		}
+
 		return $filtered;
 	}
 
@@ -322,6 +332,7 @@ class Zoninator_REST_Model implements
 			$field                        = $field_builder->build();
 			$fields[ $field->get_name() ] = $field;
 		}
+
 		return $fields;
 	}
 
@@ -335,6 +346,7 @@ class Zoninator_REST_Model implements
 		if ( ! isset( self::$data_stores_by_class_name[ $class_name ] ) ) {
 			self::$data_stores_by_class_name[ $class_name ] = new Zoninator_REST_Data_Store_Nil();
 		}
+
 		return self::$data_stores_by_class_name[ $class_name ];
 	}
 
@@ -408,6 +420,7 @@ class Zoninator_REST_Model implements
 		foreach ( $mapped_data as $name => $value ) {
 			$this->set( $name, $value );
 		}
+
 		return $this->sanitize();
 	}
 
@@ -439,8 +452,10 @@ class Zoninator_REST_Model implements
 			if ( ! $field_declaration->supports_output_type( 'json' ) ) {
 				continue;
 			}
+
 			$mappings[ $field_declaration->get_data_transfer_name() ] = $field_declaration->get_name();
 		}
+
 		return $mappings;
 	}
 
@@ -478,6 +493,7 @@ class Zoninator_REST_Model implements
 			if ( $field->is_kind( Zoninator_REST_Field_Declaration::DERIVED ) ) {
 				continue;
 			}
+
 			$dto_name   = $field->get_data_transfer_name();
 			$field_name = $field->get_name();
 			if ( isset( $data[ $dto_name ] ) && ! ( $updating && $field->is_primary() ) ) {
@@ -485,6 +501,7 @@ class Zoninator_REST_Model implements
 				$request_data[ $field_name ] = $value;
 			}
 		}
+
 		return $request_data;
 	}
 
@@ -501,6 +518,7 @@ class Zoninator_REST_Model implements
 		if ( is_callable( $method ) ) {
 			return call_user_func_array( $method, $args );
 		}
+
 		Zoninator_REST_Expect::that( method_exists( $this, $method ), $method . ' does not exist' );
 		return call_user_func_array( array( $this, $method ), $args );
 	}
@@ -559,6 +577,7 @@ class Zoninator_REST_Model implements
 		foreach ( $raw_meta_data as $key => $value_arr ) {
 			$flattened_meta[ $key ] = $value_arr[0];
 		}
+
 		$merged_data = array_merge( $raw_post_data, $flattened_meta );
 
 		return self::create(
@@ -598,8 +617,10 @@ class Zoninator_REST_Model implements
 				// just provide a default.
 				$value = $declaration->get_default_value();
 			}
+
 			$raw_data[ $key ] = $declaration->cast_value( $value );
 		}
+
 		return $raw_data;
 	}
 
@@ -638,6 +659,7 @@ class Zoninator_REST_Model implements
 		if ( isset( $deserializer ) && ! empty( $deserializer ) ) {
 			return $this->call( $deserializer, array( $value ) );
 		}
+
 		return $value;
 	}
 
@@ -654,6 +676,7 @@ class Zoninator_REST_Model implements
 		if ( isset( $serializer ) && ! empty( $serializer ) ) {
 			return $this->call( $serializer, array( $value ) );
 		}
+
 		return $value;
 	}
 
@@ -670,6 +693,7 @@ class Zoninator_REST_Model implements
 			$permissions_provider = self::$permissions_providers_by_class_name[ $class_name ];
 			return call_user_func_array( array( $permissions_provider, 'permissions_check' ), array( $request, $action ) );
 		}
+
 		return true;
 	}
 

--- a/lib/zoninator_rest/class-zoninator-rest-model.php
+++ b/lib/zoninator_rest/class-zoninator-rest-model.php
@@ -155,7 +155,7 @@ class Zoninator_REST_Model implements
 				$validation_errors[] = $is_valid->get_error_data();
 			}
 		}
-		if ( count( $validation_errors ) > 0 ) {
+		if ( $validation_errors !== array() ) {
 			return $this->validation_error( $validation_errors );
 		}
 		return true;

--- a/lib/zoninator_rest/class-zoninator-rest-model.php
+++ b/lib/zoninator_rest/class-zoninator-rest-model.php
@@ -358,10 +358,7 @@ class Zoninator_REST_Model implements
 	 */
 	public function get_environment() {
 		$class_name = get_class( $this );
-		if ( isset( self::$environments_by_class_name[ $class_name ] ) ) {
-			return self::$environments_by_class_name[ $class_name ];
-		}
-		return null;
+		return self::$environments_by_class_name[ $class_name ] ?? null;
 	}
 
 	/**

--- a/lib/zoninator_rest/class-zoninator-rest-type.php
+++ b/lib/zoninator_rest/class-zoninator-rest-type.php
@@ -24,7 +24,7 @@ class Zoninator_REST_Type implements Zoninator_REST_Interfaces_Type {
 	 *
 	 * @param string $identifier The identifier.
 	 */
-	function __construct( $identifier ) {
+	public function __construct( $identifier ) {
 		$this->identifier = $identifier;
 	}
 
@@ -33,14 +33,14 @@ class Zoninator_REST_Type implements Zoninator_REST_Interfaces_Type {
 	 *
 	 * @return string
 	 */
-	function name() {
+	public function name() {
 		return $this->identifier;
 	}
 
 	/**
 	 * The default value
 	 */
-	function default_value() {
+	public function default_value() {
 		return null;
 	}
 
@@ -51,7 +51,7 @@ class Zoninator_REST_Type implements Zoninator_REST_Interfaces_Type {
 	 *
 	 * @return mixed
 	 */
-	function cast( $value ) {
+	public function cast( $value ) {
 		return $value;
 	}
 
@@ -62,7 +62,7 @@ class Zoninator_REST_Type implements Zoninator_REST_Interfaces_Type {
 	 *
 	 * @return mixed
 	 */
-	function sanitize( $value ) {
+	public function sanitize( $value ) {
 		return $value;
 	}
 
@@ -71,7 +71,7 @@ class Zoninator_REST_Type implements Zoninator_REST_Interfaces_Type {
 	 *
 	 * @return array
 	 */
-	function schema() {
+	public function schema() {
 		return array(
 			'type' => $this->name(),
 		);
@@ -82,7 +82,7 @@ class Zoninator_REST_Type implements Zoninator_REST_Interfaces_Type {
 	 *
 	 * @return Zoninator_REST_Type
 	 */
-	static function any() {
+	public static function any() {
 		return new self( 'any' );
 	}
 }

--- a/lib/zoninator_rest/class-zoninator-rest-type.php
+++ b/lib/zoninator_rest/class-zoninator-rest-type.php
@@ -39,8 +39,6 @@ class Zoninator_REST_Type implements Zoninator_REST_Interfaces_Type {
 
 	/**
 	 * The default value
-	 *
-	 * @return null
 	 */
 	function default_value() {
 		return null;

--- a/lib/zoninator_rest/class-zoninator-rest-type.php
+++ b/lib/zoninator_rest/class-zoninator-rest-type.php
@@ -19,6 +19,7 @@ class Zoninator_REST_Type implements Zoninator_REST_Interfaces_Type {
 	 * @var string
 	 */
 	protected $identifier;
+
 	/**
 	 * Mixtape_Type constructor.
 	 *

--- a/lib/zoninator_rest/controller/bundle/class-zoninator-rest-controller-bundle-builder.php
+++ b/lib/zoninator_rest/controller/bundle/class-zoninator-rest-controller-bundle-builder.php
@@ -21,12 +21,6 @@ class Zoninator_REST_Controller_Bundle_Builder implements Zoninator_REST_Interfa
 	 */
 	private $bundle_prefix;
 	/**
-	 * Env.
-	 *
-	 * @var Zoninator_REST_Environment
-	 */
-	private $environment;
-	/**
 	 * Endpoint Builders.
 	 *
 	 * @var array
@@ -78,7 +72,6 @@ class Zoninator_REST_Controller_Bundle_Builder implements Zoninator_REST_Interfa
 	 * @return Zoninator_REST_Controller_Bundle_Builder $this
 	 */
 	public function with_environment( $env ) {
-		$this->environment = $env;
 		return $this;
 	}
 

--- a/lib/zoninator_rest/controller/bundle/class-zoninator-rest-controller-bundle-builder.php
+++ b/lib/zoninator_rest/controller/bundle/class-zoninator-rest-controller-bundle-builder.php
@@ -38,7 +38,7 @@ class Zoninator_REST_Controller_Bundle_Builder implements Zoninator_REST_Interfa
 	 *
 	 * @param Zoninator_REST_Interfaces_Controller_Bundle|null $bundle Bundle.
 	 */
-	function __construct( $bundle = null ) {
+	public function __construct( $bundle = null ) {
 		$this->bundle = $bundle;
 	}
 

--- a/lib/zoninator_rest/controller/bundle/class-zoninator-rest-controller-bundle-builder.php
+++ b/lib/zoninator_rest/controller/bundle/class-zoninator-rest-controller-bundle-builder.php
@@ -37,7 +37,7 @@ class Zoninator_REST_Controller_Bundle_Builder implements Zoninator_REST_Interfa
 	 *
 	 * @var Zoninator_REST_Controller_Bundle|null
 	 */
-	private $bundle = null;
+	private $bundle;
 
 	/**
 	 * Zoninator_REST_Controller_Bundle_Builder constructor.

--- a/lib/zoninator_rest/controller/bundle/class-zoninator-rest-controller-bundle-builder.php
+++ b/lib/zoninator_rest/controller/bundle/class-zoninator-rest-controller-bundle-builder.php
@@ -20,12 +20,14 @@ class Zoninator_REST_Controller_Bundle_Builder implements Zoninator_REST_Interfa
 	 * @var string
 	 */
 	private $bundle_prefix;
+
 	/**
 	 * Endpoint Builders.
 	 *
 	 * @var array
 	 */
 	private $endpoint_builders = array();
+
 	/**
 	 * Bundle.
 	 *
@@ -51,6 +53,7 @@ class Zoninator_REST_Controller_Bundle_Builder implements Zoninator_REST_Interfa
 		if ( is_a( $this->bundle, 'Zoninator_REST_Interfaces_Controller_Bundle' ) ) {
 			return $this->bundle;
 		}
+
 		return new Zoninator_REST_Controller_Bundle( $this->bundle_prefix, $this->endpoint_builders );
 	}
 

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
@@ -13,6 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Zoninator_REST_Controller_Action
  */
 class Zoninator_REST_Controller_Action {
+	public $controller;
+
 	/**
 	 * Permitted actions
 	 *

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
@@ -136,14 +136,12 @@ class Zoninator_REST_Controller_Action {
 			$args = $this->controller->get_endpoint_args_for_item_schema( $this->actions_to_http_methods[ $this->action_name ] );
 		}
 
-		$result = array(
+		return array(
 			'methods'             => $this->actions_to_http_methods[ $this->action_name ],
 			'callback'            => $callable_func,
 			'permission_callback' => $permission_callback,
 			'args'                => $args,
 		);
-
-		return $result;
 	}
 
 	/**

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
@@ -69,9 +69,6 @@ class Zoninator_REST_Controller_Action {
 
 		$this->controller          = $controller;
 		$this->action_name         = $action_name;
-		$this->handler             = null;
-		$this->args                = null;
-		$this->permission_callback = null;
 	}
 
 	/**

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
@@ -19,12 +19,12 @@ class Zoninator_REST_Controller_Action {
 	 * @var array
 	 */
 	private $actions_to_http_methods = array(
-		'index' => WP_REST_Server::READABLE,
-		'show' => WP_REST_Server::READABLE,
-		'create'  => WP_REST_Server::CREATABLE,
+		'index'  => WP_REST_Server::READABLE,
+		'show'   => WP_REST_Server::READABLE,
+		'create' => WP_REST_Server::CREATABLE,
 		'update' => WP_REST_Server::EDITABLE,
 		'delete' => WP_REST_Server::DELETABLE,
-		'any' => WP_REST_Server::ALLMETHODS,
+		'any'    => WP_REST_Server::ALLMETHODS,
 	);
 
 	/**
@@ -59,16 +59,16 @@ class Zoninator_REST_Controller_Action {
 	 * Zoninator_REST_Controller_Action constructor.
 	 *
 	 * @param Zoninator_REST_Controller $controller Controller.
-	 * @param string        $action_name The action Name.
+	 * @param string                    $action_name The action Name.
 	 */
 	public function __construct( $controller, $action_name ) {
 		$is_known_action = in_array( $action_name, array_keys( $this->actions_to_http_methods ), true );
 		Zoninator_REST_Expect::that( $is_known_action, 'Unknown method: ' . $action_name );
 
-		$this->controller = $controller;
-		$this->action_name = $action_name;
-		$this->handler = null;
-		$this->args = null;
+		$this->controller          = $controller;
+		$this->action_name         = $action_name;
+		$this->handler             = null;
+		$this->args                = null;
 		$this->permission_callback = null;
 	}
 

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-action.php
@@ -159,8 +159,10 @@ class Zoninator_REST_Controller_Action {
 			if ( is_string( $callable_func ) && method_exists( $this->controller, $callable_func ) ) {
 				return array( $this->controller, $callable_func );
 			}
+
 			Zoninator_REST_Expect::that( is_callable( $callable_func ), 'Callable Expected: $callable_func' );
 		}
+
 		return $callable_func;
 	}
 }

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
@@ -78,8 +78,6 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 		foreach ( $endpoints as $endpoint ) {
 			/**
 			 * Controller
-			 *
-			 * @var Zoninator_REST_Interfaces_Controller
 			 */
 			$endpoint->register( $this, $this->environment );
 		}

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
@@ -40,7 +40,7 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 	 * @param string $bundle_prefix Prefix.
 	 * @param array  $endpoints Builders.
 	 */
-	function __construct( $bundle_prefix, $endpoints ) {
+	public function __construct( $bundle_prefix, $endpoints ) {
 		$this->prefix    = $bundle_prefix;
 		$this->endpoints = $endpoints;
 	}
@@ -52,7 +52,7 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 	 * @return Zoninator_REST_Controller_Bundle $this
 	 * @throws Zoninator_REST_Exception When no prefix is defined.
 	 */
-	function register( $environment ) {
+	public function register( $environment ) {
 		Zoninator_REST_Expect::that( null !== $this->prefix, 'prefix should be defined' );
 		$this->environment = $environment;
 		/**
@@ -84,7 +84,7 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 	 *
 	 * @return string
 	 */
-	function get_prefix() {
+	public function get_prefix() {
 		return $this->prefix;
 	}
 }

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
@@ -27,6 +27,7 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 	 * @var array
 	 */
 	protected $endpoints = array();
+
 	/**
 	 * Environment.
 	 *

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
@@ -19,7 +19,7 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 	 *
 	 * @var string|null
 	 */
-	protected $prefix = null;
+	protected $prefix;
 
 	/**
 	 * Collection of Mixtape_Rest_Api_Controller subclasses

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
@@ -28,12 +28,6 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 	 */
 	protected $endpoints = array();
 	/**
-	 * Our Endpoint Builders
-	 *
-	 * @var array
-	 */
-	private $endpoint_builders;
-	/**
 	 * Environment.
 	 *
 	 * @var Zoninator_REST_Environment

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-bundle.php
@@ -47,7 +47,7 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 	 * @param array  $endpoints Builders.
 	 */
 	function __construct( $bundle_prefix, $endpoints ) {
-		$this->prefix = $bundle_prefix;
+		$this->prefix    = $bundle_prefix;
 		$this->endpoints = $endpoints;
 	}
 
@@ -96,4 +96,3 @@ class Zoninator_REST_Controller_Bundle implements Zoninator_REST_Interfaces_Cont
 		return $this->prefix;
 	}
 }
-

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-crud.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-crud.php
@@ -19,12 +19,12 @@ class Zoninator_REST_Controller_CRUD extends Zoninator_REST_Controller_Model imp
 	 */
 	public function setup() {
 		$this->add_route( '/' )
-			->add_action( $this->action( 'index',  array( $this, 'get_items' ) ) )
+			->add_action( $this->action( 'index', array( $this, 'get_items' ) ) )
 			->add_action( $this->action( 'create', array( $this, 'create_item' ) ) );
 
 		$this->add_route( '/(?P<id>\d+)' )
-			->add_action( $this->action( 'show',  array( $this, 'get_item' ) ) )
-			->add_action( $this->action( 'update',  array( $this, 'update_item' ) ) )
+			->add_action( $this->action( 'show', array( $this, 'get_item' ) ) )
+			->add_action( $this->action( 'update', array( $this, 'update_item' ) ) )
 			->add_action( $this->action( 'delete', array( $this, 'delete_item' ) ) );
 	}
 
@@ -39,7 +39,7 @@ class Zoninator_REST_Controller_CRUD extends Zoninator_REST_Controller_Model imp
 
 		if ( null === $item_id ) {
 			$models = $this->get_model_data_store()->get_entities();
-			$data = $this->prepare_dto( $models );
+			$data   = $this->prepare_dto( $models );
 			return $this->ok( $data );
 		}
 
@@ -125,9 +125,11 @@ class Zoninator_REST_Controller_CRUD extends Zoninator_REST_Controller_Model imp
 			return $this->bad_request( $id_or_error );
 		}
 
-		$dto = $this->prepare_dto( array(
-			'id' => absint( $id_or_error ),
-		) );
+		$dto = $this->prepare_dto(
+			array(
+				'id' => absint( $id_or_error ),
+			) 
+		);
 
 		return $is_update ? $this->ok( $dto ) : $this->created( $dto );
 	}
@@ -158,7 +160,7 @@ class Zoninator_REST_Controller_CRUD extends Zoninator_REST_Controller_Model imp
 	 * @return array
 	 */
 	protected function model_to_dto( $model ) {
-		$result = parent::model_to_dto( $model );
+		$result           = parent::model_to_dto( $model );
 		$result['_links'] = $this->add_links( $model );
 		return $result;
 	}

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-crud.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-crud.php
@@ -145,10 +145,12 @@ class Zoninator_REST_Controller_CRUD extends Zoninator_REST_Controller_Model imp
 		if ( empty( $id ) ) {
 			return $this->bad_request( 'No Model ID provided' );
 		}
+
 		$model = $this->model_prototype->get_data_store()->get_entity( $id );
 		if ( null === $model ) {
 			return $this->not_found( 'Model does not exist' );
 		}
+
 		$result = $this->model_data_store->delete( $model );
 		return $this->ok( $result );
 	}
@@ -188,6 +190,7 @@ class Zoninator_REST_Controller_CRUD extends Zoninator_REST_Controller_Model imp
 				),
 			);
 		}
+
 		if ( $model->has( 'author' ) ) {
 			$result['author'] = array(
 				array(
@@ -195,6 +198,7 @@ class Zoninator_REST_Controller_CRUD extends Zoninator_REST_Controller_Model imp
 				),
 			);
 		}
+
 		return $result;
 	}
 }

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-extension.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-extension.php
@@ -16,18 +16,21 @@ class Zoninator_REST_Controller_Extension implements Zoninator_REST_Interfaces_R
 	 * @var Zoninator_REST_Environment
 	 */
 	private $environment;
+
 	/**
 	 * Object to extend
 	 *
 	 * @var string
 	 */
 	private $object_to_extend;
+
 	/**
 	 * Model def.
 	 *
 	 * @var Zoninator_REST_Model_Definition
 	 */
 	private $model_definition;
+
 	/**
 	 * Model Definition name, This should be a valid Model definition at registration time, otherwise register will throw
 	 *
@@ -60,6 +63,7 @@ class Zoninator_REST_Controller_Extension implements Zoninator_REST_Interfaces_R
 		if ( ! $this->model_definition ) {
 			return new WP_Error( 'model-not-found' );
 		}
+
 		$fields = $this->model_definition->get_fields();
 		foreach ( $fields as $field ) {
 			$this->register_field( $field );

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-extension.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-extension.php
@@ -43,7 +43,7 @@ class Zoninator_REST_Controller_Extension implements Zoninator_REST_Interfaces_R
 	 */
 	function __construct( $object_to_extend, $model_definition_name ) {
 		$this->model_definition_name = $model_definition_name;
-		$this->object_to_extend = $object_to_extend;
+		$this->object_to_extend      = $object_to_extend;
 	}
 
 	/**
@@ -55,7 +55,7 @@ class Zoninator_REST_Controller_Extension implements Zoninator_REST_Interfaces_R
 	 * @return bool|WP_Error true if valid otherwise error.
 	 */
 	function register( $environment ) {
-		$this->environment = $environment;
+		$this->environment      = $environment;
 		$this->model_definition = $this->environment->model( $this->model_definition_name );
 		if ( ! $this->model_definition ) {
 			return new WP_Error( 'model-not-found' );
@@ -74,10 +74,14 @@ class Zoninator_REST_Controller_Extension implements Zoninator_REST_Interfaces_R
 	 * @param Zoninator_REST_Field_Declaration $field Field.
 	 */
 	private function register_field( $field ) {
-		register_rest_field( $this->object_to_extend, $field->get_data_transfer_name(), array(
-			'get_callback' => $field->get_reader(),
-			'update_callback' => $field->get_updater(),
-			'schema' => $field->as_item_schema_property(),
-		) );
+		register_rest_field(
+			$this->object_to_extend,
+			$field->get_data_transfer_name(),
+			array(
+				'get_callback'    => $field->get_reader(),
+				'update_callback' => $field->get_updater(),
+				'schema'          => $field->as_item_schema_property(),
+			) 
+		);
 	}
 }

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-extension.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-extension.php
@@ -41,7 +41,7 @@ class Zoninator_REST_Controller_Extension implements Zoninator_REST_Interfaces_R
 	 * @param string $object_to_extend Post type.
 	 * @param string $model_definition_name Model Definition name.
 	 */
-	function __construct( $object_to_extend, $model_definition_name ) {
+	public function __construct( $object_to_extend, $model_definition_name ) {
 		$this->model_definition_name = $model_definition_name;
 		$this->object_to_extend      = $object_to_extend;
 	}
@@ -54,7 +54,7 @@ class Zoninator_REST_Controller_Extension implements Zoninator_REST_Interfaces_R
 	 *
 	 * @return bool|WP_Error true if valid otherwise error.
 	 */
-	function register( $environment ) {
+	public function register( $environment ) {
 		$this->environment      = $environment;
 		$this->model_definition = $this->environment->model( $this->model_definition_name );
 		if ( ! $this->model_definition ) {

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-model.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-model.php
@@ -97,6 +97,7 @@ class Zoninator_REST_Controller_Model extends Zoninator_REST_Controller implemen
 				$required[] = $field_declaration->get_data_transfer_name();
 			}
 		}
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/schema#',
 			'title'      => $model_definition->get_name(),
@@ -143,6 +144,7 @@ class Zoninator_REST_Controller_Model extends Zoninator_REST_Controller implemen
 			foreach ( $entity->get_items() as $model ) {
 				$results[] = $this->model_to_dto( $model );
 			}
+
 			return $results;
 		}
 

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-model.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-model.php
@@ -104,7 +104,7 @@ class Zoninator_REST_Controller_Model extends Zoninator_REST_Controller implemen
 			'properties' => (array) apply_filters( 'mixtape_rest_api_schema_properties', $properties, $this->get_model_prototype() ),
 		);
 
-		if ( ! empty( $required ) ) {
+		if ( $required !== array() ) {
 			$schema['required'] = $required;
 		}
 

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-model.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-model.php
@@ -43,7 +43,7 @@ class Zoninator_REST_Controller_Model extends Zoninator_REST_Controller implemen
 	 * @param string $model_class_name A Definition or a definition name.
 	 */
 	public function __construct( $base, $model_class_name ) {
-		$this->base = $base;
+		$this->base             = $base;
 		$this->model_class_name = $model_class_name;
 	}
 
@@ -67,7 +67,7 @@ class Zoninator_REST_Controller_Model extends Zoninator_REST_Controller implemen
 	 * @return bool|WP_Error true if valid otherwise error.
 	 */
 	public function register( $bundle, $environment ) {
-		$this->model_prototype = $environment->model( $this->model_class_name );
+		$this->model_prototype  = $environment->model( $this->model_class_name );
 		$this->model_data_store = $this->model_prototype->get_data_store();
 		return parent::register( $bundle, $environment );
 	}
@@ -83,9 +83,9 @@ class Zoninator_REST_Controller_Model extends Zoninator_REST_Controller implemen
 	 */
 	public function get_item_schema() {
 		$model_definition = $this->get_model_prototype();
-		$fields = $model_definition->get_fields();
-		$properties = array();
-		$required = array();
+		$fields           = $model_definition->get_fields();
+		$properties       = array();
+		$required         = array();
 		foreach ( $fields as $field_declaration ) {
 			/**
 			 * Our declaration
@@ -98,9 +98,9 @@ class Zoninator_REST_Controller_Model extends Zoninator_REST_Controller implemen
 			}
 		}
 		$schema = array(
-			'$schema' => 'http://json-schema.org/schema#',
-			'title' => $model_definition->get_name(),
-			'type' => 'object',
+			'$schema'    => 'http://json-schema.org/schema#',
+			'title'      => $model_definition->get_name(),
+			'type'       => 'object',
 			'properties' => (array) apply_filters( 'mixtape_rest_api_schema_properties', $properties, $this->get_model_prototype() ),
 		);
 

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
@@ -46,12 +46,12 @@ class Zoninator_REST_Controller_Route {
 	 * Zoninator_REST_Controller_Route constructor.
 	 *
 	 * @param Zoninator_REST_Controller $controller A Controller.
-	 * @param string        $pattern Pattern.
+	 * @param string                    $pattern Pattern.
 	 */
 	public function __construct( $controller, $pattern ) {
-		$this->controller = $controller;
-		$this->pattern = $pattern;
-		$this->actions = array();
+		$this->controller   = $controller;
+		$this->pattern      = $pattern;
+		$this->actions      = array();
 		$this->http_methods = explode( ', ', WP_REST_Server::ALLMETHODS );
 	}
 
@@ -74,7 +74,7 @@ class Zoninator_REST_Controller_Route {
 	 * @return array
 	 */
 	public function as_array() {
-		$result = array();
+		$result            = array();
 		$result['pattern'] = $this->pattern;
 		$result['actions'] = array();
 		foreach ( $this->actions as $action => $route_action ) {

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
@@ -26,7 +26,7 @@ class Zoninator_REST_Controller_Route {
 	 *
 	 * @var array
 	 */
-	private $actions;
+	private $actions = array();
 
 	/**
 	 * Zoninator_REST_Controller_Route constructor.
@@ -36,7 +36,6 @@ class Zoninator_REST_Controller_Route {
 	 */
 	public function __construct( $controller, $pattern ) {
 		$this->pattern = $pattern;
-		$this->actions = array();
 	}
 
 	/**

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
@@ -29,30 +29,14 @@ class Zoninator_REST_Controller_Route {
 	private $actions;
 
 	/**
-	 * Our Controller
-	 *
-	 * @var Zoninator_REST_Controller
-	 */
-	private $controller;
-
-	/**
-	 * HTTP Methods
-	 *
-	 * @var array
-	 */
-	private $http_methods;
-
-	/**
 	 * Zoninator_REST_Controller_Route constructor.
 	 *
 	 * @param Zoninator_REST_Controller $controller A Controller.
 	 * @param string                    $pattern Pattern.
 	 */
 	public function __construct( $controller, $pattern ) {
-		$this->controller   = $controller;
-		$this->pattern      = $pattern;
-		$this->actions      = array();
-		$this->http_methods = explode( ', ', WP_REST_Server::ALLMETHODS );
+		$this->pattern = $pattern;
+		$this->actions = array();
 	}
 
 	/**

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
@@ -77,7 +77,7 @@ class Zoninator_REST_Controller_Route {
 		$result            = array();
 		$result['pattern'] = $this->pattern;
 		$result['actions'] = array();
-		foreach ( $this->actions as $action => $route_action ) {
+		foreach ( $this->actions as $route_action ) {
 			/**
 			 * The route action.
 			 *

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-route.php
@@ -69,6 +69,7 @@ class Zoninator_REST_Controller_Route {
 			 */
 			$result['actions'][] = $route_action->as_array();
 		}
+
 		return $result;
 	}
 }

--- a/lib/zoninator_rest/controller/class-zoninator-rest-controller-settings.php
+++ b/lib/zoninator_rest/controller/class-zoninator-rest-controller-settings.php
@@ -55,7 +55,7 @@ class Zoninator_REST_Controller_Settings extends Zoninator_REST_Controller_Model
 	 * @return WP_REST_Response
 	 */
 	protected function create_or_update( $request ) {
-		$is_update = $request->get_method() !== 'POST';
+		$is_update       = $request->get_method() !== 'POST';
 		$model_to_update = $this->model_prototype->get_data_store()->get_entity( null );
 		if ( empty( $model_to_update ) ) {
 			return $this->not_found( 'Model does not exist' );
@@ -79,7 +79,7 @@ class Zoninator_REST_Controller_Settings extends Zoninator_REST_Controller_Model
 		}
 
 		$model = $this->model_prototype->get_data_store()->get_entity( null );
-		$dto = $this->prepare_dto( $model );
+		$dto   = $this->prepare_dto( $model );
 
 		return $is_update ? $this->ok( $dto ) : $this->created( $dto );
 	}

--- a/lib/zoninator_rest/data/class-zoninator-rest-data-mapper.php
+++ b/lib/zoninator_rest/data/class-zoninator-rest-data-mapper.php
@@ -32,7 +32,7 @@ class Zoninator_REST_Data_Mapper {
 	 * @param Zoninator_REST_Model_Definition $definition Def.
 	 * @param Zoninator_REST_Data_Serializer  $serializer Serializer.
 	 */
-	function __construct( $definition, $serializer ) {
+	public function __construct( $definition, $serializer ) {
 		$this->definition = $definition;
 		$this->serializer = $serializer;
 	}
@@ -44,7 +44,7 @@ class Zoninator_REST_Data_Mapper {
 	 * @param array $field_declarations Declarations.
 	 * @return array
 	 */
-	function raw_data_to_model_data( $data, $field_declarations ) {
+	public function raw_data_to_model_data( $data, $field_declarations ) {
 		$raw_data        = array();
 		$post_array_keys = array_keys( $data );
 		foreach ( $field_declarations as $declaration ) {
@@ -76,7 +76,7 @@ class Zoninator_REST_Data_Mapper {
 	 * @param null|string                     $field_type Type.
 	 * @return array
 	 */
-	function model_to_data( $model, $field_type = null ) {
+	public function model_to_data( $model, $field_type = null ) {
 		$field_values_to_insert = array();
 		foreach ( $this->definition->get_field_declarations( $field_type ) as $field_declaration ) {
 			/**

--- a/lib/zoninator_rest/data/class-zoninator-rest-data-mapper.php
+++ b/lib/zoninator_rest/data/class-zoninator-rest-data-mapper.php
@@ -19,6 +19,7 @@ class Zoninator_REST_Data_Mapper {
 	 * @var Zoninator_REST_Data_Serializer
 	 */
 	private $serializer;
+
 	/**
 	 * Definition
 	 *
@@ -64,8 +65,10 @@ class Zoninator_REST_Data_Mapper {
 			} else {
 				$value = $declaration->get_default_value();
 			}
+
 			$raw_data[ $key ] = $declaration->cast_value( $value );
 		}
+
 		return $raw_data;
 	}
 

--- a/lib/zoninator_rest/data/class-zoninator-rest-data-mapper.php
+++ b/lib/zoninator_rest/data/class-zoninator-rest-data-mapper.php
@@ -45,7 +45,7 @@ class Zoninator_REST_Data_Mapper {
 	 * @return array
 	 */
 	function raw_data_to_model_data( $data, $field_declarations ) {
-		$raw_data = array();
+		$raw_data        = array();
 		$post_array_keys = array_keys( $data );
 		foreach ( $field_declarations as $declaration ) {
 			/**
@@ -53,9 +53,9 @@ class Zoninator_REST_Data_Mapper {
 			 *
 			 * @var Zoninator_REST_Field_Declaration $declaration
 			 */
-			$key = $declaration->get_name();
+			$key     = $declaration->get_name();
 			$mapping = $declaration->get_map_from();
-			$value = null;
+			$value   = null;
 			if ( in_array( $key, $post_array_keys, true ) ) {
 				// simplest case: we got a $key for this, so just map it.
 				$value = $this->serializer->deserialize( $declaration, $data[ $key ] );
@@ -73,7 +73,7 @@ class Zoninator_REST_Data_Mapper {
 	 * Transform Model to raw data array
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model Model.
-	 * @param null|string         $field_type Type.
+	 * @param null|string                     $field_type Type.
 	 * @return array
 	 */
 	function model_to_data( $model, $field_type = null ) {
@@ -84,8 +84,8 @@ class Zoninator_REST_Data_Mapper {
 			 *
 			 * @var Zoninator_REST_Field_Declaration $field_declaration
 			 */
-			$what_to_map_to = $field_declaration->get_map_from();
-			$value = $model->get( $field_declaration->get_name() );
+			$what_to_map_to                            = $field_declaration->get_map_from();
+			$value                                     = $model->get( $field_declaration->get_name() );
 			$field_values_to_insert[ $what_to_map_to ] = $this->serializer->serialize( $field_declaration, $value );
 		}
 

--- a/lib/zoninator_rest/data/class-zoninator-rest-data-serializer.php
+++ b/lib/zoninator_rest/data/class-zoninator-rest-data-serializer.php
@@ -54,6 +54,7 @@ class Zoninator_REST_Data_Serializer {
 		if ( isset( $serializer ) && ! empty( $serializer ) ) {
 			return $this->model_declaration->call( $serializer, array( $value ) );
 		}
+
 		return $value;
 	}
 }

--- a/lib/zoninator_rest/data/class-zoninator-rest-data-serializer.php
+++ b/lib/zoninator_rest/data/class-zoninator-rest-data-serializer.php
@@ -33,7 +33,7 @@ class Zoninator_REST_Data_Serializer {
 	 * Deserialize
 	 *
 	 * @param Zoninator_REST_Field_Declaration $field_declaration Declaration.
-	 * @param mixed                $value Value.
+	 * @param mixed                            $value Value.
 	 * @return mixed the deserialized value
 	 */
 	function deserialize( $field_declaration, $value ) {
@@ -45,7 +45,7 @@ class Zoninator_REST_Data_Serializer {
 	 * Serialize
 	 *
 	 * @param  Zoninator_REST_Field_Declaration $field_declaration Declaration.
-	 * @param mixed                $value Value.
+	 * @param mixed                            $value Value.
 	 * @return mixed
 	 * @throws Zoninator_REST_Exception If call fails.
 	 */

--- a/lib/zoninator_rest/data/class-zoninator-rest-data-serializer.php
+++ b/lib/zoninator_rest/data/class-zoninator-rest-data-serializer.php
@@ -25,7 +25,7 @@ class Zoninator_REST_Data_Serializer {
 	 *
 	 * @param Zoninator_REST_Model_Definition $model_definition MD.
 	 */
-	function __construct( $model_definition ) {
+	public function __construct( $model_definition ) {
 		$this->model_declaration = $model_definition->get_model_declaration();
 	}
 
@@ -36,7 +36,7 @@ class Zoninator_REST_Data_Serializer {
 	 * @param mixed                            $value Value.
 	 * @return mixed the deserialized value
 	 */
-	function deserialize( $field_declaration, $value ) {
+	public function deserialize( $field_declaration, $value ) {
 		$deserializer = $field_declaration->get_deserializer();
 		return $deserializer ? $this->model_declaration->call( $deserializer, array( $value ) ) : $value;
 	}
@@ -49,7 +49,7 @@ class Zoninator_REST_Data_Serializer {
 	 * @return mixed
 	 * @throws Zoninator_REST_Exception If call fails.
 	 */
-	function serialize( $field_declaration, $value ) {
+	public function serialize( $field_declaration, $value ) {
 		$serializer = $field_declaration->get_serializer();
 		if ( isset( $serializer ) && ! empty( $serializer ) ) {
 			return $this->model_declaration->call( $serializer, array( $value ) );

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-abstract.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-abstract.php
@@ -33,11 +33,11 @@ abstract class Zoninator_REST_Data_Store_Abstract implements Zoninator_REST_Inte
 	 * Zoninator_REST_Data_Store_Abstract constructor.
 	 *
 	 * @param null|Zoninator_REST_Model $model_prototype Def.
-	 * @param array         $args Args.
+	 * @param array                     $args Args.
 	 */
 	public function __construct( $model_prototype = null, $args = array() ) {
 		$this->type_serializers = array();
-		$this->args = $args;
+		$this->args             = $args;
 		Zoninator_REST_Expect::is_a( $model_prototype, 'Zoninator_REST_Interfaces_Model' );
 		$this->set_model_factory( $model_prototype );
 	}

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-abstract.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-abstract.php
@@ -23,21 +23,13 @@ abstract class Zoninator_REST_Data_Store_Abstract implements Zoninator_REST_Inte
 	protected $model_prototype;
 
 	/**
-	 * Type Serializers
-	 *
-	 * @var array
-	 */
-	private $type_serializers;
-
-	/**
 	 * Zoninator_REST_Data_Store_Abstract constructor.
 	 *
 	 * @param null|Zoninator_REST_Model $model_prototype Def.
 	 * @param array                     $args Args.
 	 */
 	public function __construct( $model_prototype = null, $args = array() ) {
-		$this->type_serializers = array();
-		$this->args             = $args;
+		$this->args = $args;
 		Zoninator_REST_Expect::is_a( $model_prototype, 'Zoninator_REST_Interfaces_Model' );
 		$this->set_model_factory( $model_prototype );
 	}

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-abstract.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-abstract.php
@@ -16,6 +16,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class Zoninator_REST_Data_Store_Abstract implements Zoninator_REST_Interfaces_Data_Store {
 
 	/**
+	 * @var mixed[]
+	 */
+	public $args;
+
+	/**
 	 * Definition
 	 *
 	 * @var Zoninator_REST_Model

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-builder.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-builder.php
@@ -57,7 +57,7 @@ class Zoninator_REST_Data_Store_Builder {
 	 * @param array $args Args.
 	 * @return Zoninator_REST_Data_Store_Builder $this
 	 */
-	function with_args( $args ) {
+	public function with_args( $args ) {
 		$this->args = $args;
 		return $this;
 	}
@@ -68,7 +68,7 @@ class Zoninator_REST_Data_Store_Builder {
 	 * @param string|Zoninator_REST_Model_Definition $model_definition Def.
 	 * @return Zoninator_REST_Data_Store_Builder $this
 	 */
-	function with_model_definition( $model_definition ) {
+	public function with_model_definition( $model_definition ) {
 		$this->model_definition = $model_definition;
 		return $this;
 	}
@@ -78,7 +78,7 @@ class Zoninator_REST_Data_Store_Builder {
 	 *
 	 * @return Zoninator_REST_Interfaces_Data_Store
 	 */
-	function build() {
+	public function build() {
 		$store_class = $this->store_class;
 		return new $store_class( $this->model_definition, $this->args );
 	}

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-customposttype.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-customposttype.php
@@ -24,7 +24,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 	 * Mixtape_Data_Store_CustomPostType constructor.
 	 *
 	 * @param null|Zoninator_REST_Model_Definition $model_prototype Def.
-	 * @param array                    $args Args.
+	 * @param array                                $args Args.
 	 */
 	public function __construct( $model_prototype = null, $args = array() ) {
 		$this->post_type = isset( $args['post_type'] ) ? $args['post_type'] : 'post';
@@ -39,11 +39,13 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 	 * @return Zoninator_REST_Model_Collection
 	 */
 	public function get_entities( $filter = null ) {
-		$query = new WP_Query( array(
-			'post_type' => $this->post_type,
-			'post_status' => 'any',
-		) );
-		$posts = $query->get_posts();
+		$query      = new WP_Query(
+			array(
+				'post_type'   => $this->post_type,
+				'post_status' => 'any',
+			) 
+		);
+		$posts      = $query->get_posts();
 		$collection = array();
 		foreach ( $posts as $post ) {
 			$collection[] = $this->create_from_post( $post );
@@ -75,8 +77,8 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 	 */
 	private function create_from_post( $post ) {
 		$field_declarations = $this->get_model_prototype()->get_fields();
-		$raw_post_data = $post->to_array();
-		$raw_meta_data = get_post_meta( $post->ID ); // assumes we are only ever adding one postmeta per key.
+		$raw_post_data      = $post->to_array();
+		$raw_meta_data      = get_post_meta( $post->ID ); // assumes we are only ever adding one postmeta per key.
 
 		$flattened_meta = array();
 		foreach ( $raw_meta_data as $key => $value_arr ) {
@@ -84,24 +86,30 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 		}
 		$merged_data = array_merge( $raw_post_data, $flattened_meta );
 
-		return $this->get_model_prototype()->create( $merged_data, array(
-			'deserialize' => true,
-		) );
+		return $this->get_model_prototype()->create(
+			$merged_data,
+			array(
+				'deserialize' => true,
+			) 
+		);
 	}
 
 	/**
 	 * Delete
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model Model.
-	 * @param array               $args Args.
+	 * @param array                           $args Args.
 	 * @return mixed
 	 */
 	public function delete( $model, $args = array() ) {
 		$id = $model->get_id();
 
-		$args = wp_parse_args( $args, array(
-			'force_delete' => false,
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'force_delete' => false,
+			) 
+		);
 
 		do_action( 'mixtape_data_store_delete_model_before', $model, $id );
 
@@ -130,9 +138,9 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 	 * @return mixed|WP_Error
 	 */
 	public function upsert( $model ) {
-		$id = $model->get_id();
-		$updating = ! empty( $id );
-		$fields = $model->serialize( Zoninator_REST_Field_Declaration::FIELD );
+		$id          = $model->get_id();
+		$updating    = ! empty( $id );
+		$fields      = $model->serialize( Zoninator_REST_Field_Declaration::FIELD );
 		$meta_fields = $model->serialize( Zoninator_REST_Field_Declaration::META );
 		if ( ! isset( $fields['post_type'] ) ) {
 			$fields['post_type'] = $this->post_type;
@@ -164,7 +172,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 					'mixtape-error-creating-meta',
 					'There was an error updating/creating an entity field',
 					array(
-						'field_key' => $meta_key,
+						'field_key'   => $meta_key,
 						'field_value' => $meta_value,
 					)
 				);

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-customposttype.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-customposttype.php
@@ -43,7 +43,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 			array(
 				'post_type'   => $this->post_type,
 				'post_status' => 'any',
-			) 
+			)
 		);
 		$posts      = $query->get_posts();
 		$collection = array();
@@ -76,9 +76,8 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 	 * @throws Zoninator_REST_Exception If something goes wrong.
 	 */
 	private function create_from_post( $post ) {
-		$field_declarations = $this->get_model_prototype()->get_fields();
-		$raw_post_data      = $post->to_array();
-		$raw_meta_data      = get_post_meta( $post->ID ); // assumes we are only ever adding one postmeta per key.
+		$raw_post_data = $post->to_array();
+		$raw_meta_data = get_post_meta( $post->ID ); // assumes we are only ever adding one postmeta per key.
 
 		$flattened_meta = array();
 		foreach ( $raw_meta_data as $key => $value_arr ) {
@@ -90,7 +89,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 			$merged_data,
 			array(
 				'deserialize' => true,
-			) 
+			)
 		);
 	}
 
@@ -108,7 +107,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 			$args,
 			array(
 				'force_delete' => false,
-			) 
+			)
 		);
 
 		do_action( 'mixtape_data_store_delete_model_before', $model, $id );

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-customposttype.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-customposttype.php
@@ -50,6 +50,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 		foreach ( $posts as $post ) {
 			$collection[] = $this->create_from_post( $post );
 		}
+
 		return new Zoninator_REST_Model_Collection( $collection );
 	}
 
@@ -83,6 +84,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 		foreach ( $raw_meta_data as $key => $value_arr ) {
 			$flattened_meta[ $key ] = $value_arr[0];
 		}
+
 		$merged_data = array_merge( $raw_post_data, $flattened_meta );
 
 		return $this->get_model_prototype()->create(
@@ -126,6 +128,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 			do_action( 'mixtape_data_store_delete_model_fail', $model, $id );
 			return new WP_Error( 'delete-failed', 'delete-failed' );
 		}
+
 		return $result;
 	}
 
@@ -144,6 +147,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 		if ( ! isset( $fields['post_type'] ) ) {
 			$fields['post_type'] = $this->post_type;
 		}
+
 		if ( isset( $fields['ID'] ) && empty( $fields['ID'] ) ) {
 			// ID of 0 is not acceptable on CPTs, so remove it.
 			unset( $fields['ID'] );
@@ -156,6 +160,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 			do_action( 'mixtape_data_store_model_upsert_error', $model );
 			return $id_or_error;
 		}
+
 		$model->set( 'id', absint( $id_or_error ) );
 		foreach ( $meta_fields as $meta_key => $meta_value ) {
 			if ( $updating ) {

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-customposttype.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-customposttype.php
@@ -27,7 +27,7 @@ class Zoninator_REST_Data_Store_CustomPostType extends Zoninator_REST_Data_Store
 	 * @param array                                $args Args.
 	 */
 	public function __construct( $model_prototype = null, $args = array() ) {
-		$this->post_type = isset( $args['post_type'] ) ? $args['post_type'] : 'post';
+		$this->post_type = $args['post_type'] ?? 'post';
 		parent::__construct( $model_prototype, $args );
 	}
 

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-nil.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-nil.php
@@ -29,7 +29,6 @@ class Zoninator_REST_Data_Store_Nil implements Zoninator_REST_Interfaces_Data_St
 	 * Get Entity
 	 *
 	 * @param int $id Id.
-	 * @return null
 	 */
 	public function get_entity( $id ) {
 		return null;

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-nil.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-nil.php
@@ -39,7 +39,7 @@ class Zoninator_REST_Data_Store_Nil implements Zoninator_REST_Interfaces_Data_St
 	 * Delete
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model Model.
-	 * @param array               $args Args.
+	 * @param array                           $args Args.
 	 * @return bool
 	 */
 	public function delete( $model, $args = array() ) {

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-option.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-option.php
@@ -89,6 +89,7 @@ class Zoninator_REST_Data_Store_Option extends Zoninator_REST_Data_Store_Abstrac
 				}
 			}
 		}
+
 		return true;
 	}
 
@@ -108,6 +109,7 @@ class Zoninator_REST_Data_Store_Option extends Zoninator_REST_Data_Store_Abstrac
 				add_option( $option_name, $option_value );
 			}
 		}
+
 		return true;
 	}
 }

--- a/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-option.php
+++ b/lib/zoninator_rest/data/store/class-zoninator-rest-data-store-option.php
@@ -25,7 +25,7 @@ class Zoninator_REST_Data_Store_Option extends Zoninator_REST_Data_Store_Abstrac
 	 * Zoninator_REST_Data_Store_Option constructor.
 	 *
 	 * @param Zoninator_REST_Model $model_prototype Def.
-	 * @param array    $args Args.
+	 * @param array                $args Args.
 	 */
 	public function __construct( $model_prototype, $args = array() ) {
 		parent::__construct( $model_prototype, $args );
@@ -51,7 +51,7 @@ class Zoninator_REST_Data_Store_Option extends Zoninator_REST_Data_Store_Abstrac
 	 */
 	public function get_entity( $id ) {
 		$field_declarations = $this->get_model_prototype()->get_fields();
-		$raw_data = array();
+		$raw_data           = array();
 		foreach ( $field_declarations as $field_declaration ) {
 			/**
 			 * Field Declaration
@@ -64,16 +64,19 @@ class Zoninator_REST_Data_Store_Option extends Zoninator_REST_Data_Store_Abstrac
 			}
 		}
 
-		return $this->get_model_prototype()->create( $raw_data, array(
-			'deserialize' => true,
-		) );
+		return $this->get_model_prototype()->create(
+			$raw_data,
+			array(
+				'deserialize' => true,
+			) 
+		);
 	}
 
 	/**
 	 * Delete
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model Model.
-	 * @param array               $args Args.
+	 * @param array                           $args Args.
 	 * @return mixed
 	 */
 	public function delete( $model, $args = array() ) {

--- a/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
+++ b/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
@@ -397,7 +397,7 @@ class Zoninator_REST_Field_Declaration {
 	 *
 	 * @return Zoninator_REST_Interfaces_Type
 	 */
-	function get_type() {
+	public function get_type() {
 		return $this->type;
 	}
 

--- a/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
+++ b/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
@@ -169,32 +169,32 @@ class Zoninator_REST_Field_Declaration {
 			throw new Zoninator_REST_Exception( 'every field should have a kind (one of ' . implode( ',', $this->field_kinds ) . ')' );
 		}
 
-		$this->name                = $args['name'];
-		$this->description         = $this->value_or_default( $args, 'description', '' );
+		$this->name        = $args['name'];
+		$this->description = $this->value_or_default( $args, 'description', '' );
 
-		$this->kind                = $args['kind'];
-		$this->type                = $this->value_or_default( $args, 'type', Zoninator_REST_Type::any() );
-		$this->choices             = $this->value_or_default( $args, 'choices', null );
-		$this->default_value       = $this->value_or_default( $args, 'default_value' );
+		$this->kind          = $args['kind'];
+		$this->type          = $this->value_or_default( $args, 'type', Zoninator_REST_Type::any() );
+		$this->choices       = $this->value_or_default( $args, 'choices', null );
+		$this->default_value = $this->value_or_default( $args, 'default_value' );
 
-		$this->map_from            = $this->value_or_default( $args, 'map_from' );
-		$this->data_transfer_name  = $this->value_or_default( $args, 'data_transfer_name', $this->get_name() );
+		$this->map_from           = $this->value_or_default( $args, 'map_from' );
+		$this->data_transfer_name = $this->value_or_default( $args, 'data_transfer_name', $this->get_name() );
 
-		$this->primary             = $this->value_or_default( $args, 'primary', false );
-		$this->required            = $this->value_or_default( $args, 'required', false );
-		$this->supported_outputs   = $this->value_or_default( $args, 'supported_outputs', array( 'json' ) );
+		$this->primary           = $this->value_or_default( $args, 'primary', false );
+		$this->required          = $this->value_or_default( $args, 'required', false );
+		$this->supported_outputs = $this->value_or_default( $args, 'supported_outputs', array( 'json' ) );
 
-		$this->sanitizer           = $this->value_or_default( $args, 'sanitizer' );
-		$this->validations         = $this->value_or_default( $args, 'validations', array() );
+		$this->sanitizer   = $this->value_or_default( $args, 'sanitizer' );
+		$this->validations = $this->value_or_default( $args, 'validations', array() );
 
-		$this->serializer          = $this->value_or_default( $args, 'serializer' );
-		$this->deserializer        = $this->value_or_default( $args, 'deserializer' );
+		$this->serializer   = $this->value_or_default( $args, 'serializer' );
+		$this->deserializer = $this->value_or_default( $args, 'deserializer' );
 
-		$this->before_get          = $this->value_or_default( $args, 'before_get' );
-		$this->before_set          = $this->value_or_default( $args, 'before_set' );
+		$this->before_get = $this->value_or_default( $args, 'before_get' );
+		$this->before_set = $this->value_or_default( $args, 'before_set' );
 
-		$this->reader              = $this->value_or_default( $args, 'reader' );
-		$this->updater             = $this->value_or_default( $args, 'updater' );
+		$this->reader  = $this->value_or_default( $args, 'reader' );
+		$this->updater = $this->value_or_default( $args, 'updater' );
 	}
 
 	/**
@@ -279,8 +279,8 @@ class Zoninator_REST_Field_Declaration {
 	 * @return array
 	 */
 	public function as_item_schema_property() {
-		$schema = $this->type->schema();
-		$schema['context'] = array( 'view', 'edit' );
+		$schema                = $this->type->schema();
+		$schema['context']     = array( 'view', 'edit' );
 		$schema['description'] = $this->get_description();
 
 		if ( $this->get_choices() ) {

--- a/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
+++ b/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
@@ -245,7 +245,7 @@ class Zoninator_REST_Field_Declaration {
 	 * @return mixed
 	 */
 	public function get_default_value() {
-		if ( isset( $this->default_value ) && ! empty( $this->default_value ) ) {
+		if ( $this->default_value !== null && ! empty( $this->default_value ) ) {
 			return ( is_array( $this->default_value ) && is_callable( $this->default_value ) ) ? call_user_func( $this->default_value ) : $this->default_value;
 		}
 
@@ -292,7 +292,7 @@ class Zoninator_REST_Field_Declaration {
 	 * Get Map From
 	 */
 	public function get_map_from() {
-		if ( isset( $this->map_from ) && ! empty( $this->map_from ) ) {
+		if ( $this->map_from !== null && ! empty( $this->map_from ) ) {
 			return $this->map_from;
 		}
 
@@ -341,7 +341,7 @@ class Zoninator_REST_Field_Declaration {
 	 * @return string
 	 */
 	public function get_description() {
-		if ( isset( $this->description ) && ! empty( $this->description ) ) {
+		if ( $this->description !== null && ! empty( $this->description ) ) {
 			return $this->description;
 		}
 		return ucfirst( str_replace( '_', ' ', $this->get_name() ) );

--- a/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
+++ b/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
@@ -221,7 +221,6 @@ class Zoninator_REST_Field_Declaration {
 	 * @param array  $args Args.
 	 * @param string $name Name.
 	 * @param mixed  $default Default.
-	 * @return null
 	 */
 	private function value_or_default( $args, $name, $default = null ) {
 		return $args[ $name ] ?? $default;
@@ -291,8 +290,6 @@ class Zoninator_REST_Field_Declaration {
 
 	/**
 	 * Get Map From
-	 *
-	 * @return null
 	 */
 	public function get_map_from() {
 		if ( isset( $this->map_from ) && ! empty( $this->map_from ) ) {

--- a/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
+++ b/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
@@ -17,18 +17,18 @@ class Zoninator_REST_Field_Declaration {
 	/**
 	 * Field A field
 	 */
-	const FIELD = 'field';
+	public const FIELD = 'field';
 
 	/**
 	 * Meta a meta field
 	 */
-	const META = 'meta';
+	public const META = 'meta';
 
 	/**
 	 * Derived field kinds get their values from callables. It is also
 	 * possible to update their values from callables
 	 */
-	const DERIVED = 'derived';
+	public const DERIVED = 'derived';
 	/**
 	 * Map From
 	 *

--- a/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
+++ b/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
@@ -224,7 +224,7 @@ class Zoninator_REST_Field_Declaration {
 	 * @return null
 	 */
 	private function value_or_default( $args, $name, $default = null ) {
-		return isset( $args[ $name ] ) ? $args[ $name ] : $default;
+		return $args[ $name ] ?? $default;
 	}
 
 	/**
@@ -357,7 +357,7 @@ class Zoninator_REST_Field_Declaration {
 	 * @return string
 	 */
 	public function get_data_transfer_name() {
-		return isset( $this->data_transfer_name ) ? $this->data_transfer_name : $this->get_name();
+		return $this->data_transfer_name ?? $this->get_name();
 	}
 
 	/**

--- a/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
+++ b/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
@@ -347,8 +347,7 @@ class Zoninator_REST_Field_Declaration {
 		if ( isset( $this->description ) && ! empty( $this->description ) ) {
 			return $this->description;
 		}
-		$name = ucfirst( str_replace( '_', ' ', $this->get_name() ) );
-		return $name;
+		return ucfirst( str_replace( '_', ' ', $this->get_name() ) );
 	}
 
 	/**

--- a/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
+++ b/lib/zoninator_rest/field/class-zoninator-rest-field-declaration.php
@@ -29,78 +29,91 @@ class Zoninator_REST_Field_Declaration {
 	 * possible to update their values from callables
 	 */
 	public const DERIVED = 'derived';
+
 	/**
 	 * Map From
 	 *
 	 * @var null|string
 	 */
 	private $map_from;
+
 	/**
 	 * The field kind
 	 *
 	 * @var string
 	 */
 	private $kind;
+
 	/**
 	 * Field name
 	 *
 	 * @var string
 	 */
 	private $name;
+
 	/**
 	 * Is this a primary field?
 	 *
 	 * @var bool
 	 */
 	private $primary;
+
 	/**
 	 * Is this a required field?
 	 *
 	 * @var bool
 	 */
 	private $required;
+
 	/**
 	 * Outputs
 	 *
 	 * @var array
 	 */
 	private $supported_outputs;
+
 	/**
 	 * Description
 	 *
 	 * @var string
 	 */
 	private $description;
+
 	/**
 	 * Data Transfer Name
 	 *
 	 * @var null|string
 	 */
 	private $data_transfer_name;
+
 	/**
 	 * Validations
 	 *
 	 * @var null|array
 	 */
 	private $validations;
+
 	/**
 	 * Default Value
 	 *
 	 * @var null|mixed
 	 */
 	private $default_value;
+
 	/**
 	 * Field Choices
 	 *
 	 * @var null|array
 	 */
 	private $choices;
+
 	/**
 	 * Type
 	 *
 	 * @var null|Zoninator_REST_Interfaces_Type
 	 */
 	private $type;
+
 	/**
 	 * Acceptable field kinds
 	 *
@@ -111,18 +124,21 @@ class Zoninator_REST_Field_Declaration {
 		self::META,
 		self::DERIVED,
 	);
+
 	/**
 	 * A custom function to call before serialization
 	 *
 	 * @var null|callable
 	 */
 	private $serializer;
+
 	/**
 	 * A custom function to call before deserialization
 	 *
 	 * @var null|callable
 	 */
 	private $deserializer;
+
 	/**
 	 * A custom function to use for sanitizing the field value before setting it.
 	 * Used when receiving values from untrusted sources (e.g. a web form of a REST API request)
@@ -130,24 +146,28 @@ class Zoninator_REST_Field_Declaration {
 	 * @var null|callable
 	 */
 	private $sanitizer;
+
 	/**
 	 * A custom filtering callable triggered before setting the field with the value
 	 *
 	 * @var null|callable
 	 */
 	private $before_set;
+
 	/**
 	 * A custom filtering callable triggered before returning the field value
 	 *
 	 * @var null|callable
 	 */
 	private $before_get;
+
 	/**
 	 * Used by derived fields: The function to use to get the field value
 	 *
 	 * @var null|callable
 	 */
 	private $reader;
+
 	/**
 	 * Used by derived fields: The function to use to update the field value
 	 *
@@ -165,6 +185,7 @@ class Zoninator_REST_Field_Declaration {
 		if ( ! isset( $args['name'] ) || empty( $args['name'] ) || ! is_string( $args['name'] ) ) {
 			throw new Zoninator_REST_Exception( 'every field declaration should have a (non-empty) name string' );
 		}
+
 		if ( ! isset( $args['kind'] ) || ! in_array( $args['kind'], $this->field_kinds, true ) ) {
 			throw new Zoninator_REST_Exception( 'every field should have a kind (one of ' . implode( ',', $this->field_kinds ) . ')' );
 		}
@@ -236,6 +257,7 @@ class Zoninator_REST_Field_Declaration {
 		if ( ! in_array( $kind, $this->field_kinds, true ) ) {
 			return false;
 		}
+
 		return $this->kind === $kind;
 	}
 
@@ -285,6 +307,7 @@ class Zoninator_REST_Field_Declaration {
 		if ( $this->get_choices() ) {
 			$schema['enum'] = (array) $this->get_choices();
 		}
+
 		return $schema;
 	}
 
@@ -344,6 +367,7 @@ class Zoninator_REST_Field_Declaration {
 		if ( $this->description !== null && ! empty( $this->description ) ) {
 			return $this->description;
 		}
+
 		return ucfirst( str_replace( '_', ' ', $this->get_name() ) );
 	}
 

--- a/lib/zoninator_rest/field/declaration/class-zoninator-rest-field-declaration-builder.php
+++ b/lib/zoninator_rest/field/declaration/class-zoninator-rest-field-declaration-builder.php
@@ -20,7 +20,7 @@ class Zoninator_REST_Field_Declaration_Builder {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		$this->args = array(
 			'name'               => '',
 			'kind'               => Zoninator_REST_Field_Declaration::FIELD,

--- a/lib/zoninator_rest/field/declaration/class-zoninator-rest-field-declaration-builder.php
+++ b/lib/zoninator_rest/field/declaration/class-zoninator-rest-field-declaration-builder.php
@@ -15,6 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Zoninator_REST_Field_Declaration_Builder {
 
+	public $args;
+
 	/**
 	 * Constructor.
 	 */

--- a/lib/zoninator_rest/field/declaration/class-zoninator-rest-field-declaration-builder.php
+++ b/lib/zoninator_rest/field/declaration/class-zoninator-rest-field-declaration-builder.php
@@ -133,7 +133,6 @@ class Zoninator_REST_Field_Declaration_Builder {
 	 */
 	public function with_required( $required = true ) {
 		return $this->with( 'required', $required );
-
 	}
 
 	/**

--- a/lib/zoninator_rest/field/declaration/class-zoninator-rest-field-declaration-builder.php
+++ b/lib/zoninator_rest/field/declaration/class-zoninator-rest-field-declaration-builder.php
@@ -159,6 +159,7 @@ class Zoninator_REST_Field_Declaration_Builder {
 		if ( ! is_a( $value_type, 'Zoninator_REST_Interfaces_Type' ) ) {
 			throw new Zoninator_REST_Exception( get_class( $value_type ) . ' is not a Mixtape_Interfaces_Type' );
 		}
+
 		return $this->with( 'type', $value_type );
 	}
 
@@ -192,6 +193,7 @@ class Zoninator_REST_Field_Declaration_Builder {
 		if ( is_callable( $validations ) || ! is_array( $validations ) ) {
 			$validations = array( $validations );
 		}
+
 		return $this->with( 'validations', $validations );
 	}
 
@@ -226,6 +228,7 @@ class Zoninator_REST_Field_Declaration_Builder {
 		if ( empty( $choices ) ) {
 			return $this;
 		}
+
 		return $this->with( 'choices', is_array( $choices ) ? $choices : array( $choices ) );
 	}
 
@@ -252,6 +255,7 @@ class Zoninator_REST_Field_Declaration_Builder {
 		if ( $func ) {
 			$this->with_map_from( $func );
 		}
+
 		return $this->with_kind( Zoninator_REST_Field_Declaration::DERIVED );
 	}
 

--- a/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-builder.php
+++ b/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-builder.php
@@ -18,5 +18,5 @@ interface Zoninator_REST_Interfaces_Builder {
 	 *
 	 * @return mixed
 	 */
-	function build();
+	public function build();
 }

--- a/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-classloader.php
+++ b/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-classloader.php
@@ -21,5 +21,5 @@ interface Zoninator_REST_Interfaces_Classloader {
 	 * @param string $name The class to load.
 	 * @return Zoninator_REST_Interfaces_Classloader
 	 */
-	function load_class( $name );
+	public function load_class( $name );
 }

--- a/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-controller.php
+++ b/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-controller.php
@@ -22,5 +22,5 @@ interface Zoninator_REST_Interfaces_Controller {
 	 *
 	 * @return bool|WP_Error true if valid otherwise error.
 	 */
-	function register( $bundle, $environment );
+	public function register( $bundle, $environment );
 }

--- a/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-model.php
+++ b/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-model.php
@@ -20,7 +20,7 @@ interface Zoninator_REST_Interfaces_Model {
 	 *
 	 * @return mixed a unique identifier
 	 */
-	function get_id();
+	public function get_id();
 
 	/**
 	 * Set this model's unique identifier
@@ -28,7 +28,7 @@ interface Zoninator_REST_Interfaces_Model {
 	 * @param mixed $new_id The new Id.
 	 * @return Zoninator_REST_Interfaces_Model $model This model.
 	 */
-	function set_id( $new_id );
+	public function set_id( $new_id );
 
 	/**
 	 * Get a field for this model
@@ -38,7 +38,7 @@ interface Zoninator_REST_Interfaces_Model {
 	 *
 	 * @return mixed|null
 	 */
-	function get( $field_name, $args = array() );
+	public function get( $field_name, $args = array() );
 
 	/**
 	 * Set a field for this model
@@ -48,7 +48,7 @@ interface Zoninator_REST_Interfaces_Model {
 	 *
 	 * @return Zoninator_REST_Interfaces_Model $this;
 	 */
-	function set( $field, $value );
+	public function set( $field, $value );
 
 	/**
 	 * Check if this model has a field
@@ -57,7 +57,7 @@ interface Zoninator_REST_Interfaces_Model {
 	 *
 	 * @return bool
 	 */
-	function has( $field );
+	public function has( $field );
 
 	/**
 	 * Validate this Model instance.
@@ -66,7 +66,7 @@ interface Zoninator_REST_Interfaces_Model {
 	 *
 	 * @return bool|WP_Error true if valid otherwise error.
 	 */
-	function validate();
+	public function validate();
 
 	/**
 	 * Sanitize this Model's field values
@@ -75,7 +75,7 @@ interface Zoninator_REST_Interfaces_Model {
 	 *
 	 * @return Zoninator_REST_Interfaces_Model
 	 */
-	function sanitize();
+	public function sanitize();
 
 	/**
 	 * Get this model class fields
@@ -137,7 +137,7 @@ interface Zoninator_REST_Interfaces_Model {
 	 *
 	 * @return mixed
 	 */
-	function update_from_array( $data, $updating = false );
+	public function update_from_array( $data, $updating = false );
 
 	/**
 	 * Transform Model to raw data array
@@ -146,5 +146,5 @@ interface Zoninator_REST_Interfaces_Model {
 	 *
 	 * @return array
 	 */
-	function serialize( $field_type = null );
+	public function serialize( $field_type = null );
 }

--- a/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-registrable.php
+++ b/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-registrable.php
@@ -20,5 +20,5 @@ interface Zoninator_REST_Interfaces_Registrable {
 	 * @param Zoninator_REST_Environment $environment The Environment to use.
 	 * @return void
 	 */
-	function register( $environment );
+	public function register( $environment );
 }

--- a/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-type.php
+++ b/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-type.php
@@ -23,8 +23,6 @@ interface Zoninator_REST_Interfaces_Type {
 	public function cast( $value );
 	/**
 	 * The default value
-	 *
-	 * @return null
 	 */
 	public function default_value();
 	/**

--- a/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-type.php
+++ b/lib/zoninator_rest/interfaces/class-zoninator-rest-interfaces-type.php
@@ -21,16 +21,19 @@ interface Zoninator_REST_Interfaces_Type {
 	 * @return mixed
 	 */
 	public function cast( $value );
+
 	/**
 	 * The default value
 	 */
 	public function default_value();
+
 	/**
 	 * The type's name
 	 *
 	 * @return string
 	 */
 	public function name();
+
 	/**
 	 * Sanitize this value
 	 *
@@ -39,6 +42,7 @@ interface Zoninator_REST_Interfaces_Type {
 	 * @return mixed
 	 */
 	public function sanitize( $value );
+
 	/**
 	 * Get this type's JSON Schema.
 	 *

--- a/lib/zoninator_rest/interfaces/data/class-zoninator-rest-interfaces-data-store.php
+++ b/lib/zoninator_rest/interfaces/data/class-zoninator-rest-interfaces-data-store.php
@@ -36,7 +36,7 @@ interface Zoninator_REST_Interfaces_Data_Store {
 	 * Delete a Model
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model The model to delete.
-	 * @param array               $args Args.
+	 * @param array                           $args Args.
 	 * @return mixed
 	 */
 	public function delete( $model, $args = array() );

--- a/lib/zoninator_rest/interfaces/model/class-zoninator-rest-interfaces-model-collection.php
+++ b/lib/zoninator_rest/interfaces/model/class-zoninator-rest-interfaces-model-collection.php
@@ -18,5 +18,5 @@ interface Zoninator_REST_Interfaces_Model_Collection {
 	 *
 	 * @return Iterator
 	 */
-	function get_items();
+	public function get_items();
 }

--- a/lib/zoninator_rest/interfaces/model/class-zoninator-rest-interfaces-model-declaration.php
+++ b/lib/zoninator_rest/interfaces/model/class-zoninator-rest-interfaces-model-declaration.php
@@ -25,14 +25,14 @@ interface Zoninator_REST_Interfaces_Model_Declaration {
 	 * @param Zoninator_REST_Model_Definition $def The definition.
 	 * @return mixed
 	 */
-	function set_definition( $def );
+	public function set_definition( $def );
 
 	/**
 	 * Get this Declaration's Definition
 	 *
 	 * @return Zoninator_REST_Model_Definition
 	 */
-	function definition();
+	public function definition();
 
 	/**
 	 * Declare the fields of our Model.
@@ -40,7 +40,7 @@ interface Zoninator_REST_Interfaces_Model_Declaration {
 	 * @param Zoninator_REST_Environment $environment The Environment.
 	 * @return array list of Mixtape_Model_Field_Declaration
 	 */
-	function declare_fields( $environment );
+	public function declare_fields( $environment );
 
 	/**
 	 * Call a method
@@ -49,7 +49,7 @@ interface Zoninator_REST_Interfaces_Model_Declaration {
 	 * @param array  $args The args.
 	 * @return mixed
 	 */
-	function call( $method, $args = array() );
+	public function call( $method, $args = array() );
 
 	/**
 	 * Get this model's unique identifier
@@ -57,7 +57,7 @@ interface Zoninator_REST_Interfaces_Model_Declaration {
 	 * @param Zoninator_REST_Interfaces_Model $model The model.
 	 * @return mixed
 	 */
-	function get_id( $model );
+	public function get_id( $model );
 
 	/**
 	 * Set this model's unique identifier
@@ -67,12 +67,12 @@ interface Zoninator_REST_Interfaces_Model_Declaration {
 	 *
 	 * @return Zoninator_REST_Interfaces_Model The model.
 	 */
-	function set_id( $model, $id );
+	public function set_id( $model, $id );
 
 	/**
 	 * Get the name
 	 *
 	 * @return string This declaration's name.
 	 */
-	function get_name();
+	public function get_name();
 }

--- a/lib/zoninator_rest/interfaces/model/class-zoninator-rest-interfaces-model-declaration.php
+++ b/lib/zoninator_rest/interfaces/model/class-zoninator-rest-interfaces-model-declaration.php
@@ -49,7 +49,7 @@ interface Zoninator_REST_Interfaces_Model_Declaration {
 	 * @param array  $args The args.
 	 * @return mixed
 	 */
-	function call( $method, $args = array());
+	function call( $method, $args = array() );
 
 	/**
 	 * Get this model's unique identifier
@@ -63,7 +63,7 @@ interface Zoninator_REST_Interfaces_Model_Declaration {
 	 * Set this model's unique identifier
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model The model.
-	 * @param mixed               $id The id.
+	 * @param mixed                           $id The id.
 	 *
 	 * @return Zoninator_REST_Interfaces_Model The model.
 	 */
@@ -75,5 +75,4 @@ interface Zoninator_REST_Interfaces_Model_Declaration {
 	 * @return string This declaration's name.
 	 */
 	function get_name();
-
 }

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-declaration.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-declaration.php
@@ -27,7 +27,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 	 *
 	 * @return Zoninator_REST_Interfaces_Model_Declaration $this
 	 */
-	function set_definition( $def ) {
+	public function set_definition( $def ) {
 		$this->model_definition = $def;
 		return $this;
 	}
@@ -37,7 +37,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 	 *
 	 * @return Zoninator_REST_Model_Definition
 	 */
-	function definition() {
+	public function definition() {
 		return $this->model_definition;
 	}
 
@@ -49,7 +49,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 	 * @return void
 	 * @throws Zoninator_REST_Exception Override this.
 	 */
-	function declare_fields( $env ) {
+	public function declare_fields( $env ) {
 		throw new Zoninator_REST_Exception( 'Override me: ' . __FUNCTION__ );
 	}
 
@@ -60,7 +60,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 	 *
 	 * @return mixed|null
 	 */
-	function get_id( $model ) {
+	public function get_id( $model ) {
 		return $model->get( 'id' );
 	}
 
@@ -72,7 +72,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 	 *
 	 * @return mixed|null
 	 */
-	function set_id( $model, $new_id ) {
+	public function set_id( $model, $new_id ) {
 		return $model->set( 'id', $new_id );
 	}
 
@@ -85,7 +85,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 	 * @return mixed
 	 * @throws Zoninator_REST_Exception Throw if method nonexistent.
 	 */
-	function call( $method, $args = array() ) {
+	public function call( $method, $args = array() ) {
 		if ( is_callable( $method ) ) {
 			return $this->perform_call( $method, $args );
 		}
@@ -98,7 +98,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 	 *
 	 * @return string
 	 */
-	function get_name() {
+	public function get_name() {
 		return strtolower( get_class( $this ) );
 	}
 

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-declaration.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-declaration.php
@@ -68,7 +68,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 	 * Set the id
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model The model.
-	 * @param mixed               $new_id The new id.
+	 * @param mixed                           $new_id The new id.
 	 *
 	 * @return mixed|null
 	 */

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-declaration.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-declaration.php
@@ -89,6 +89,7 @@ class Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Mode
 		if ( is_callable( $method ) ) {
 			return $this->perform_call( $method, $args );
 		}
+
 		Zoninator_REST_Expect::that( method_exists( $this, $method ), $method . ' does not exist' );
 		return $this->perform_call( array( $this, $method ), $args );
 	}

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-definition.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-definition.php
@@ -63,21 +63,21 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	/**
 	 * Mixtape_Model_Definition constructor.
 	 *
-	 * @param Zoninator_REST_Environment                                 $environment The Environment.
-	 * @param Zoninator_REST_Interfaces_Model_Declaration                $model_declaration Declaration.
+	 * @param Zoninator_REST_Environment                                             $environment The Environment.
+	 * @param Zoninator_REST_Interfaces_Model_Declaration                            $model_declaration Declaration.
 	 * @param Zoninator_REST_Interfaces_Data_Store|Zoninator_REST_Data_Store_Builder $data_store Store.
-	 * @param Zoninator_REST_Interfaces_Permissions_Provider             $permissions_provider Provider.
+	 * @param Zoninator_REST_Interfaces_Permissions_Provider                         $permissions_provider Provider.
 	 *
 	 * @throws Zoninator_REST_Exception Throws if wrong types or null args provided.
 	 */
 	function __construct( $environment, $model_declaration, $data_store, $permissions_provider ) {
-		Zoninator_REST_Expect::that( null !== $environment         , '$environment cannot be null' );
-		Zoninator_REST_Expect::that( null !== $model_declaration   , '$model_declaration cannot be null' );
-		Zoninator_REST_Expect::that( null !== $data_store          , '$data_store cannot be null' );
+		Zoninator_REST_Expect::that( null !== $environment, '$environment cannot be null' );
+		Zoninator_REST_Expect::that( null !== $model_declaration, '$model_declaration cannot be null' );
+		Zoninator_REST_Expect::that( null !== $data_store, '$data_store cannot be null' );
 		Zoninator_REST_Expect::that( null !== $permissions_provider, '$permissions_provider cannot be null' );
 		// Fail if provided with inappropriate types.
-		Zoninator_REST_Expect::is_a( $environment         , 'Zoninator_REST_Environment' );
-		Zoninator_REST_Expect::is_a( $model_declaration   , 'Zoninator_REST_Interfaces_Model_Declaration' );
+		Zoninator_REST_Expect::is_a( $environment, 'Zoninator_REST_Environment' );
+		Zoninator_REST_Expect::is_a( $model_declaration, 'Zoninator_REST_Interfaces_Model_Declaration' );
 		Zoninator_REST_Expect::is_a( $permissions_provider, 'Zoninator_REST_Interfaces_Permissions_Provider' );
 
 		$this->field_declarations   = null;
@@ -195,8 +195,8 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 * Note: Values change in place.
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model The model.
-	 * @param array               $data The data (key-value assumed).
-	 * @param bool                $updating Is this an update?.
+	 * @param array                           $data The data (key-value assumed).
+	 * @param bool                            $updating Is this an update?.
 	 *
 	 * @return Zoninator_REST_Interfaces_Model|WP_Error
 	 * @throws Zoninator_REST_Exception Throws.
@@ -260,7 +260,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	function model_to_dto( $model ) {
 		$result = array();
 		foreach ( $this->get_dto_field_mappings() as $mapping_name => $field_name ) {
-			$value = $model->get( $field_name );
+			$value                   = $model->get( $field_name );
 			$result[ $mapping_name ] = $value;
 		}
 
@@ -296,7 +296,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 */
 	private function map_data( $data, $updating = false ) {
 		$request_data = array();
-		$fields = $this->get_field_declarations();
+		$fields       = $this->get_field_declarations();
 		foreach ( $fields as $field ) {
 			/**
 			 * Field
@@ -306,10 +306,10 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 			if ( $field->is_kind( Zoninator_REST_Field_Declaration::DERIVED ) ) {
 				continue;
 			}
-			$dto_name = $field->get_data_transfer_name();
+			$dto_name   = $field->get_data_transfer_name();
 			$field_name = $field->get_name();
 			if ( isset( $data[ $dto_name ] ) && ! ( $updating && $field->is_primary() ) ) {
-				$value = $data[ $dto_name ];
+				$value                       = $data[ $dto_name ];
 				$request_data[ $field_name ] = $value;
 			}
 		}
@@ -331,7 +331,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 			 *
 			 * @var Zoninator_REST_Field_Declaration $field Field Builder.
 			 */
-			$field = $field_builder->build();
+			$field                        = $field_builder->build();
 			$fields[ $field->get_name() ] = $field;
 		}
 		return $fields;

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-definition.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-definition.php
@@ -82,8 +82,6 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 		Zoninator_REST_Expect::is_a( $environment, 'Zoninator_REST_Environment' );
 		Zoninator_REST_Expect::is_a( $model_declaration, 'Zoninator_REST_Interfaces_Model_Declaration' );
 		Zoninator_REST_Expect::is_a( $permissions_provider, 'Zoninator_REST_Interfaces_Permissions_Provider' );
-
-		$this->field_declarations   = null;
 		$this->environment          = $environment;
 		$this->model_declaration    = $model_declaration;
 		$this->model_class          = get_class( $model_declaration );

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-definition.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-definition.php
@@ -20,18 +20,21 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 * @var Zoninator_REST_Environment
 	 */
 	private $environment;
+
 	/**
 	 * Field Declarations
 	 *
 	 * @var array
 	 */
 	private $field_declarations;
+
 	/**
 	 * Model class
 	 *
 	 * @var string
 	 */
 	private $model_class;
+
 	/**
 	 * Data Store
 	 *
@@ -123,6 +126,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 		} else {
 			$this->data_store = $data_store;
 		}
+
 		// at this point we should have a data store.
 		Zoninator_REST_Expect::is_a( $this->data_store, 'Zoninator_REST_Interfaces_Data_Store' );
 
@@ -172,6 +176,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 				$filtered[] = $field_declaration;
 			}
 		}
+
 		return $filtered;
 	}
 
@@ -187,6 +192,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 		if ( is_array( $data ) ) {
 			return new Zoninator_REST_Model( $this, $data );
 		}
+
 		throw new Zoninator_REST_Exception( 'does not understand entity' );
 	}
 
@@ -206,6 +212,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 		foreach ( $mapped_data as $name => $value ) {
 			$model->set( $name, $value );
 		}
+
 		return $model->sanitize();
 	}
 
@@ -245,8 +252,10 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 			if ( ! $field_declaration->supports_output_type( 'json' ) ) {
 				continue;
 			}
+
 			$mappings[ $field_declaration->get_data_transfer_name() ] = $field_declaration->get_name();
 		}
+
 		return $mappings;
 	}
 
@@ -306,6 +315,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 			if ( $field->is_kind( Zoninator_REST_Field_Declaration::DERIVED ) ) {
 				continue;
 			}
+
 			$dto_name   = $field->get_data_transfer_name();
 			$field_name = $field->get_name();
 			if ( isset( $data[ $dto_name ] ) && ! ( $updating && $field->is_primary() ) ) {
@@ -313,6 +323,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 				$request_data[ $field_name ] = $value;
 			}
 		}
+
 		return $request_data;
 	}
 
@@ -334,6 +345,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 			$field                        = $field_builder->build();
 			$fields[ $field->get_name() ] = $field;
 		}
+
 		return $fields;
 	}
 }

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-definition.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-definition.php
@@ -70,7 +70,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 *
 	 * @throws Zoninator_REST_Exception Throws if wrong types or null args provided.
 	 */
-	function __construct( $environment, $model_declaration, $data_store, $permissions_provider ) {
+	public function __construct( $environment, $model_declaration, $data_store, $permissions_provider ) {
 		Zoninator_REST_Expect::that( null !== $environment, '$environment cannot be null' );
 		Zoninator_REST_Expect::that( null !== $model_declaration, '$model_declaration cannot be null' );
 		Zoninator_REST_Expect::that( null !== $data_store, '$data_store cannot be null' );
@@ -95,7 +95,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 *
 	 * @return string
 	 */
-	function get_model_class() {
+	public function get_model_class() {
 		return $this->model_class;
 	}
 
@@ -104,7 +104,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 *
 	 * @return Zoninator_REST_Interfaces_Data_Store
 	 */
-	function get_data_store() {
+	public function get_data_store() {
 		return $this->data_store;
 	}
 
@@ -115,7 +115,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 * @return $this
 	 * @throws Zoninator_REST_Exception Throws when Data Store Invalid.
 	 */
-	function set_data_store( $data_store ) {
+	public function set_data_store( $data_store ) {
 		if ( is_a( $data_store, 'Zoninator_REST_Data_Store_Builder' ) ) {
 			$this->data_store = $data_store
 				->with_model_definition( $this )
@@ -134,7 +134,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 *
 	 * @return Zoninator_REST_Environment
 	 */
-	function environment() {
+	public function environment() {
 		return $this->environment;
 	}
 
@@ -145,7 +145,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 *
 	 * @return array|null
 	 */
-	function get_field_declarations( $filter_by_type = null ) {
+	public function get_field_declarations( $filter_by_type = null ) {
 		$model_declaration = $this->get_model_declaration()->set_definition( $this );
 
 		Zoninator_REST_Expect::is_a( $model_declaration, 'Zoninator_REST_Interfaces_Model_Declaration' );
@@ -183,7 +183,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 * @return Zoninator_REST_Model
 	 * @throws Zoninator_REST_Exception Throws if data not an array.
 	 */
-	function create_instance( $data ) {
+	public function create_instance( $data ) {
 		if ( is_array( $data ) ) {
 			return new Zoninator_REST_Model( $this, $data );
 		}
@@ -201,7 +201,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 * @return Zoninator_REST_Interfaces_Model|WP_Error
 	 * @throws Zoninator_REST_Exception Throws.
 	 */
-	function update_model_from_array( $model, $data, $updating = false ) {
+	public function update_model_from_array( $model, $data, $updating = false ) {
 		$mapped_data = $this->map_data( $data, $updating );
 		foreach ( $mapped_data as $name => $value ) {
 			$model->set( $name, $value );
@@ -234,7 +234,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 *
 	 * @return array
 	 */
-	function get_dto_field_mappings() {
+	public function get_dto_field_mappings() {
 		$mappings = array();
 		foreach ( $this->get_field_declarations() as $field_declaration ) {
 			/**
@@ -257,7 +257,7 @@ class Zoninator_REST_Model_Definition implements Zoninator_REST_Interfaces_Permi
 	 *
 	 * @return array
 	 */
-	function model_to_dto( $model ) {
+	public function model_to_dto( $model ) {
 		$result = array();
 		foreach ( $this->get_dto_field_mappings() as $mapping_name => $field_name ) {
 			$value                   = $model->get( $field_name );

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
@@ -59,7 +59,7 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 		$settings_per_group = $this->get_settings();
 		$fields             = array();
 
-		foreach ( $settings_per_group as $group_name => $group_data ) {
+		foreach ( $settings_per_group as $group_data ) {
 			$group_fields = $group_data[1];
 
 			foreach ( $group_fields as $field_data ) {

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
@@ -87,7 +87,7 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 	 * @return bool
 	 */
 	public function bit_to_bool( $value ) {
-		return ( ! empty( $value ) && '0' !== $value ) ? true : false;
+		return ! empty( $value ) && '0' !== $value;
 	}
 
 	/**

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
@@ -40,9 +40,9 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 	/**
 	 * On Field Setup
 	 *
-	 * @param string                       $field_name Name.
+	 * @param string                                   $field_name Name.
 	 * @param Zoninator_REST_Field_Declaration_Builder $field_builder Builder.
-	 * @param array                        $field_data Data.
+	 * @param array                                    $field_data Data.
 	 * @param Zoninator_REST_Environment               $env Env.
 	 * @return void
 	 */
@@ -55,16 +55,16 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 	 * @return array
 	 */
 	public function declare_fields() {
-		$env = $this->get_environment();
+		$env                = $this->get_environment();
 		$settings_per_group = $this->get_settings();
-		$fields = array();
+		$fields             = array();
 
 		foreach ( $settings_per_group as $group_name => $group_data ) {
 			$group_fields = $group_data[1];
 
 			foreach ( $group_fields as $field_data ) {
 				$field_builder = $this->field_declaration_builder_from_data( $env, $field_data );
-				$fields[] = $field_builder;
+				$fields[]      = $field_builder;
 			}
 		}
 		return $fields;
@@ -113,18 +113,18 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 	 * Build declarations from array
 	 *
 	 * @param Zoninator_REST_Environment $env Environment.
-	 * @param array          $field_data Data.
+	 * @param array                      $field_data Data.
 	 * @return Zoninator_REST_Field_Declaration_Builder
 	 */
 	private function field_declaration_builder_from_data( $env, $field_data ) {
-		$field_name = $field_data['name'];
+		$field_name    = $field_data['name'];
 		$field_builder = $env->field( $field_name );
 		$default_value = isset( $field_data['std'] ) ? $field_data['std'] : $this->default_for_attribute( $field_data, 'std' );
-		$label = isset( $field_data['label'] ) ? $field_data['label'] : $field_name;
-		$description = isset( $field_data['desc'] ) ? $field_data['desc'] : $label;
-		$setting_type = isset( $field_data['type'] ) ? $field_data['type'] : null;
-		$choices = isset( $field_data['options'] ) ? array_keys( $field_data['options'] ) : null;
-		$field_type = 'string';
+		$label         = isset( $field_data['label'] ) ? $field_data['label'] : $field_name;
+		$description   = isset( $field_data['desc'] ) ? $field_data['desc'] : $label;
+		$setting_type  = isset( $field_data['type'] ) ? $field_data['type'] : null;
+		$choices       = isset( $field_data['options'] ) ? array_keys( $field_data['options'] ) : null;
+		$field_type    = 'string';
 
 		if ( 'checkbox' === $setting_type ) {
 			$field_type = 'boolean';
@@ -135,7 +135,6 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 			$field_builder
 				->with_serializer( array( $this, 'bool_to_bit' ) )
 				->with_deserializer( array( $this, 'bit_to_bool' ) );
-
 		} elseif ( 'select' === $setting_type ) {
 			$field_type = 'string';
 		} else {

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
@@ -67,6 +67,7 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 				$fields[]      = $field_builder;
 			}
 		}
+
 		return $fields;
 	}
 
@@ -132,6 +133,7 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 				// convert our default value as well.
 				$default_value = $this->bit_to_bool( $default_value );
 			}
+
 			$field_builder
 				->with_serializer( array( $this, 'bool_to_bit' ) )
 				->with_deserializer( array( $this, 'bit_to_bool' ) );
@@ -145,6 +147,7 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 		if ( $default_value ) {
 			$field_builder->with_default( $default_value );
 		}
+
 		$field_builder
 			->with_description( $description )
 			->with_dto_name( $field_name )

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
@@ -137,11 +137,9 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 				->with_deserializer( array( $this, 'bit_to_bool' ) );
 		} elseif ( 'select' === $setting_type ) {
 			$field_type = 'string';
-		} else {
+		} elseif ( is_numeric( $default_value ) ) {
 			// try to guess numeric fields, although this is not perfect.
-			if ( is_numeric( $default_value ) ) {
-				$field_type = is_float( $default_value ) ? 'float' : 'integer';
-			}
+			$field_type = is_float( $default_value ) ? 'float' : 'integer';
 		}
 
 		if ( $default_value ) {

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-settings.php
@@ -119,10 +119,10 @@ class Zoninator_REST_Model_Settings extends Zoninator_REST_Model {
 	private function field_declaration_builder_from_data( $env, $field_data ) {
 		$field_name    = $field_data['name'];
 		$field_builder = $env->field( $field_name );
-		$default_value = isset( $field_data['std'] ) ? $field_data['std'] : $this->default_for_attribute( $field_data, 'std' );
-		$label         = isset( $field_data['label'] ) ? $field_data['label'] : $field_name;
-		$description   = isset( $field_data['desc'] ) ? $field_data['desc'] : $label;
-		$setting_type  = isset( $field_data['type'] ) ? $field_data['type'] : null;
+		$default_value = $field_data['std'] ?? $this->default_for_attribute( $field_data, 'std' );
+		$label         = $field_data['label'] ?? $field_name;
+		$description   = $field_data['desc'] ?? $label;
+		$setting_type  = $field_data['type'] ?? null;
 		$choices       = isset( $field_data['options'] ) ? array_keys( $field_data['options'] ) : null;
 		$field_type    = 'string';
 

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-validationdata.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-validationdata.php
@@ -35,7 +35,7 @@ class Zoninator_REST_Model_ValidationData {
 	/**
 	 * Mixtape_Model_ValidationData constructor.
 	 *
-	 * @param mixed                $value The value.
+	 * @param mixed                            $value The value.
 	 * @param Zoninator_REST_Interfaces_Model  $model The Model.
 	 * @param Zoninator_REST_Field_Declaration $field The Field.
 	 */

--- a/lib/zoninator_rest/model/class-zoninator-rest-model-validationdata.php
+++ b/lib/zoninator_rest/model/class-zoninator-rest-model-validationdata.php
@@ -19,12 +19,14 @@ class Zoninator_REST_Model_ValidationData {
 	 * @var mixed
 	 */
 	private $value;
+
 	/**
 	 * The model
 	 *
 	 * @var Zoninator_REST_Interfaces_Model
 	 */
 	private $model;
+
 	/**
 	 * The field
 	 *

--- a/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
+++ b/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
@@ -119,10 +119,10 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	private function field_declaration_builder_from_data( $env, $field_data ) {
 		$field_name    = $field_data['name'];
 		$field_builder = $env->field( $field_name );
-		$default_value = isset( $field_data['std'] ) ? $field_data['std'] : $this->default_for_attribute( $field_data, 'std' );
-		$label         = isset( $field_data['label'] ) ? $field_data['label'] : $field_name;
-		$description   = isset( $field_data['desc'] ) ? $field_data['desc'] : $label;
-		$setting_type  = isset( $field_data['type'] ) ? $field_data['type'] : null;
+		$default_value = $field_data['std'] ?? $this->default_for_attribute( $field_data, 'std' );
+		$label         = $field_data['label'] ?? $field_name;
+		$description   = $field_data['desc'] ?? $label;
+		$setting_type  = $field_data['type'] ?? null;
 		$choices       = isset( $field_data['options'] ) ? array_keys( $field_data['options'] ) : null;
 		$field_type    = 'string';
 

--- a/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
+++ b/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
@@ -85,7 +85,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 * @return bool
 	 */
 	function bit_to_bool( $value ) {
-		return ( ! empty( $value ) && '0' !== $value ) ? true : false;
+		return ! empty( $value ) && '0' !== $value;
 	}
 
 	/**

--- a/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
+++ b/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
@@ -57,7 +57,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 		$settings_per_group = $this->get_settings();
 		$fields             = array();
 
-		foreach ( $settings_per_group as $group_name => $group_data ) {
+		foreach ( $settings_per_group as $group_data ) {
 			$group_fields = $group_data[1];
 
 			foreach ( $group_fields as $field_data ) {

--- a/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
+++ b/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
@@ -137,11 +137,9 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 				->with_deserializer( array( $this, 'bit_to_bool' ) );
 		} elseif ( 'select' === $setting_type ) {
 			$field_type = 'string';
-		} else {
+		} elseif ( is_numeric( $default_value ) ) {
 			// try to guess numeric fields, although this is not perfect.
-			if ( is_numeric( $default_value ) ) {
-				$field_type = is_float( $default_value ) ? 'float' : 'integer';
-			}
+			$field_type = is_float( $default_value ) ? 'float' : 'integer';
 		}
 
 		if ( $default_value ) {

--- a/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
+++ b/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
@@ -13,8 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Mixtape_Model_Declaration_Settings
  * Represents a single setting field
  */
-class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Declaration
-	implements Zoninator_REST_Interfaces_Permissions_Provider {
+class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Declaration implements Zoninator_REST_Interfaces_Permissions_Provider {
 
 	/**
 	 * Get Settings
@@ -39,9 +38,9 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	/**
 	 * On Field Setup
 	 *
-	 * @param string                       $field_name Name.
+	 * @param string                                   $field_name Name.
 	 * @param Zoninator_REST_Field_Declaration_Builder $field_builder Builder.
-	 * @param array                        $field_data Data.
+	 * @param array                                    $field_data Data.
 	 * @param Zoninator_REST_Environment               $env Env.
 	 * @return void
 	 */
@@ -56,14 +55,14 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 */
 	function declare_fields( $env ) {
 		$settings_per_group = $this->get_settings();
-		$fields = array();
+		$fields             = array();
 
 		foreach ( $settings_per_group as $group_name => $group_data ) {
 			$group_fields = $group_data[1];
 
 			foreach ( $group_fields as $field_data ) {
 				$field_builder = $this->field_declaration_builder_from_data( $env, $field_data );
-				$fields[] = $field_builder;
+				$fields[]      = $field_builder;
 			}
 		}
 		return $fields;
@@ -103,7 +102,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 * Set ID
 	 *
 	 * @param Zoninator_REST_Interfaces_Model $model Model.
-	 * @param mixed               $new_id New ID.
+	 * @param mixed                           $new_id New ID.
 	 * @return Zoninator_REST_Interfaces_Model $this
 	 */
 	function set_id( $model, $new_id ) {
@@ -114,18 +113,18 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 * Build declarations from array
 	 *
 	 * @param Zoninator_REST_Environment $env Environment.
-	 * @param array          $field_data Data.
+	 * @param array                      $field_data Data.
 	 * @return Zoninator_REST_Field_Declaration_Builder
 	 */
 	private function field_declaration_builder_from_data( $env, $field_data ) {
-		$field_name = $field_data['name'];
+		$field_name    = $field_data['name'];
 		$field_builder = $env->field( $field_name );
 		$default_value = isset( $field_data['std'] ) ? $field_data['std'] : $this->default_for_attribute( $field_data, 'std' );
-		$label = isset( $field_data['label'] ) ? $field_data['label'] : $field_name;
-		$description = isset( $field_data['desc'] ) ? $field_data['desc'] : $label;
-		$setting_type = isset( $field_data['type'] ) ? $field_data['type'] : null;
-		$choices = isset( $field_data['options'] ) ? array_keys( $field_data['options'] ) : null;
-		$field_type = 'string';
+		$label         = isset( $field_data['label'] ) ? $field_data['label'] : $field_name;
+		$description   = isset( $field_data['desc'] ) ? $field_data['desc'] : $label;
+		$setting_type  = isset( $field_data['type'] ) ? $field_data['type'] : null;
+		$choices       = isset( $field_data['options'] ) ? array_keys( $field_data['options'] ) : null;
+		$field_type    = 'string';
 
 		if ( 'checkbox' === $setting_type ) {
 			$field_type = 'boolean';
@@ -136,7 +135,6 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 			$field_builder
 				->with_serializer( array( $this, 'bool_to_bit' ) )
 				->with_deserializer( array( $this, 'bit_to_bool' ) );
-
 		} elseif ( 'select' === $setting_type ) {
 			$field_type = 'string';
 		} else {

--- a/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
+++ b/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
@@ -20,7 +20,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 *
 	 * @throws Zoninator_REST_Exception Override this.
 	 */
-	function get_settings() {
+	public function get_settings() {
 		Zoninator_REST_Expect::that( false, 'Override this' );
 	}
 
@@ -53,7 +53,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 * @param Zoninator_REST_Environment $env Def.
 	 * @return array
 	 */
-	function declare_fields( $env ) {
+	public function declare_fields( $env ) {
 		$settings_per_group = $this->get_settings();
 		$fields             = array();
 
@@ -74,7 +74,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 * @param mixed $value Val.
 	 * @return string
 	 */
-	function bool_to_bit( $value ) {
+	public function bool_to_bit( $value ) {
 		return ( ! empty( $value ) && 'false' !== $value ) ? '1' : '';
 	}
 
@@ -84,7 +84,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 * @param mixed $value Val.
 	 * @return bool
 	 */
-	function bit_to_bool( $value ) {
+	public function bit_to_bool( $value ) {
 		return ! empty( $value ) && '0' !== $value;
 	}
 
@@ -94,7 +94,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 * @param Zoninator_REST_Interfaces_Model $model Model.
 	 * @return string
 	 */
-	function get_id( $model ) {
+	public function get_id( $model ) {
 		return strtolower( get_class( $this ) );
 	}
 
@@ -105,7 +105,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 	 * @param mixed                           $new_id New ID.
 	 * @return Zoninator_REST_Interfaces_Model $this
 	 */
-	function set_id( $model, $new_id ) {
+	public function set_id( $model, $new_id ) {
 		return $this;
 	}
 

--- a/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
+++ b/lib/zoninator_rest/model/declaration/class-zoninator-rest-model-declaration-settings.php
@@ -65,6 +65,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 				$fields[]      = $field_builder;
 			}
 		}
+
 		return $fields;
 	}
 
@@ -132,6 +133,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 				// convert our default value as well.
 				$default_value = $this->bit_to_bool( $default_value );
 			}
+
 			$field_builder
 				->with_serializer( array( $this, 'bool_to_bit' ) )
 				->with_deserializer( array( $this, 'bit_to_bool' ) );
@@ -145,6 +147,7 @@ class Zoninator_REST_Model_Declaration_Settings extends Zoninator_REST_Model_Dec
 		if ( $default_value ) {
 			$field_builder->with_default( $default_value );
 		}
+
 		$field_builder
 			->with_description( $description )
 			->with_dto_name( $field_name )

--- a/lib/zoninator_rest/model/definition/class-zoninator-rest-model-definition-builder.php
+++ b/lib/zoninator_rest/model/definition/class-zoninator-rest-model-definition-builder.php
@@ -41,7 +41,7 @@ class Zoninator_REST_Model_Definition_Builder implements Zoninator_REST_Interfac
 	/**
 	 * Zoninator_REST_Model_Definition_Builder constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		$this->with_data_store( new Zoninator_REST_Data_Store_Nil() )
 			->with_permissions_provider( new Zoninator_REST_Permissions_Any() );
 	}
@@ -52,7 +52,7 @@ class Zoninator_REST_Model_Definition_Builder implements Zoninator_REST_Interfac
 	 * @param Zoninator_REST_Interfaces_Model_Declaration|Zoninator_REST_Interfaces_Permissions_Provider $declaration D.
 	 * @return Zoninator_REST_Model_Definition_Builder
 	 */
-	function with_declaration( $declaration ) {
+	public function with_declaration( $declaration ) {
 		if ( is_string( $declaration ) && class_exists( $declaration ) ) {
 			$declaration = new $declaration();
 		}
@@ -71,7 +71,7 @@ class Zoninator_REST_Model_Definition_Builder implements Zoninator_REST_Interfac
 	 *
 	 * @return Zoninator_REST_Model_Definition_Builder $this
 	 */
-	function with_data_store( $data_store = null ) {
+	public function with_data_store( $data_store = null ) {
 		$this->data_store = $data_store;
 		return $this;
 	}
@@ -81,7 +81,7 @@ class Zoninator_REST_Model_Definition_Builder implements Zoninator_REST_Interfac
 	 *
 	 * @param Zoninator_REST_Interfaces_Permissions_Provider $permissions_provider Provider.
 	 */
-	function with_permissions_provider( $permissions_provider ) {
+	public function with_permissions_provider( $permissions_provider ) {
 		$this->permissions_provider = $permissions_provider;
 	}
 
@@ -92,7 +92,7 @@ class Zoninator_REST_Model_Definition_Builder implements Zoninator_REST_Interfac
 	 *
 	 * @return Zoninator_REST_Model_Definition_Builder $this
 	 */
-	function with_environment( $environment ) {
+	public function with_environment( $environment ) {
 		$this->environment = $environment;
 		return $this;
 	}
@@ -102,7 +102,7 @@ class Zoninator_REST_Model_Definition_Builder implements Zoninator_REST_Interfac
 	 *
 	 * @return Zoninator_REST_Model_Definition
 	 */
-	function build() {
+	public function build() {
 		return new Zoninator_REST_Model_Definition( $this->environment, $this->declaration, $this->data_store, $this->permissions_provider );
 	}
 }

--- a/lib/zoninator_rest/model/definition/class-zoninator-rest-model-definition-builder.php
+++ b/lib/zoninator_rest/model/definition/class-zoninator-rest-model-definition-builder.php
@@ -19,18 +19,21 @@ class Zoninator_REST_Model_Definition_Builder implements Zoninator_REST_Interfac
 	 * @var Zoninator_REST_Interfaces_Model_Declaration
 	 */
 	private $declaration;
+
 	/**
 	 * Data Store
 	 *
 	 * @var Zoninator_REST_Interfaces_Data_Store
 	 */
 	private $data_store;
+
 	/**
 	 * Environment
 	 *
 	 * @var Zoninator_REST_Environment
 	 */
 	private $environment;
+
 	/**
 	 * Permissions Provider
 	 *
@@ -56,11 +59,13 @@ class Zoninator_REST_Model_Definition_Builder implements Zoninator_REST_Interfac
 		if ( is_string( $declaration ) && class_exists( $declaration ) ) {
 			$declaration = new $declaration();
 		}
+
 		Zoninator_REST_Expect::is_a( $declaration, 'Zoninator_REST_Interfaces_Model_Declaration' );
 		$this->declaration = $declaration;
 		if ( is_a( $declaration, 'Zoninator_REST_Interfaces_Permissions_Provider' ) ) {
 			$this->with_permissions_provider( $declaration );
 		}
+
 		return $this;
 	}
 

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-boolean.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-boolean.php
@@ -40,6 +40,7 @@ class Zoninator_REST_Type_Boolean extends Zoninator_REST_Type {
 		if ( 'false' === $value ) {
 			return false;
 		}
+
 		return (bool) $value;
 	}
 }

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-integer.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-integer.php
@@ -50,6 +50,7 @@ class Zoninator_REST_Type_Integer extends Zoninator_REST_Type {
 		if ( ! is_numeric( $value ) ) {
 			return $this->default_value();
 		}
+
 		return $this->unsigned ? absint( $value ) : intval( $value, 10 );
 	}
 

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-integer.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-integer.php
@@ -59,7 +59,7 @@ class Zoninator_REST_Type_Integer extends Zoninator_REST_Type {
 	 * @param mixed $value Val.
 	 * @return int
 	 */
-	function sanitize( $value ) {
+	public function sanitize( $value ) {
 		return $this->cast( $value );
 	}
 }

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-nullable.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-nullable.php
@@ -47,6 +47,7 @@ class Zoninator_REST_Type_Nullable extends Zoninator_REST_Type {
 		if ( null === $value ) {
 			return null;
 		}
+
 		return $this->item_type_definition->cast( $value );
 	}
 
@@ -60,6 +61,7 @@ class Zoninator_REST_Type_Nullable extends Zoninator_REST_Type {
 		if ( null === $value ) {
 			return null;
 		}
+
 		return $this->item_type_definition->sanitize( $value );
 	}
 

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-nullable.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-nullable.php
@@ -25,7 +25,7 @@ class Zoninator_REST_Type_Nullable extends Zoninator_REST_Type {
 	 *
 	 * @param Zoninator_REST_Interfaces_Type $item_type_definition Def.
 	 */
-	function __construct( $item_type_definition ) {
+	public function __construct( $item_type_definition ) {
 		parent::__construct( 'nullable:' . $item_type_definition->name() );
 		$this->item_type_definition = $item_type_definition;
 	}
@@ -66,7 +66,7 @@ class Zoninator_REST_Type_Nullable extends Zoninator_REST_Type {
 	/**
 	 * Schema
 	 */
-	function schema() {
+	public function schema() {
 		$schema         = parent::schema();
 		$schema['type'] = array_unique( array_merge( $schema['type'], array( 'null' ) ) );
 	}

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-nullable.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-nullable.php
@@ -32,8 +32,6 @@ class Zoninator_REST_Type_Nullable extends Zoninator_REST_Type {
 
 	/**
 	 * Default value as always null.
-	 *
-	 * @return null
 	 */
 	public function default_value() {
 		return null;

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-nullable.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-nullable.php
@@ -69,7 +69,7 @@ class Zoninator_REST_Type_Nullable extends Zoninator_REST_Type {
 	 * Schema
 	 */
 	function schema() {
-		$schema = parent::schema();
+		$schema         = parent::schema();
 		$schema['type'] = array_unique( array_merge( $schema['type'], array( 'null' ) ) );
 	}
 }

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-number.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-number.php
@@ -40,6 +40,7 @@ class Zoninator_REST_Type_Number extends Zoninator_REST_Type {
 		if ( ! is_numeric( $value ) ) {
 			return $this->default_value();
 		}
+
 		return floatval( $value );
 	}
 

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-number.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-number.php
@@ -17,7 +17,7 @@ class Zoninator_REST_Type_Number extends Zoninator_REST_Type {
 	/**
 	 * Zoninator_REST_Type_Number constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		parent::__construct( 'number' );
 	}
 
@@ -26,7 +26,7 @@ class Zoninator_REST_Type_Number extends Zoninator_REST_Type {
 	 *
 	 * @return float
 	 */
-	function default_value() {
+	public function default_value() {
 		return 0.0;
 	}
 
@@ -36,7 +36,7 @@ class Zoninator_REST_Type_Number extends Zoninator_REST_Type {
 	 * @param mixed $value The thing to cast.
 	 * @return float
 	 */
-	function cast( $value ) {
+	public function cast( $value ) {
 		if ( ! is_numeric( $value ) ) {
 			return $this->default_value();
 		}
@@ -49,7 +49,7 @@ class Zoninator_REST_Type_Number extends Zoninator_REST_Type {
 	 * @param mixed $value The value to sanitize.
 	 * @return float
 	 */
-	function sanitize( $value ) {
+	public function sanitize( $value ) {
 		return $this->cast( $value );
 	}
 }

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php
@@ -33,7 +33,7 @@ class Zoninator_REST_Type_Registry {
 	/**
 	 * Define a new type
 	 *
-	 * @param string             $identifier The Identifier.
+	 * @param string                         $identifier The Identifier.
 	 * @param Zoninator_REST_Interfaces_Type $instance The type instance.
 	 *
 	 * @return Zoninator_REST_Type_Registry $this
@@ -61,7 +61,6 @@ class Zoninator_REST_Type_Registry {
 			// maybe lazy-register missing compound type.
 			$parts = explode( ':', $type );
 			if ( count( $parts ) > 1 ) {
-
 				$container_type = $parts[0];
 				if ( ! in_array( $container_type, $this->container_types, true ) ) {
 					throw new Zoninator_REST_Exception( $container_type . ' is not a known container type' );
@@ -110,16 +109,21 @@ class Zoninator_REST_Type_Registry {
 			return;
 		}
 
-		$this->types = apply_filters( 'mixtape_type_registry_register_types', array(
-			'any'           => new Zoninator_REST_Type( 'any' ),
-			'string'        => new Zoninator_REST_Type_String(),
-			'integer'       => new Zoninator_REST_Type_Integer(),
-			'int'           => new Zoninator_REST_Type_Integer(),
-			'uint'          => new Zoninator_REST_Type_Integer( true ),
-			'number'        => new Zoninator_REST_Type_Number(),
-			'float'         => new Zoninator_REST_Type_Number(),
-			'boolean'       => new Zoninator_REST_Type_Boolean(),
-			'array'         => new Zoninator_REST_Type_Array(),
-		), $this, $environment );
+		$this->types = apply_filters(
+			'mixtape_type_registry_register_types',
+			array(
+				'any'     => new Zoninator_REST_Type( 'any' ),
+				'string'  => new Zoninator_REST_Type_String(),
+				'integer' => new Zoninator_REST_Type_Integer(),
+				'int'     => new Zoninator_REST_Type_Integer(),
+				'uint'    => new Zoninator_REST_Type_Integer( true ),
+				'number'  => new Zoninator_REST_Type_Number(),
+				'float'   => new Zoninator_REST_Type_Number(),
+				'boolean' => new Zoninator_REST_Type_Boolean(),
+				'array'   => new Zoninator_REST_Type_Array(),
+			),
+			$this,
+			$environment 
+		);
 	}
 }

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php
@@ -28,7 +28,7 @@ class Zoninator_REST_Type_Registry {
 	 *
 	 * @var null|array
 	 */
-	private $types = null;
+	private $types;
 
 	/**
 	 * Define a new type

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php
@@ -54,7 +54,7 @@ class Zoninator_REST_Type_Registry {
 	 *
 	 * @throws Zoninator_REST_Exception In case of type name not confirming to syntax.
 	 */
-	function definition( $type ) {
+	public function definition( $type ) {
 		$types = $this->get_types();
 
 		if ( ! isset( $types[ $type ] ) ) {

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php
@@ -70,6 +70,7 @@ class Zoninator_REST_Type_Registry {
 				if ( empty( $item_type ) ) {
 					throw new Zoninator_REST_Exception( $type . ': invalid syntax' );
 				}
+
 				$item_type_definition = $this->definition( $item_type );
 
 				if ( 'array' === $container_type ) {
@@ -87,6 +88,7 @@ class Zoninator_REST_Type_Registry {
 		if ( ! isset( $types[ $type ] ) ) {
 			throw new Zoninator_REST_Exception();
 		}
+
 		return $types[ $type ];
 	}
 

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-string.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-string.php
@@ -51,8 +51,10 @@ class Zoninator_REST_Type_String extends Zoninator_REST_Type {
 			foreach ( $value as $v ) {
 				$cast_ones[] = $this->cast( $v );
 			}
+
 			return '(' . implode( ',', $cast_ones ) . ')';
 		}
+
 		return (string) $value;
 	}
 }

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-string.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-string.php
@@ -16,7 +16,7 @@ class Zoninator_REST_Type_String extends Zoninator_REST_Type {
 	/**
 	 * Zoninator_REST_Type_String constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		parent::__construct( 'string' );
 	}
 
@@ -26,7 +26,7 @@ class Zoninator_REST_Type_String extends Zoninator_REST_Type {
 	 * @param mixed $value Val.
 	 * @return string
 	 */
-	function sanitize( $value ) {
+	public function sanitize( $value ) {
 		return sanitize_text_field( $value );
 	}
 
@@ -35,7 +35,7 @@ class Zoninator_REST_Type_String extends Zoninator_REST_Type {
 	 *
 	 * @return string
 	 */
-	function default_value() {
+	public function default_value() {
 		return '';
 	}
 
@@ -45,7 +45,7 @@ class Zoninator_REST_Type_String extends Zoninator_REST_Type {
 	 * @param mixed $value Val.
 	 * @return string
 	 */
-	function cast( $value ) {
+	public function cast( $value ) {
 		if ( is_array( $value ) ) {
 			$cast_ones = array();
 			foreach ( $value as $v ) {

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-typedarray.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-typedarray.php
@@ -63,8 +63,8 @@ class Zoninator_REST_Type_TypedArray extends Zoninator_REST_Type {
 	 * @return array
 	 */
 	function schema() {
-		$schema = parent::schema();
-		$schema['type'] = 'array';
+		$schema          = parent::schema();
+		$schema['type']  = 'array';
 		$schema['items'] = $this->item_type_definition->schema();
 		return $schema;
 	}

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-typedarray.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-typedarray.php
@@ -28,7 +28,7 @@ class Zoninator_REST_Type_TypedArray extends Zoninator_REST_Type {
 	 *
 	 * @param Zoninator_REST_Interfaces_Type $item_type_definition The type.
 	 */
-	function __construct( $item_type_definition ) {
+	public function __construct( $item_type_definition ) {
 		parent::__construct( 'array:' . $item_type_definition->name() );
 		$this->item_type_definition = $item_type_definition;
 	}
@@ -62,7 +62,7 @@ class Zoninator_REST_Type_TypedArray extends Zoninator_REST_Type {
 	 *
 	 * @return array
 	 */
-	function schema() {
+	public function schema() {
 		$schema          = parent::schema();
 		$schema['type']  = 'array';
 		$schema['items'] = $this->item_type_definition->schema();

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-typedarray.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-typedarray.php
@@ -54,7 +54,7 @@ class Zoninator_REST_Type_TypedArray extends Zoninator_REST_Type {
 		foreach ( $value as $v ) {
 			$new_value[] = $this->item_type_definition->cast( $v );
 		}
-		return (array) $new_value;
+		return $new_value;
 	}
 
 	/**

--- a/lib/zoninator_rest/type/class-zoninator-rest-type-typedarray.php
+++ b/lib/zoninator_rest/type/class-zoninator-rest-type-typedarray.php
@@ -54,6 +54,7 @@ class Zoninator_REST_Type_TypedArray extends Zoninator_REST_Type {
 		foreach ( $value as $v ) {
 			$new_value[] = $this->item_type_definition->cast( $v );
 		}
+
 		return $new_value;
 	}
 

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+	->withPaths(
+		array(
+			__DIR__ . '/includes',
+			__DIR__ . '/lib',
+			__DIR__ . '/tests',
+			__DIR__ . '/functions.php',
+			__DIR__ . '/widget.zone-posts.php',
+			__DIR__ . '/zoninator.php',
+		)
+	)
+	->withSkip(
+		array(
+			LongArrayToShortArrayRector::class,
+		)
+	)
+	->withPhpSets( php53: true )
+	->withTypeCoverageLevel( 0 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 13 )
+	->withCodeQualityLevel( 18 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 25 )
+	->withCodeQualityLevel( 29 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -31,7 +31,6 @@ return RectorConfig::configure()
 			MakeInheritedMethodVisibilitySameAsParentRector::class,
 			NewlineAfterStatementRector::class,
 			SymplifyQuoteEscapeRector::class,
-			ExplicitPublicClassMethodRector::class,
 		)
 	)
 	->withPhpSets( php74: true )

--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
-use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
 	->withPaths(
@@ -22,5 +21,5 @@ return RectorConfig::configure()
 			LongArrayToShortArrayRector::class,
 		)
 	)
-	->withPhpSets( php73: true )
+	->withPhpSets( php74: true )
 	->withTypeCoverageLevel( 0 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 21 )
+	->withDeadCodeLevel( 26 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 39 )
+	->withCodeQualityLevel( 48 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 22 )
+	->withCodeQualityLevel( 24 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 29 )
+	->withCodeQualityLevel( 34 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 			LongArrayToShortArrayRector::class,
 		)
 	)
-	->withPhpSets( php55: true )
+	->withPhpSets( php70: true )
 	->withTypeCoverageLevel( 0 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 1 )
+	->withDeadCodeLevel( 2 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 35 )
+	->withCodeQualityLevel( 38 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 19 )
+	->withDeadCodeLevel( 21 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 11 )
+	->withCodeQualityLevel( 13 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 			LongArrayToShortArrayRector::class,
 		)
 	)
-	->withPhpSets( php53: true )
+	->withPhpSets( php55: true )
 	->withTypeCoverageLevel( 0 );

--- a/rector.php
+++ b/rector.php
@@ -2,9 +2,13 @@
 
 declare(strict_types=1);
 
+use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
+use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
+use Rector\CodingStyle\Rector\String_\SymplifyQuoteEscapeRector;
 use Rector\Config\RectorConfig;
 use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
+use Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector;
 
 return RectorConfig::configure()
 	->withPaths(
@@ -24,9 +28,12 @@ return RectorConfig::configure()
 			DisallowedEmptyRuleFixerRector::class => array(
 				__DIR__ . '/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php',
 			),
+			MakeInheritedMethodVisibilitySameAsParentRector::class,
+			NewlineAfterStatementRector::class,
+			SymplifyQuoteEscapeRector::class,
+			ExplicitPublicClassMethodRector::class,
 		)
 	)
 	->withPhpSets( php74: true )
-	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 70 )
+	->withPreparedSets( deadCode: true, codeQuality: true, instanceOf: true, codingStyle: true )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 14 )
+	->withDeadCodeLevel( 19 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -3,12 +3,9 @@
 declare(strict_types=1);
 
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
-use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
-use Rector\CodingStyle\Rector\String_\SymplifyQuoteEscapeRector;
 use Rector\Config\RectorConfig;
 use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
-use Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector;
 
 return RectorConfig::configure()
 	->withPaths(
@@ -28,8 +25,10 @@ return RectorConfig::configure()
 			DisallowedEmptyRuleFixerRector::class => array(
 				__DIR__ . '/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php',
 			),
+			// Child classes can legitimately relax the visibility of a method, so while this
+			// might not be desirable, changing them from public to the original parent-defined
+			// protected would count as a breaking change.
 			MakeInheritedMethodVisibilitySameAsParentRector::class,
-			NewlineAfterStatementRector::class,
 		)
 	)
 	->withPhpSets( php74: true )

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 40 )
+	->withDeadCodeLevel( 41 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 
 return RectorConfig::configure()
 	->withPaths(
@@ -19,9 +20,13 @@ return RectorConfig::configure()
 	->withSkip(
 		array(
 			LongArrayToShortArrayRector::class,
+			// Need a better understanding of intent in this file before switching out the use of empty().
+			DisallowedEmptyRuleFixerRector::class => array(
+				__DIR__ . '/lib/zoninator_rest/type/class-zoninator-rest-type-registry.php',
+			),
 		)
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 65 )
+	->withCodeQualityLevel( 70 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 18 )
+	->withCodeQualityLevel( 22 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 41 )
+	->withDeadCodeLevel( 44 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,4 +22,4 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withTypeCoverageLevel( 0 );
+	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 2 )
+	->withDeadCodeLevel( 7 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,6 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 44 )
+	->withPreparedSets( deadCode: true )
+	->withCodeQualityLevel( 11 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,4 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
+	->withDeadCodeLevel( 1 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 57 )
+	->withCodeQualityLevel( 65 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -30,7 +30,6 @@ return RectorConfig::configure()
 			),
 			MakeInheritedMethodVisibilitySameAsParentRector::class,
 			NewlineAfterStatementRector::class,
-			SymplifyQuoteEscapeRector::class,
 		)
 	)
 	->withPhpSets( php74: true )

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 26 )
+	->withDeadCodeLevel( 40 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 			LongArrayToShortArrayRector::class,
 		)
 	)
-	->withPhpSets( php71: true )
+	->withPhpSets( php73: true )
 	->withTypeCoverageLevel( 0 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 24 )
+	->withCodeQualityLevel( 25 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 51 )
+	->withCodeQualityLevel( 57 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 48 )
+	->withCodeQualityLevel( 51 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 			LongArrayToShortArrayRector::class,
 		)
 	)
-	->withPhpSets( php70: true )
+	->withPhpSets( php71: true )
 	->withTypeCoverageLevel( 0 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 38 )
+	->withCodeQualityLevel( 39 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -22,5 +22,5 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
-	->withDeadCodeLevel( 7 )
+	->withDeadCodeLevel( 14 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -23,5 +23,5 @@ return RectorConfig::configure()
 	)
 	->withPhpSets( php74: true )
 	->withPreparedSets( deadCode: true )
-	->withCodeQualityLevel( 34 )
+	->withCodeQualityLevel( 35 )
 	->withTypeCoverageLevel( 1 );

--- a/rector.php
+++ b/rector.php
@@ -2,9 +2,19 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
+use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
 use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+use Rector\Php80\Rector\Identical\StrEndsWithRector;
+use Rector\Php80\Rector\Identical\StrStartsWithRector;
+use Rector\Php80\Rector\NotIdentical\StrContainsRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\Php82\Rector\Encapsed\VariableInStringInterpolationFixerRector;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 
 return RectorConfig::configure()
@@ -32,5 +42,30 @@ return RectorConfig::configure()
 		)
 	)
 	->withPhpSets( php74: true )
+	// Changes from later PHP Sets that are backwards compatible:
+	->withRules(
+		array(
+			// 8.0
+			ConsistentImplodeRector::class,
+			OptionalParametersAfterRequiredRector::class,
+			RemoveParentCallWithoutParentRector::class,
+			// Backfilled from PHP 8.0 into WP 5.9, so these can be used.
+			StrContainsRector::class,
+			StrEndsWithRector::class,
+			StrStartsWithRector::class,
+
+			// 8.1
+			NullToStrictStringFuncCallArgRector::class,
+
+			// 8.2
+			VariableInStringInterpolationFixerRector::class,
+
+			// 8.3
+			AddOverrideAttributeToOverriddenMethodsRector::class,
+
+			// 8.4
+			ExplicitNullableParamTypeRector::class,
+		)
+	)
 	->withPreparedSets( deadCode: true, codeQuality: true, instanceOf: true, codingStyle: true )
 	->withTypeCoverageLevel( 1 );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,7 @@ $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
+
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	echo sprintf('Could not find %s/includes/functions.php, have you run bin/install-wp-tests.sh ?', $_tests_dir) . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );
@@ -16,6 +17,7 @@ function _manually_load_plugin(): void {
 	$file = $thispath . '/../zoninator.php';
 	require_once realpath( $file );
 }
+
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,7 +12,7 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
-	$thispath = dirname( __FILE__ );
+	$thispath = __DIR__;
 	$file = $thispath . '/../zoninator.php';
 	require_once realpath( $file );
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo sprintf('Could not find %s/includes/functions.php, have you run bin/install-wp-tests.sh ?', $_tests_dir) . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,7 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 
 require_once $_tests_dir . '/includes/functions.php';
 
-function _manually_load_plugin() {
+function _manually_load_plugin(): void {
 	$thispath = __DIR__;
 	$file = $thispath . '/../zoninator.php';
 	require_once realpath( $file );

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -97,6 +97,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		foreach ( $args as $key => $value ) {
 			$request->set_param( $key, $value );
 		}
+
 		return $this->rest_server->dispatch( $request );
 	}
 
@@ -390,6 +391,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		if ( is_wp_error( $insert ) ) {
 			throw new Exception( 'Error' );
 		}
+
 		return $insert;
 	}
 
@@ -398,6 +400,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+
 		return $result['term_id'] ?? 0;
 	}
 

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -425,11 +425,10 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 */
 	private function add_a_zone( $slug = 'zone-1' ) {
 		$term_factory = new WP_UnitTest_Factory_For_Term(null, Zoninator()->zone_taxonomy);
-		$zone_id = $term_factory->create_object(array(
+		return $term_factory->create_object(array(
 			'name' => 'The Zone Add Post one ' . rand_str(),
 			'description' => 'Zone ' . rand_str(),
 			'slug' => $slug,
 		));
-		return $zone_id;
 	}
 }

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -413,7 +413,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		return isset( $result['term_id'] ) ? $result['term_id'] : 0;
+		return $result['term_id'] ?? 0;
 	}
 
 	/**

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -3,25 +3,11 @@
 class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 
 	/**
-	 * The Mighty Zoninator!
-	 *
-	 * @var Zoninator
-	 */
-	private $_zoninator;
-
-	/**
 	 * REST Server
 	 *
 	 * @var WP_REST_Server
 	 */
 	protected $rest_server;
-
-	/**
-	 * Post ID
-	 *
-	 * @var int
-	 */
-	private $_post_id = 0;
 
 	/**
 	 * Admin ID
@@ -171,7 +157,6 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		global $wp_rest_server;
 		$this->rest_server = new Spy_REST_Server;
 		$wp_rest_server = $this->rest_server;
-		$this->_zoninator = Zoninator();
 		$admin = get_user_by( 'email', 'rest_api_admin_user@test.com' );
 		if ( false === $admin ) {
 			$this->admin_id = wp_create_user(

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -7,7 +7,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @var Zoninator
 	 */
-	private $_zoninator = null;
+	private $_zoninator;
 
 	/**
 	 * REST Server

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -305,7 +305,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 */
 	function test_update_zone_posts_fails_if_invalid_data() {
 		$this->login_as_admin();
-		$post_id = $this->_insert_a_post();
+		$this->_insert_a_post();
 		$zone_id = $this->create_a_zone( 'test-zone', 'Test Zone' );
 		$response = $this->put( '/zoninator/v1/zones/' . $zone_id . '/posts', array() );
 		$this->assertResponseStatus( $response, 400 );
@@ -318,7 +318,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 */
 	function test_update_zone_posts_fails_if_invalid_post_id() {
 		$this->login_as_admin();
-		$post_id = $this->_insert_a_post();
+		$this->_insert_a_post();
 		$zone_id = $this->create_a_zone( 'test-zone', 'Test Zone' );
 		$response = $this->put( '/zoninator/v1/zones/' . $zone_id . '/posts', array(
 			'post_ids' => array( 123456789 ),

--- a/tests/unit/class-zoninator-api-controller-test.php
+++ b/tests/unit/class-zoninator-api-controller-test.php
@@ -22,7 +22,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param WP_REST_Response $response Response.
 	 * @param int              $status_code Code.
 	 */
-	function assert_response_status( $response, $status_code ) {
+	public function assert_response_status( $response, $status_code ) {
 		$this->assertEquals( $status_code, $response->get_status() );
 	}
 
@@ -31,7 +31,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @return Zoninator_Api_Controller_Test
 	 */
-	function login_as_admin() {
+	public function login_as_admin() {
 		return $this->login_as( $this->admin_id );
 	}
 
@@ -41,7 +41,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param int $user_id U.
 	 * @return Zoninator_Api_Controller_Test $this
 	 */
-	function login_as( $user_id ) {
+	public function login_as( $user_id ) {
 		wp_set_current_user( $user_id );
 		return $this;
 	}
@@ -51,7 +51,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param WP_REST_Response $response Response.
 	 */
-	function assert_http_response_status_success( $response ) {
+	public function assert_http_response_status_success( $response ) {
 		$this->assert_response_status( $response, MT_Controller::HTTP_OK );
 	}
 
@@ -60,7 +60,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param WP_REST_Response $response Response.
 	 */
-	function assert_http_response_status_created( $response ) {
+	public function assert_http_response_status_created( $response ) {
 		$this->assert_response_status( $response, MT_Controller::HTTP_CREATED );
 	}
 
@@ -69,7 +69,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param WP_REST_Response $response Response.
 	 */
-	function assert_http_response_status_not_found( $response ) {
+	public function assert_http_response_status_not_found( $response ) {
 		$this->assert_response_status( $response, MT_Controller::HTTP_NOT_FOUND );
 	}
 
@@ -79,7 +79,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param WP_REST_Response $response The Response.
 	 * @param int              $status_code Expected status code.
 	 */
-	function assertResponseStatus( $response, $status_code ) {
+	public function assertResponseStatus( $response, $status_code ) {
 		$this->assertInstanceOf( 'WP_REST_Response', $response );
 		$this->assertEquals( $status_code, $response->get_status() );
 	}
@@ -92,7 +92,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	function request( $endpoint, $method, $args = array() ) {
+	public function request( $endpoint, $method, $args = array() ) {
 		$request = new WP_REST_Request( $method, $endpoint );
 		foreach ( $args as $key => $value ) {
 			$request->set_param( $key, $value );
@@ -107,7 +107,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	function get( $endpoint, $args = array() ) {
+	public function get( $endpoint, $args = array() ) {
 		return $this->request( $endpoint, 'GET', $args );
 	}
 
@@ -118,7 +118,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	function post( $endpoint, $args = array() ) {
+	public function post( $endpoint, $args = array() ) {
 		return $this->request( $endpoint, 'POST', $args );
 	}
 
@@ -129,7 +129,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	function put( $endpoint, $args = array() ) {
+	public function put( $endpoint, $args = array() ) {
 		return $this->request( $endpoint, 'PUT', $args );
 	}
 
@@ -140,14 +140,14 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param array  $args Any Data/Args.
 	 * @return WP_REST_Response
 	 */
-	function delete( $endpoint, $args = array() ) {
+	public function delete( $endpoint, $args = array() ) {
 		return $this->request( $endpoint, 'DELETE', $args );
 	}
 
 	/**
 	 * Setup
 	 */
-	function setUp(): void {
+	public function setUp(): void {
 		parent::setUp();
 		/**
 		 *The global
@@ -180,7 +180,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_create_zone_responds_with_created_when_method_post() {
+	public function test_create_zone_responds_with_created_when_method_post() {
 		$this->login_as_admin();
 		$response = $this->post( '/zoninator/v1/zones', array(
 			'slug' => 'test-zone',
@@ -193,7 +193,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_create_zone_fail_if_invalid_data() {
+	public function test_create_zone_fail_if_invalid_data() {
 		$this->login_as_admin();
 		$response = $this->post( '/zoninator/v1/zones', array(
 			'description' => 'No slug provided.'
@@ -206,7 +206,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E
 	 */
-	function test_create_zone_with_special_chars() {
+	public function test_create_zone_with_special_chars() {
 		$this->login_as_admin();
 		$response = $this->post( '/zoninator/v1/zones', array(
 			'name' => '&<>!@#(',
@@ -224,7 +224,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_update_zone_responds_with_success_when_method_put() {
+	public function test_update_zone_responds_with_success_when_method_put() {
 		$this->login_as_admin();
 		$zone_id = $this->create_a_zone( 'test-update-zone', 'Test Zone' );
 		$response = $this->put( '/zoninator/v1/zones/' . $zone_id, array(
@@ -238,7 +238,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_update_zone_responds_with_not_found_if_zone_not_exist() {
+	public function test_update_zone_responds_with_not_found_if_zone_not_exist() {
 		$this->login_as_admin();
 		$response = $this->put( '/zoninator/v1/zones/666666', array(
 			'name' => 'Other test zone',
@@ -251,7 +251,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_delete_zone_responds_with_success_when_method_delete() {
+	public function test_delete_zone_responds_with_success_when_method_delete() {
 		$this->login_as_admin();
 		$zone_id = $this->create_a_zone( 'test-update-zone', 'Test Zone' );
 		$response = $this->delete( '/zoninator/v1/zones/' . $zone_id );
@@ -263,7 +263,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_delete_zone_responds_with_not_found_if_zone_not_exist() {
+	public function test_delete_zone_responds_with_not_found_if_zone_not_exist() {
 		$this->login_as_admin();
 		$response = $this->delete( '/zoninator/v1/zones/666666' );
 		$this->assertResponseStatus( $response, 404 );
@@ -274,7 +274,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_update_zone_posts_responds_with_success_when_method_put() {
+	public function test_update_zone_posts_responds_with_success_when_method_put() {
 		$this->login_as_admin();
 		$post_id = $this->_insert_a_post();
 		$zone_id = $this->create_a_zone( 'test-zone', 'Test Zone' );
@@ -289,7 +289,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_update_zone_posts_responds_with_not_found_if_zone_not_exist() {
+	public function test_update_zone_posts_responds_with_not_found_if_zone_not_exist() {
 		$this->login_as_admin();
 		$post_id = $this->_insert_a_post();
 		$response = $this->put( '/zoninator/v1/zones/666666/posts', array(
@@ -303,7 +303,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_update_zone_posts_fails_if_invalid_data() {
+	public function test_update_zone_posts_fails_if_invalid_data() {
 		$this->login_as_admin();
 		$this->_insert_a_post();
 		$zone_id = $this->create_a_zone( 'test-zone', 'Test Zone' );
@@ -316,7 +316,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_update_zone_posts_fails_if_invalid_post_id() {
+	public function test_update_zone_posts_fails_if_invalid_post_id() {
 		$this->login_as_admin();
 		$this->_insert_a_post();
 		$zone_id = $this->create_a_zone( 'test-zone', 'Test Zone' );
@@ -331,7 +331,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @throws Exception E.
 	 */
-	function test_get_zone_posts_success_when_valid_zone_and_posts() {
+	public function test_get_zone_posts_success_when_valid_zone_and_posts() {
 		$this->login_as_admin();
 		self::factory()->post->create_many( 5 );
 		$query = new WP_Query();
@@ -349,7 +349,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Test test_get_zone_posts_success_when_no_posts_in_zone
 	 */
-	function test_get_zone_posts_success_when_no_posts_in_zone() {
+	public function test_get_zone_posts_success_when_no_posts_in_zone() {
 		$term_factory = new WP_UnitTest_Factory_For_Term( null, Zoninator()->zone_taxonomy );
 		$zone_id = $term_factory->create_object( array(
 			'name' => 'The Zone Add Post one',
@@ -364,7 +364,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Test test_get_zone_posts_not_found_when_invalid_zone
 	 */
-	function test_get_zone_posts_not_found_when_invalid_zone() {
+	public function test_get_zone_posts_not_found_when_invalid_zone() {
 		$term_factory = new WP_UnitTest_Factory_For_Term( null, Zoninator()->zone_taxonomy );
 		$zone_id = $term_factory->create_object( array(
 			'name' => 'The Zone Add Post one',

--- a/widget.zone-posts.php
+++ b/widget.zone-posts.php
@@ -38,7 +38,7 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 
 		ob_start();
 
-		$zone_id          = $instance['zone_id'] ? $instance['zone_id'] : 0;
+		$zone_id          = $instance['zone_id'] ?: 0;
 		$show_description = $instance['show_description'] ? 1 : 0;
 		if ( ! $zone_id ) {
 			return;

--- a/widget.zone-posts.php
+++ b/widget.zone-posts.php
@@ -5,7 +5,7 @@
  */
 class Zoninator_ZonePosts_Widget extends WP_Widget {
 
-	function __construct() {
+	public function __construct() {
 		$widget_ops = array(
 			'classname'   => 'widget-zone-posts',
 			'description' => __( 'Use this widget to display a list of posts from any zone.', 'zoninator' ),
@@ -23,7 +23,7 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 		);
 	}
 
-	function widget( $args, $instance ) {
+	public function widget( $args, $instance ) {
 		$cache_key = 'widget-zone-posts';
 		$cache     = wp_cache_get( $cache_key, 'widget' );
 
@@ -85,7 +85,7 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 		wp_cache_set( 'widget-zone-posts', $cache, 'widget' );
 	}
 
-	function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) {
 		$instance                     = $old_instance;
 		$new_instance                 = wp_parse_args(
 			(array) $new_instance,
@@ -105,7 +105,7 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 		return $instance;
 	}
 
-	function flush_widget_cache() {
+	public function flush_widget_cache() {
 		$cache_key = 'widget-zone-posts';
 
 		$block_save_cache_seconds = absint( apply_filters( 'zone_posts_widget_block_save_cache_seconds', 5 ) );
@@ -117,7 +117,7 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 		wp_cache_delete( $cache_key, 'widget' );
 	}
 
-	function form( $instance ) {
+	public function form( $instance ) {
 		// select - zone
 		// checkbox - show description
 		$zones = z_get_zones();

--- a/widget.zone-posts.php
+++ b/widget.zone-posts.php
@@ -7,8 +7,8 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 
 	function __construct() {
 		$widget_ops = array(
-			'classname' => 'widget-zone-posts',
-			'description' => __( 'Use this widget to display a list of posts from any zone.', 'zoninator' )
+			'classname'   => 'widget-zone-posts',
+			'description' => __( 'Use this widget to display a list of posts from any zone.', 'zoninator' ),
 		);
 
 		$this->alt_option_name = 'widget_zone_posts';
@@ -25,10 +25,11 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 
 	function widget( $args, $instance ) {
 		$cache_key = 'widget-zone-posts';
-		$cache = wp_cache_get( $cache_key, 'widget' );
+		$cache     = wp_cache_get( $cache_key, 'widget' );
 
-		if ( ! is_array( $cache ) )
+		if ( ! is_array( $cache ) ) {
 			$cache = array();
+		}
 
 		if ( isset( $cache[ $args['widget_id'] ] ) ) {
 			echo $cache[ $args['widget_id'] ];
@@ -39,16 +40,19 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 
 		$zone_id          = $instance['zone_id'] ? $instance['zone_id'] : 0;
 		$show_description = $instance['show_description'] ? 1 : 0;
-		if ( ! $zone_id )
+		if ( ! $zone_id ) {
 			return;
+		}
 
 		$zone = z_get_zone( $zone_id );
-		if ( ! $zone )
+		if ( ! $zone ) {
 			return;
+		}
 
 		$posts = z_get_posts_in_zone( $zone_id );
-		if ( empty( $posts ) )
+		if ( empty( $posts ) ) {
 			return;
+		}
 
 		?>
 		<?php echo wp_kses_post( $args['before_widget'] ); ?>
@@ -82,14 +86,21 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 	}
 
 	function update( $new_instance, $old_instance ) {
-		$instance     = $old_instance;
-		$new_instance = wp_parse_args( (array) $new_instance, array( 'zone_id' => 0, 'show_description' => 0 ) );
+		$instance                     = $old_instance;
+		$new_instance                 = wp_parse_args(
+			(array) $new_instance,
+			array(
+				'zone_id'          => 0,
+				'show_description' => 0,
+			) 
+		);
 		$instance['zone_id']          = absint( $new_instance['zone_id'] );
 		$instance['show_description'] = $new_instance['show_description'] ? 1 : 0;
 		$this->flush_widget_cache();
 		$alloptions = wp_cache_get( 'alloptions', 'options' );
-		if ( isset( $alloptions['widget-zone-posts'] ) )
+		if ( isset( $alloptions['widget-zone-posts'] ) ) {
 			delete_option( 'widget-zone-posts' );
+		}
 
 		return $instance;
 	}
@@ -140,6 +151,6 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 				<?php esc_html_e( 'Show zone description in widget', 'zoninator' ); ?>
 			</label>
 		</p>
-	<?php
+		<?php
 	}
 }

--- a/widget.zone-posts.php
+++ b/widget.zone-posts.php
@@ -61,7 +61,9 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 
 		<?php if ( ! empty( $zone->description ) && $show_description ) : ?>
 			<p class="description"><?php echo esc_html( $zone->description ); ?></p>
-		<?php endif; ?>
+			<?php
+		endif;
+		?>
 
 		<ul>
 			<?php foreach ( $posts as $post ) : ?>
@@ -70,7 +72,9 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 						<?php echo esc_html( get_the_title( $post->ID ) ); ?>
 					</a>
 				</li>
-			<?php endforeach; ?>
+				<?php
+			endforeach;
+			?>
 		</ul>
 
 		<?php echo wp_kses_post( $args['after_widget'] ); ?>
@@ -82,6 +86,7 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 			// Save is blocked while the cache flush is in progress.
 			return;
 		}
+
 		wp_cache_set( 'widget-zone-posts', $cache, 'widget' );
 	}
 
@@ -141,7 +146,9 @@ class Zoninator_ZonePosts_Widget extends WP_Widget {
 					<option value="<?php echo $zone->term_id; ?>" <?php selected( $zone_id, $zone->term_id ); ?>>
 						<?php echo esc_html( $zone->name ); ?>
 					</option>
-				<?php endforeach; ?>
+					<?php
+				endforeach;
+				?>
 			</select>
 		</p>
 

--- a/zoninator.php
+++ b/zoninator.php
@@ -485,7 +485,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				</div>
 
 				<div class="col-wrap zone-col zone-posts-col">
-					<div class="zone-posts-wrapper <?php echo ! $this->_current_user_can_manage_zones( $zone_id ) || $zone_locked ? 'readonly' : ''; ?>">
+					<div class="zone-posts-wrapper <?php echo ! $this->_current_user_can_manage_zones() || $zone_locked ? 'readonly' : ''; ?>">
 						<?php if ( $zone_id ) : ?>
 							<h3><?php esc_html_e( 'Zone Content', 'zoninator' ); ?></h3>
 
@@ -1518,7 +1518,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				if ( is_wp_error( $results ) ) {
 					self::send_user_error($results->get_error_message());
 				}
-				$this->json_return( $results, false );
+				$this->json_return( $results );
 			}
 
 			return;

--- a/zoninator.php
+++ b/zoninator.php
@@ -602,7 +602,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 			// Convert string dates into actual dates
 			foreach ( $date_filters as $date ) :
-				if ( true === is_array( $date ) ) {
+				if ( is_array( $date ) ) {
 					$output = array_key_exists( 'value', $date ) ? $date['value'] : 0;
 					$label  = array_key_exists( 'label', $date ) ? $date['label'] : $output;
 				} else {

--- a/zoninator.php
+++ b/zoninator.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		 */
 		public $default_post_types = array( 'post' );
 
-		function __construct() {
+		public function __construct() {
 			add_action( 'init', array( $this, 'init' ), 99 ); // init later after other post types have been registered
 
 			add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
@@ -91,12 +91,12 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return null;
 		}
 
-		function add_zone_feed() {
+		public function add_zone_feed() {
 			add_rewrite_tag( '%' . $this->zone_taxonomy . '%', '([^&]+)' );
 			add_rewrite_rule( '^zones/([^/]+)/feed.json/?$', 'index.php?' . $this->zone_taxonomy . '=$matches[1]', 'top' );
 		}
 
-		function init() {
+		public function init() {
 			$this->zone_messages = array(
 				'insert-success'      => __( 'The zone was successfully created.', 'zoninator' ),
 				'update-success'      => __( 'The zone was successfully updated.', 'zoninator' ),
@@ -149,12 +149,12 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			load_plugin_textdomain( 'zoninator', false, basename( ZONINATOR_PATH ) . '/language' );
 		}
 
-		function widgets_init() {
+		public function widgets_init() {
 			register_widget( 'Zoninator_ZonePosts_Widget' );
 		}
 
 		// Add necessary AJAX actions
-		function admin_ajax_init() {
+		public function admin_ajax_init() {
 			add_action( 'wp_ajax_zoninator_reorder_posts', array( $this, 'ajax_reorder_posts' ) );
 			add_action( 'wp_ajax_zoninator_add_post', array( $this, 'ajax_add_post' ) );
 			add_action( 'wp_ajax_zoninator_remove_post', array( $this, 'ajax_remove_post' ) );
@@ -163,7 +163,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			add_action( 'wp_ajax_zoninator_update_recent', array( $this, 'ajax_recent_posts' ) );
 		}
 
-		function admin_init() {
+		public function admin_init() {
 
 			$this->admin_ajax_init();
 
@@ -172,12 +172,12 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
 		}
 
-		function admin_page_init() {
+		public function admin_page_init() {
 			// Set up page
 			add_menu_page( __( 'Zoninator', 'zoninator' ), __( 'Zones', 'zoninator' ), $this->_get_manage_zones_cap(), $this->key, array( $this, 'admin_page' ), '', 11 );
 		}
 
-		function admin_enqueue_scripts() {
+		public function admin_enqueue_scripts() {
 			if ( $this->is_zoninator_page() ) {
 				wp_enqueue_script( 'zoninator-js', ZONINATOR_URL . 'js/zoninator.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-widget', 'jquery-ui-mouse', 'jquery-ui-position', 'jquery-ui-sortable', 'jquery-ui-autocomplete' ), ZONINATOR_VERSION, true );
 
@@ -199,14 +199,14 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function admin_enqueue_styles() {
+		public function admin_enqueue_styles() {
 			if ( $this->is_zoninator_page() ) {
 				wp_enqueue_style( 'zoninator-jquery-ui', ZONINATOR_URL . 'css/jquery-ui/smoothness/jquery-ui-zoninator.css', false, ZONINATOR_VERSION, 'all' );
 				wp_enqueue_style( 'zoninator-styles', ZONINATOR_URL . 'css/zoninator.css', false, ZONINATOR_VERSION, 'all' );
 			}
 		}
 
-		function admin_controller() {
+		public function admin_controller() {
 			if ( $this->is_zoninator_page() ) {
 				$action = $this->_get_request_var( 'action' );
 
@@ -282,7 +282,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function admin_page() {
+		public function admin_page() {
 			global $zoninator_admin_page;
 
 			$title = __( 'Zones', 'zoninator' );
@@ -341,7 +341,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function admin_page_zone_tabs( $zones, $active_zone_id = 0 ) {
+		public function admin_page_zone_tabs( $zones, $active_zone_id = 0 ) {
 			?>
 		<div class="nav-tabs-container zone-tabs-container">
 			<div class="nav-tabs-nav-wrapper zone-tabs-nav-wrapper">
@@ -371,7 +371,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function admin_page_zone_edit( $zone = null ) {
+		public function admin_page_zone_edit( $zone = null ) {
 			$zone_id          = $this->_get_value_or_default( 'term_id', $zone, 0, 'absint' );
 			$zone_name        = $this->_get_value_or_default( 'name', $zone );
 			$zone_slug        = $this->_get_value_or_default( 'slug', $zone, '', array( $this, 'get_unformatted_zone_slug' ) );
@@ -512,7 +512,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function admin_page_zone_post( $post, $zone ) {
+		public function admin_page_zone_post( $post, $zone ) {
 			$columns = apply_filters(
 				'zoninator_zone_post_columns',
 				array(
@@ -540,7 +540,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function admin_page_zone_post_col_position( $post, $zone ) {
+		public function admin_page_zone_post_col_position( $post, $zone ) {
 			$current_position = $this->get_post_order( $post->ID, $zone );
 			?>
 		<span title="<?php esc_attr_e( 'Click and drag to change the position of this item.', 'zoninator' ); ?>">
@@ -548,7 +548,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		</span>
 			<?php
 		}
-		function admin_page_zone_post_col_info( $post, $zone ) {
+		public function admin_page_zone_post_col_info( $post, $zone ) {
 			$action_links = array(
 				sprintf( '<a href="%s" class="edit" target="_blank" title="%s">%s</a>', get_edit_post_link( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'Edit', 'zoninator' ) ),
 				sprintf( '<a href="#" class="delete" title="%s">%s</a>', __( 'Remove this item from the zone', 'zoninator' ), __( 'Remove', 'zoninator' ) ),
@@ -565,7 +565,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function zone_advanced_search_filters() {
+		public function zone_advanced_search_filters() {
 			?>
 		<div class="zone-advanced-search-filters-heading">
 			<span class="zone-toggle-advanced-search" data-alt-label="<?php esc_attr_e( 'Hide', 'zoninator' ); ?>"><?php esc_html_e( 'Show Filters', 'zoninator' ); ?></span>
@@ -576,7 +576,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function zone_advanced_search_cat_filter() {
+		public function zone_advanced_search_cat_filter() {
 			$current_cat = $this->_get_post_var( 'zone_advanced_filter_taxonomy', '', 'absint' );
 			?>
 		<label for="zone_advanced_filter_taxonomy"><?php esc_html_e( 'Filter:', 'zoninator' ); ?></label>
@@ -595,7 +595,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			);
 		}
 
-		function zone_advanced_search_date_filter() {
+		public function zone_advanced_search_date_filter() {
 			$current_date = $this->_get_post_var( 'zone_advanced_filter_date', apply_filters( 'zoninator_advanced_filter_date_default', '' ), 'striptags' );
 			$date_filters = apply_filters( 'zoninator_advanced_filter_date', array( 'all', 'today', 'yesterday' ) );
 			?>
@@ -618,7 +618,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function ajax_recent_posts() {
+		public function ajax_recent_posts() {
 
 			$cat     = $this->_get_post_var( 'cat', '', 'absint' );
 			$date    = $this->_get_post_var( 'date', '', 'striptags' );
@@ -685,7 +685,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			$this->ajax_return( $status, $content );
 		}
 
-		function zone_admin_recent_posts_dropdown( $zone_id ) {
+		public function zone_admin_recent_posts_dropdown( $zone_id ) {
 
 			$limit         = $this->posts_per_page;
 			$post_types    = $this->get_supported_post_types();
@@ -723,7 +723,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function zone_admin_search_form() {
+		public function zone_admin_search_form() {
 			?>
 		<div class="zone-search-wrapper">
 			<label for="zone-post-search"><?php esc_html_e( 'Search for content', 'zoninator' ); ?></label>
@@ -733,7 +733,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			<?php
 		}
 
-		function is_zoninator_page() {
+		public function is_zoninator_page() {
 			global $current_screen;
 
 			if ( function_exists( 'get_current_screen' ) ) {
@@ -747,7 +747,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function ajax_return( $status, $content = '', $action = '' ) {
+		public function ajax_return( $status, $content = '', $action = '' ) {
 			$action = empty( $action ) ? $this->zone_ajax_nonce_action : $action;
 			$nonce  = wp_create_nonce( $this->_get_nonce_key( $action ) );
 
@@ -761,7 +761,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			exit;
 		}
 
-		function ajax_add_post() {
+		public function ajax_add_post() {
 			$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
 			$post_id = $this->_get_post_var( 'post_id', 0, 'absint' );
 
@@ -794,7 +794,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			$this->ajax_return( $status, $content );
 		}
 
-		function ajax_remove_post() {
+		public function ajax_remove_post() {
 			$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
 			$post_id = $this->_get_post_var( 'post_id', 0, 'absint' );
 
@@ -820,7 +820,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			$this->ajax_return( $status, $content );
 		}
 
-		function ajax_reorder_posts() {
+		public function ajax_reorder_posts() {
 			$zone_id  = $this->_get_post_var( 'zone_id', 0, 'absint' );
 			$post_ids = (array) $this->_get_post_var( 'posts', array(), 'absint' );
 
@@ -847,7 +847,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		// TODO: implement in front-end
-		function ajax_move_zone_post( $from_zone, $to_zone, $post_id ) {
+		public function ajax_move_zone_post( $from_zone, $to_zone, $post_id ) {
 			$from_zone_id = $this->_get_post_var( 'from_zone_id', 0, 'absint' );
 			$to_zone_id   = $this->_get_post_var( 'to_zone_id', 0, 'absint' );
 
@@ -862,7 +862,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			$this->remove_zone_posts( $from_zone_id, $post_id );
 		}
 
-		function ajax_search_posts() {
+		public function ajax_search_posts() {
 
 			$q = $this->_get_request_var( 'term', '', 'stripslashes' );
 
@@ -930,7 +930,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function ajax_update_lock() {
+		public function ajax_update_lock() {
 			$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
 
 			$this->verify_nonce( $this->zone_ajax_nonce_action );
@@ -946,7 +946,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function get_supported_post_types() {
+		public function get_supported_post_types() {
 			if ( $this->post_types !== null ) {
 				return $this->post_types;
 			}
@@ -968,7 +968,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		 * @param string|array $post_types A post type string or array of post type strings to register.
 		 * @return bool True if any post types were added, false if not.
 		 */
-		function register_zone_post_type( $post_types = '' ) {
+		public function register_zone_post_type( $post_types = '' ) {
 
 			$did_register_post_types = false;
 
@@ -993,7 +993,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return $did_register_post_types;
 		}
 
-		function insert_zone( $slug, $name = '', $details = array() ) {
+		public function insert_zone( $slug, $name = '', $details = array() ) {
 
 			// slug cannot be empty
 			if ( empty( $slug ) ) {
@@ -1017,7 +1017,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return wp_insert_term( $name, $this->zone_taxonomy, $args );
 		}
 
-		function update_zone( $zone, $data = array() ) {
+		public function update_zone( $zone, $data = array() ) {
 			$zone_id = $this->get_zone_id( $zone );
 
 			if ( $this->zone_exists( $zone_id ) ) {
@@ -1046,7 +1046,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
 		}
 
-		function delete_zone( $zone ) {
+		public function delete_zone( $zone ) {
 			$zone_id  = $this->get_zone_id( $zone );
 			$meta_key = $this->get_zone_meta_key( $zone );
 
@@ -1075,7 +1075,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		 * @param bool  $append
 		 * @return bool|WP_Error
 		 */
-		function add_zone_posts( $zone, $posts, $append = false ) {
+		public function add_zone_posts( $zone, $posts, $append = false ) {
 			$zone     = $this->get_zone( $zone );
 			$meta_key = $this->get_zone_meta_key( $zone );
 
@@ -1112,7 +1112,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		 *
 		 * @return bool|WP_Error
 		 */
-		function remove_zone_posts( $zone, $posts = null ) {
+		public function remove_zone_posts( $zone, $posts = null ) {
 			$zone     = $this->get_zone( $zone );
 			$meta_key = $this->get_zone_meta_key( $zone );
 
@@ -1135,7 +1135,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			do_action( 'zoninator_remove_zone_posts', $posts, $zone );
 		}
 
-		function get_zone_posts( $zone, $args = array() ) {
+		public function get_zone_posts( $zone, $args = array() ) {
 			// Check cache first
 			if ( $posts = $this->get_zone_posts_from_cache( $zone, $args ) ) {
 				return $posts;
@@ -1150,7 +1150,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return $posts;
 		}
 
-		function get_zone_query( $zone, $args = array() ) {
+		public function get_zone_query( $zone, $args = array() ) {
 			$meta_key = $this->get_zone_meta_key( $zone );
 
 			$defaults = array(
@@ -1191,7 +1191,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return new WP_Query( $args );
 		}
 
-		function get_last_post_in_zone( $zone ) {
+		public function get_last_post_in_zone( $zone ) {
 			return $this->get_single_post_in_zone(
 				$zone,
 				array(
@@ -1200,11 +1200,11 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			);
 		}
 
-		function get_first_post_in_zone( $zone ) {
+		public function get_first_post_in_zone( $zone ) {
 			return $this->get_single_post_in_zone( $zone );
 		}
 
-		function get_prev_post_in_zone( $zone, $post_id ) {
+		public function get_prev_post_in_zone( $zone, $post_id ) {
 			// TODO: test this works
 			$order = $this->get_post_order_in_zone( $zone, $post_id );
 
@@ -1217,7 +1217,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			);
 		}
 
-		function get_next_post_in_zone( $zone, $post_id ) {
+		public function get_next_post_in_zone( $zone, $post_id ) {
 			// TODO: test this works
 			$order = $this->get_post_order_in_zone( $zone, $post_id );
 
@@ -1230,7 +1230,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			);
 		}
 
-		function get_single_post_in_zone( $zone, $args = array() ) {
+		public function get_single_post_in_zone( $zone, $args = array() ) {
 
 			$args = wp_parse_args(
 				$args,
@@ -1249,7 +1249,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return false;
 		}
 
-		function get_zones_for_post( $post_id ) {
+		public function get_zones_for_post( $post_id ) {
 			// TODO: build this out
 
 			// get_object_terms
@@ -1273,7 +1273,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			// return $zones;
 		}
 
-		function get_zones( $args = array() ) {
+		public function get_zones( $args = array() ) {
 
 			$args = wp_parse_args(
 				$args,
@@ -1298,7 +1298,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return false;
 		}
 
-		function get_zone( $zone ) {
+		public function get_zone( $zone ) {
 			if ( is_int( $zone ) ) {
 				$field = 'id';
 			} elseif ( is_string( $zone ) ) {
@@ -1323,7 +1323,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return $this->_fill_zone_details( $zone );
 		}
 
-		function lock_zone( $zone, $user_id = 0 ) {
+		public function lock_zone( $zone, $user_id = 0 ) {
 			$zone_id = $this->get_zone_id( $zone );
 
 			if ( ! $zone_id ) {
@@ -1344,7 +1344,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		// Not really needed with transients...
-		function unlock_zone( $zone ) {
+		public function unlock_zone( $zone ) {
 			$zone_id = $this->get_zone_id( $zone );
 
 			if ( ! $zone_id ) {
@@ -1357,7 +1357,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return null;
 		}
 
-		function is_zone_locked( $zone ) {
+		public function is_zone_locked( $zone ) {
 			$zone_id = $this->get_zone_id( $zone );
 			if ( ! $zone_id ) {
 				return false;
@@ -1376,12 +1376,12 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function zone_exists( $zone ) {
+		public function zone_exists( $zone ) {
 			$zone_id = $this->get_zone_id( $zone );
 			return (bool) term_exists( $zone_id, $this->zone_taxonomy );
 		}
 
-		function get_zone_id( $zone ) {
+		public function get_zone_id( $zone ) {
 			if ( is_int( $zone ) ) {
 				return $zone;
 			}
@@ -1394,12 +1394,12 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return (int) $zone;
 		}
 
-		function get_zone_meta_key( $zone ) {
+		public function get_zone_meta_key( $zone ) {
 			$zone_id = $this->get_zone_id( $zone );
 			return $this->zone_meta_prefix . $zone_id;
 		}
 
-		function get_zone_slug( $zone ) {
+		public function get_zone_slug( $zone ) {
 			if ( is_int( $zone ) ) {
 				$zone = $this->get_zone( $zone );
 			}
@@ -1411,14 +1411,14 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return $this->get_formatted_zone_slug( $zone );
 		}
 
-		function get_formatted_zone_slug( $slug ) {
+		public function get_formatted_zone_slug( $slug ) {
 			return $slug; // legacy function -- slugs can no longer be changed
 		}
-		function get_unformatted_zone_slug( $slug ) {
+		public function get_unformatted_zone_slug( $slug ) {
 			return $slug; // legacy function -- slugs can no longer be changed
 		}
 
-		function get_post_id( $post ) {
+		public function get_post_id( $post ) {
 			if ( is_int( $post ) ) {
 				return $post;
 			} elseif ( is_array( $post ) ) {
@@ -1430,14 +1430,14 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return false;
 		}
 
-		function get_post_order( $post, $zone ) {
+		public function get_post_order( $post, $zone ) {
 			$post_id  = $this->get_post_id( $post );
 			$meta_key = $this->get_zone_meta_key( $zone );
 
 			return get_metadata( 'post', $post_id, $meta_key, true );
 		}
 
-		function verify_nonce( $action ) {
+		public function verify_nonce( $action ) {
 			$action = $this->_get_nonce_key( $action );
 			$nonce  = $this->_get_request_var( $action );
 
@@ -1450,7 +1450,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function verify_access( $action = '', $zone_id = null ) {
+		public function verify_access( $action = '', $zone_id = null ) {
 			// TODO: should check if zone locked
 
 			$verify_function = '';
@@ -1472,11 +1472,11 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function _unauthorized_access() {
+		public function _unauthorized_access() {
 			wp_die( __( 'Sorry, you\'re not supposed to do that...', 'zoninator' ) );
 		}
 
-		function _fill_zone_details( $zone ) {
+		public function _fill_zone_details( $zone ) {
 			if ( ! empty( $zone->zoninator_parsed ) && $zone->zoninator_parsed ) {
 				return $zone;
 			}
@@ -1498,7 +1498,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return $zone;
 		}
 
-		function do_zoninator_feeds() {
+		public function do_zoninator_feeds() {
 			$query_var = get_query_var( $this->zone_taxonomy );
 
 			if ( ! empty( $query_var ) ) {
@@ -1577,19 +1577,19 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		// TODO: Caching needs to be testing properly before being implemented!
-		function get_zone_cache_key( $zone, $args = array() ) {
+		public function get_zone_cache_key( $zone, $args = array() ) {
 			return '';
 		}
 
-		function get_zone_posts_from_cache( $zone, $args = array() ) {
+		public function get_zone_posts_from_cache( $zone, $args = array() ) {
 			return false;
 		}
 
-		function add_zone_posts_to_cache( $posts, $zone, $args = array() ) {
+		public function add_zone_posts_to_cache( $posts, $zone, $args = array() ) {
 		}
 
 		// Handle 4.2 term-splitting
-		function split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
+		public function split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
 			if ( $this->zone_taxonomy === $taxonomy ) {
 				do_action( 'zoninator_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
 
@@ -1604,11 +1604,11 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 		}
 
-		function _empty_zone_posts_cache( $meta_key ) {
+		public function _empty_zone_posts_cache( $meta_key ) {
 			return; // TODO: implement
 		}
 
-		function _get_message( $message_id, $encode = false ) {
+		public function _get_message( $message_id, $encode = false ) {
 			$message = '';
 
 			if ( ! empty( $this->zone_messages[ $message_id ] ) ) {
@@ -1622,36 +1622,36 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return $message;
 		}
 
-		function _get_nonce_key( $action ) {
+		public function _get_nonce_key( $action ) {
 			return sprintf( '%s-%s', $this->zone_nonce_prefix, $action );
 		}
 
-		function _current_user_can_add_zones() {
+		public function _current_user_can_add_zones() {
 			return current_user_can( $this->_get_add_zones_cap() );
 		}
 
-		function _current_user_can_edit_zones( $zone_id ) {
+		public function _current_user_can_edit_zones( $zone_id ) {
 			$has_cap = current_user_can( $this->_get_edit_zones_cap() );
 			return apply_filters( 'zoninator_current_user_can_edit_zone', $has_cap, $zone_id );
 		}
 
-		function _current_user_can_manage_zones() {
+		public function _current_user_can_manage_zones() {
 			return current_user_can( $this->_get_manage_zones_cap() );
 		}
 
-		function _get_add_zones_cap() {
+		public function _get_add_zones_cap() {
 			return apply_filters( 'zoninator_add_zone_cap', 'edit_others_posts' );
 		}
 
-		function _get_edit_zones_cap() {
+		public function _get_edit_zones_cap() {
 			return apply_filters( 'zoninator_edit_zone_cap', 'edit_others_posts' );
 		}
 
-		function _get_manage_zones_cap() {
+		public function _get_manage_zones_cap() {
 			return apply_filters( 'zoninator_manage_zone_cap', 'edit_others_posts' );
 		}
 
-		function _get_zone_page_url( $args = array() ) {
+		public function _get_zone_page_url( $args = array() ) {
 			$url = menu_page_url( $this->key, false );
 
 			foreach ( $args as $arg_key => $arg_value ) {
@@ -1661,19 +1661,19 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return $url;
 		}
 
-		function _validate_date_filter( $date ) {
+		public function _validate_date_filter( $date ) {
 			return preg_match( '/(\d{4})-(\d{2})-(\d{2})/', $date );
 		}
 
-		function _validate_category_filter( $cat ) {
+		public function _validate_category_filter( $cat ) {
 			return $cat && get_term_by( 'id', $cat, 'category' );
 		}
 
-		function _sanitize_value( $var ) {
+		public function _sanitize_value( $var ) {
 			return htmlentities( stripslashes( $var ) );
 		}
 
-		function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {
+		public function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {
 			if ( is_object( $object ) ) {
 				$value = empty( $object->$var ) ? $default : $object->$var;
 			} elseif ( is_array( $object ) ) {
@@ -1689,14 +1689,14 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			return $value;
 		}
 
-		function _get_request_var( $var, $default = '', $sanitize_callback = '' ) {
+		public function _get_request_var( $var, $default = '', $sanitize_callback = '' ) {
 			return $this->_get_value_or_default( $var, $_REQUEST, $default, $sanitize_callback );
 		}
 
-		function _get_get_var( $var, $default = '', $sanitize_callback = '' ) {
+		public function _get_get_var( $var, $default = '', $sanitize_callback = '' ) {
 			return $this->_get_value_or_default( $var, $_GET, $default, $sanitize_callback );
 		}
-		function _get_post_var( $var, $default = '', $sanitize_callback = '' ) {
+		public function _get_post_var( $var, $default = '', $sanitize_callback = '' ) {
 			return $this->_get_value_or_default( $var, $_POST, $default, $sanitize_callback );
 		}
 
@@ -1761,7 +1761,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		 * @param $zone_slug_or_id
 		 * @return array|WP_Error
 		 */
-		function get_zone_feed( $zone_slug_or_id ) {
+		public function get_zone_feed( $zone_slug_or_id ) {
 			$zone_id = $this->get_zone( $zone_slug_or_id );
 
 			if ( empty( $zone_id ) ) {

--- a/zoninator.php
+++ b/zoninator.php
@@ -1659,7 +1659,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		function _validate_date_filter( $date ) {
-			return preg_match( '/([0-9]{4})-([0-9]{2})-([0-9]{2})/', $date );
+			return preg_match( '/(\d{4})-(\d{2})-(\d{2})/', $date );
 		}
 
 		function _validate_category_filter( $cat ) {

--- a/zoninator.php
+++ b/zoninator.php
@@ -40,25 +40,39 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 	class Zoninator {
 
-		public $key                    = 'zoninator';
-		public $zone_taxonomy          = 'zoninator_zones';
-		public $zone_term_prefix       = 'zone-';
-		public $zone_meta_prefix       = '_zoninator_order_';
-		public $zone_nonce_prefix      = 'zone-nonce';
+		public $key = 'zoninator';
+
+		public $zone_taxonomy = 'zoninator_zones';
+
+		public $zone_term_prefix = 'zone-';
+
+		public $zone_meta_prefix = '_zoninator_order_';
+
+		public $zone_nonce_prefix = 'zone-nonce';
+
 		public $zone_ajax_nonce_action = 'ajax-action';
-		public $zone_lock_period       = 30; // number of seconds a lock is valid for
-		public $zone_max_lock_period   = 600; // max number of seconds for all locks in a session
+
+		// Number of seconds a lock is valid for.
+		public $zone_lock_period = 30;
+
+		// Max number of seconds for all locks in a session.
+		public $zone_max_lock_period = 600;
 		public $post_types;
+
 		public $zone_detail_defaults = array(
 			'description' => '',
-		// Add additional properties here!
+			// Add additional properties here!
 		);
+
 		public $zone_messages;
+
 		public $posts_per_page = 10;
+
 		/**
 		 * @var Zoninator_Api
 		 */
 		public $rest_api;
+
 		/**
 		 * @var array|string[] Default post types that support zones.
 		 */
@@ -316,20 +330,26 @@ if ( ! class_exists( 'Zoninator' ) ) :
 						<a href="<?php echo esc_url( $new_link ); ?>" class="add-new-h2 zone-button-add-new"><?php esc_html_e( 'Add New', 'zoninator' ); ?></a>
 					<?php else : ?>
 						<span class="nav-tab nav-tab-active zone-tab zone-tab-active"><?php esc_html_e( 'Add New', 'zoninator' ); ?></span>
-					<?php endif; ?>
-				<?php endif; ?>
+						<?php
+					endif;
+				endif;
+				?>
 			</h2>
 
 				<?php if ( $message ) : ?>
 				<div id="zone-message" class="updated below-h2">
 					<p><?php echo esc_html( $message ); ?></p>
 				</div>
-			<?php endif; ?>
+					<?php
+				endif;
+				?>
 				<?php if ( $error ) : ?>
 				<div id="zone-message" class="error below-h2">
 					<p><?php echo esc_html( $error ); ?></p>
 				</div>
-			<?php endif; ?>
+					<?php
+				endif;
+				?>
 
 			<div id="zoninator-wrap">
 
@@ -362,8 +382,10 @@ if ( ! class_exists( 'Zoninator' ) ) :
 								<span class="nav-tab nav-tab-active zone-tab zone-tab-active"><?php echo esc_html( $zone->name ); ?></span>
 							<?php else : ?>
 								<a href="<?php echo esc_url( $zone_link ); ?>" class="nav-tab zone-tab"><?php echo esc_html( $zone->name ); ?></a>
-							<?php endif; ?>
-						<?php endforeach; ?>
+								<?php
+							endif;
+						endforeach;
+						?>
 					</div>
 				</div>
 			</div>
@@ -397,7 +419,9 @@ if ( ! class_exists( 'Zoninator' ) ) :
 						<p><?php printf( $this->_get_message( 'error-zone-lock' ), sprintf( '<a href="mailto:%s">%s</a>', esc_attr( $locking_user->user_email ), esc_html( $locking_user->display_name ) ) ); ?></p>
 					</div>
 					<input type="hidden" id="zone-locked" name="zone-locked" value="1" />
-				<?php endif; ?>
+					<?php
+				endif;
+				?>
 				<div class="col-wrap zone-col zone-info-col">
 					<div class="form-wrap zone-form zone-info-form">
 
@@ -418,7 +442,9 @@ if ( ! class_exists( 'Zoninator' ) ) :
 									<span><?php echo esc_attr( $zone_slug ); ?></span>
 									<input type="hidden" id="zone-slug" name="slug" value="<?php echo esc_attr( $zone_slug ); ?>" />
 								</div>
-								<?php endif; ?>
+									<?php
+								endif;
+								?>
 
 								<div class="form-field zone-field">
 									<label for="zone-description"><?php esc_html_e( 'Description', 'zoninator' ); ?></label>
@@ -432,14 +458,18 @@ if ( ! class_exists( 'Zoninator' ) ) :
 									<?php wp_nonce_field( $this->_get_nonce_key( 'update' ) ); ?>
 								<?php else : ?>
 									<?php wp_nonce_field( $this->_get_nonce_key( 'insert' ) ); ?>
-								<?php endif; ?>
+									<?php
+								endif;
+								?>
 
 								<div class="submit-field submitbox">
 									<input type="submit" value="<?php esc_attr_e( 'Save zone info', 'zoninator' ); ?>" name="submit" class="button" />
 
 									<?php if ( $zone_id ) : ?>
 										<a href="<?php echo $delete_link; ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( 'Are you sure you want to delete this zone?', 'zoninator' ); ?>')"><?php esc_html_e( 'Delete', 'zoninator' ); ?></a>
-									<?php endif; ?>
+										<?php
+									endif;
+									?>
 								</div>
 
 								<input type="hidden" name="action" value="<?php echo $zone_id ? 'update' : 'insert'; ?>">
@@ -471,7 +501,9 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 								<?php do_action( 'zoninator_post_zone_readonly', $zone ); ?>
 							</div>
-						<?php endif; ?>
+							<?php
+						endif;
+						?>
 
 						<?php // Ideally, we should separate nonces for each action. But this will do for simplicity. ?>
 						<?php wp_nonce_field( $this->_get_nonce_key( $this->zone_ajax_nonce_action ), $this->_get_nonce_key( $this->zone_ajax_nonce_action ), false ); ?>
@@ -498,17 +530,22 @@ if ( ! class_exists( 'Zoninator' ) ) :
 							<div class="zone-posts-list">
 								<?php foreach ( $zone_posts as $post ) : ?>
 									<?php $this->admin_page_zone_post( $post, $zone ); ?>
-								<?php endforeach; ?>
+									<?php
+								endforeach;
+								?>
 							</div>
 
 						<?php else : ?>
 							<p class="description"><?php esc_html_e( 'To create a zone, enter a name (and optional description) and click "Save zone info". You can then choose content items to add to the zone.', 'zoninator' ); ?></p>
-						<?php endif; ?>
+							<?php
+						endif;
+						?>
 					</div>
 				</div>
-<?php endif; ?>
+				<?php
+				endif;
+			?>
 		</div>
-
 			<?php
 		}
 
@@ -531,8 +568,10 @@ if ( ! class_exists( 'Zoninator' ) ) :
 							<td class="zone-post-col zone-post-<?php echo $column_key; ?>">
 								<?php call_user_func( $column_callback, $post, $zone ); ?>
 							</td>
-						<?php endif; ?>
-					<?php endforeach; ?>
+							<?php
+						endif;
+					endforeach;
+					?>
 				</tr>
 			</table>
 			<input type="hidden" name="zone-post-id" value="<?php echo $post->ID; ?>" />
@@ -548,6 +587,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		</span>
 			<?php
 		}
+
 		public function admin_page_zone_post_col_info( $post, $zone ) {
 			$action_links = array(
 				sprintf( '<a href="%s" class="edit" target="_blank" title="%s">%s</a>', get_edit_post_link( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'Edit', 'zoninator' ) ),
@@ -611,6 +651,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 					$output    = ( $timestamp ) ? date( 'Y-m-d', $timestamp ) : 0;
 					$label     = $date;
 				}
+
 				printf( '<option value="%s" %s>%s</option>', esc_attr( $output ), selected( $output, $current_date, false ), esc_html( $label ) );
 				endforeach;
 			?>
@@ -667,6 +708,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				foreach ( $recent_posts as $post ) :
 					$content .= sprintf( '<option value="%d">%s</option>', $post->ID, get_the_title( $post->ID ) . ' (' . $post->post_status . ')' );
 				endforeach;
+
 				wp_reset_postdata();
 				$status = 1;
 			}
@@ -716,6 +758,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				foreach ( $recent_posts as $post ) :
 					printf( '<option value="%d">%s</option>', $post->ID, esc_html( get_the_title( $post->ID ) . ' (' . $post->post_status . ')' ) );
 					endforeach;
+
 				wp_reset_postdata();
 				?>
 			</select>
@@ -875,6 +918,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				if ( $limit <= 0 ) {
 					$limit = $this->posts_per_page;
 				}
+
 				$exclude = (array) $this->_get_request_var( 'exclude', array(), 'absint' );
 
 				$args = apply_filters(
@@ -1043,6 +1087,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 				return wp_update_term( $zone_id, $this->zone_taxonomy, $args );
 			}
+
 			return new WP_Error( 'invalid-zone', __( "Sorry, that zone doesn't exist.", 'zoninator' ) );
 		}
 
@@ -1066,6 +1111,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 					return $delete;
 				}
 			}
+
 			return new WP_Error( 'invalid-zone', __( "Sorry, that zone doesn't exist.", 'zoninator' ) );
 		}
 
@@ -1096,6 +1142,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 					++$order;
 					update_metadata( 'post', $post_id, $meta_key, $order, true );
 				}
+
 				// TODO: remove_object_terms -- but need remove object terms function :(
 			}
 
@@ -1414,6 +1461,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		public function get_formatted_zone_slug( $slug ) {
 			return $slug; // legacy function -- slugs can no longer be changed
 		}
+
 		public function get_unformatted_zone_slug( $slug ) {
 			return $slug; // legacy function -- slugs can no longer be changed
 		}
@@ -1507,6 +1555,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				if ( is_wp_error( $results ) ) {
 					$this->send_user_error( $results->get_error_message() );
 				}
+
 				$this->json_return( $results );
 			}
 		}
@@ -1524,12 +1573,15 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				if ( ! isset( $filtered_results[ $i ] ) ) {
 					$filtered_results[ $i ] = new stdClass();
 				}
+
 				foreach ( $whitelisted_fields as $field ) {
 					if ( ! isset( $filtered_results[ $i ] ) ) {
 						$filtered_results[ $i ] = new stdClass();
 					}
+
 					$filtered_results[ $i ]->$field = $result->$field;
 				}
+
 				++$i;
 			}
 
@@ -1696,6 +1748,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		public function _get_get_var( $var, $default = '', $sanitize_callback = '' ) {
 			return $this->_get_value_or_default( $var, $_GET, $default, $sanitize_callback );
 		}
+
 		public function _get_post_var( $var, $default = '', $sanitize_callback = '' ) {
 			return $this->_get_value_or_default( $var, $_POST, $default, $sanitize_callback );
 		}
@@ -1793,6 +1846,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		if ( ! isset( $zoninator ) || null === $zoninator ) {
 			$zoninator = new Zoninator();
 		}
+
 		return $zoninator;
 	}
 

--- a/zoninator.php
+++ b/zoninator.php
@@ -829,7 +829,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			$this->verify_access( '', $zone_id );
 
 			// validate
-			if ( ! $zone_id || empty( $post_ids ) ) {
+			if ( ! $zone_id || $post_ids === array() ) {
 				$this->ajax_return( 0 );
 			}
 
@@ -1242,7 +1242,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 			$post = $this->get_zone_posts( $zone, $args );
 
-			if ( is_array( $post ) && ! empty( $post ) ) {
+			if ( is_array( $post ) && $post !== array() ) {
 				return array_pop( $post );
 			}
 

--- a/zoninator.php
+++ b/zoninator.php
@@ -57,6 +57,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 		// Max number of seconds for all locks in a session.
 		public $zone_max_lock_period = 600;
+
 		public $post_types;
 
 		public $zone_detail_defaults = array(

--- a/zoninator.php
+++ b/zoninator.php
@@ -1043,7 +1043,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 				return wp_update_term( $zone_id, $this->zone_taxonomy, $args );
 			}
-			return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
+			return new WP_Error( 'invalid-zone', __( "Sorry, that zone doesn't exist.", 'zoninator' ) );
 		}
 
 		public function delete_zone( $zone ) {
@@ -1060,13 +1060,13 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				$delete = wp_delete_term( $zone_id, $this->zone_taxonomy );
 
 				if ( ! $delete ) {
-					return new WP_Error( 'delete-zone', __( 'Sorry, we couldn\'t delete the zone.', 'zoninator' ) );
+					return new WP_Error( 'delete-zone', __( "Sorry, we couldn't delete the zone.", 'zoninator' ) );
 				} else {
 					do_action( 'zoninator_delete_zone', $zone_id );
 					return $delete;
 				}
 			}
-			return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
+			return new WP_Error( 'invalid-zone', __( "Sorry, that zone doesn't exist.", 'zoninator' ) );
 		}
 
 		/**
@@ -1473,7 +1473,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		public function _unauthorized_access() {
-			wp_die( __( 'Sorry, you\'re not supposed to do that...', 'zoninator' ) );
+			wp_die( __( "Sorry, you're not supposed to do that...", 'zoninator' ) );
 		}
 
 		public function _fill_zone_details( $zone ) {

--- a/zoninator.php
+++ b/zoninator.php
@@ -258,7 +258,6 @@ if ( ! class_exists( 'Zoninator' ) ) :
 							);
 							exit;
 						}
-						break;
 
 					case 'delete':
 						$zone_id = $this->_get_request_var( 'zone_id', 0, 'absint' );
@@ -1593,29 +1592,14 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		// TODO: Caching needs to be testing properly before being implemented!
 		function get_zone_cache_key( $zone, $args = array() ) {
 			return '';
-
-			$meta_key = $this->get_zone_meta_key( $zone );
-			$hash     = md5( serialize( $args ) );
-			return $meta_key . $hash;
 		}
 
 		function get_zone_posts_from_cache( $zone, $args = array() ) {
-			return false; // TODO: implement
-
-			$meta_key  = $this->get_zone_meta_key( $zone );
-			$cache_key = $this->get_zone_cache_key( $zone, $args );
-			if ( $posts = wp_cache_get( $cache_key, $meta_key ) ) {
-				return $posts;
-			}
 			return false;
 		}
 
 		function add_zone_posts_to_cache( $posts, $zone, $args = array() ) {
-			return; // TODO: implement
-
-			$meta_key  = $this->get_zone_meta_key( $zone );
-			$cache_key = $this->get_zone_cache_key( $zone, $args );
-			wp_cache_set( $cache_key, $posts, $meta_key );
+			return;
 		}
 
 		// Handle 4.2 term-splitting

--- a/zoninator.php
+++ b/zoninator.php
@@ -295,7 +295,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 
 			$active_zone_id = $this->_get_request_var( 'zone_id', $default_active_zone, 'absint' );
-			$active_zone    = ! empty( $active_zone_id ) ? $this->get_zone( $active_zone_id ) : array();
+			$active_zone    = empty( $active_zone_id ) ? array() : $this->get_zone( $active_zone_id );
 			if ( ! empty( $active_zone ) ) {
 				$title = __( 'Edit Zone', 'zoninator' );
 			}
@@ -748,7 +748,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		function ajax_return( $status, $content = '', $action = '' ) {
-			$action = ! empty( $action ) ? $action : $this->zone_ajax_nonce_action;
+			$action = empty( $action ) ? $this->zone_ajax_nonce_action : $action;
 			$nonce  = wp_create_nonce( $this->_get_nonce_key( $action ) );
 
 			echo json_encode(
@@ -915,7 +915,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 					$stripped_posts[] = apply_filters(
 						'zoninator_search_results_post',
 						array(
-							'title'       => ! empty( $post->post_title ) ? $post->post_title : __( '(no title)', 'zoninator' ),
+							'title'       => empty( $post->post_title ) ? __( '(no title)', 'zoninator' ) : $post->post_title,
 							'post_id'     => $post->ID,
 							'date'        => get_the_time( get_option( 'date_format' ), $post ),
 							'post_type'   => $post->post_type,
@@ -1001,7 +1001,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 
 			$slug = $this->get_formatted_zone_slug( $slug );
-			$name = ! empty( $name ) ? $name : $slug;
+			$name = empty( $name ) ? $slug : $name;
 
 			$details = wp_parse_args( $details, $this->zone_detail_defaults );
 			$details = maybe_serialize( stripslashes_deep( $details ) );
@@ -1675,9 +1675,9 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 		function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {
 			if ( is_object( $object ) ) {
-				$value = ! empty( $object->$var ) ? $object->$var : $default;
+				$value = empty( $object->$var ) ? $default : $object->$var;
 			} elseif ( is_array( $object ) ) {
-				$value = ! empty( $object[ $var ] ) ? $object[ $var ] : $default;
+				$value = empty( $object[ $var ] ) ? $default : $object[ $var ];
 			} else {
 				$value = $default;
 			}

--- a/zoninator.php
+++ b/zoninator.php
@@ -284,8 +284,6 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		function admin_page() {
 			global $zoninator_admin_page;
 
-			$view  = $this->_get_value_or_default( 'view', $zoninator_admin_page, 'edit.php' );
-			$view  = sprintf( '%s/views/%s', ZONINATOR_PATH, $view );
 			$title = __( 'Zones', 'zoninator' );
 
 			$zones = $this->get_zones( apply_filters( 'zoninator_admin_page_get_zones_args', array() ) );
@@ -345,7 +343,6 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		function admin_page_zone_tabs( $zones, $active_zone_id = 0 ) {
-			$new_link = $this->_get_zone_page_url( array( 'action' => 'new' ) );
 			?>
 		<div class="nav-tabs-container zone-tabs-container">
 			<div class="nav-tabs-nav-wrapper zone-tabs-nav-wrapper">

--- a/zoninator.php
+++ b/zoninator.php
@@ -947,7 +947,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		function get_supported_post_types() {
-			if ( isset( $this->post_types ) ) {
+			if ( $this->post_types !== null ) {
 				return $this->post_types;
 			}
 

--- a/zoninator.php
+++ b/zoninator.php
@@ -1116,8 +1116,9 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		/**
-		 * @param $zone
-		 * @param null $posts
+		 * @param mixed $zone
+		 * @param mixed $posts
+		 *
 		 * @return bool|WP_Error
 		 */
 		function remove_zone_posts( $zone, $posts = null ) {

--- a/zoninator.php
+++ b/zoninator.php
@@ -1505,7 +1505,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				$zone_slug = get_query_var( $this->zone_taxonomy );
 				$results   = $this->get_zone_feed( $zone_slug );
 				if ( is_wp_error( $results ) ) {
-					self::send_user_error( $results->get_error_message() );
+					$this->send_user_error( $results->get_error_message() );
 				}
 				$this->json_return( $results );
 			}
@@ -1552,8 +1552,8 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			exit();
 		}
 
-		private static function send_user_error( $message ) {
-			self::status_header_with_message( 406, $message );
+		private function send_user_error( $message ) {
+			$this->status_header_with_message( 406, $message );
 			exit();
 		}
 
@@ -1564,7 +1564,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		 * @param int    $status
 		 * @param string $message
 		 */
-		private static function status_header_with_message( $status, $message ) {
+		private function status_header_with_message( $status, $message ) {
 			global $wp_header_to_desc;
 
 			$status                       = absint( $status );

--- a/zoninator.php
+++ b/zoninator.php
@@ -48,17 +48,17 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		public $zone_ajax_nonce_action = 'ajax-action';
 		public $zone_lock_period       = 30; // number of seconds a lock is valid for
 		public $zone_max_lock_period   = 600; // max number of seconds for all locks in a session
-		public $post_types             = null;
-		public $zone_detail_defaults   = array(
+		public $post_types;
+		public $zone_detail_defaults = array(
 			'description' => '',
 		// Add additional properties here!
 		);
-		public $zone_messages  = null;
+		public $zone_messages;
 		public $posts_per_page = 10;
 		/**
 		 * @var Zoninator_Api
 		 */
-		public $rest_api = null;
+		public $rest_api;
 		/**
 		 * @var array|string[] Default post types that support zones.
 		 */

--- a/zoninator.php
+++ b/zoninator.php
@@ -1517,8 +1517,6 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				}
 				$this->json_return( $results );
 			}
-
-			return;
 		}
 
 		private function filter_zone_feed_fields( $results ) {
@@ -1596,7 +1594,6 @@ if ( ! class_exists( 'Zoninator' ) ) :
 		}
 
 		function add_zone_posts_to_cache( $posts, $zone, $args = array() ) {
-			return;
 		}
 
 		// Handle 4.2 term-splitting

--- a/zoninator.php
+++ b/zoninator.php
@@ -1085,11 +1085,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			if ( $append ) {
 				// Order should be the highest post order
 				$last_post = $this->get_last_post_in_zone( $zone );
-				if ( $last_post ) {
-					$order = $this->get_post_order( $last_post, $zone );
-				} else {
-					$order = 0;
-				}
+				$order     = $last_post ? $this->get_post_order( $last_post, $zone ) : 0;
 			} else {
 				$order = 0;
 				$this->remove_zone_posts( $zone );
@@ -1686,11 +1682,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			}
 
 			if ( is_callable( $sanitize_callback ) ) {
-				if ( is_array( $value ) ) {
-					$value = array_map( $sanitize_callback, $value );
-				} else {
-					$value = call_user_func( $sanitize_callback, $value );
-				}
+				$value = is_array( $value ) ? array_map( $sanitize_callback, $value ) : call_user_func( $sanitize_callback, $value );
 			}
 
 			return $value;

--- a/zoninator.php
+++ b/zoninator.php
@@ -1516,7 +1516,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				$zone_slug = get_query_var( $this->zone_taxonomy );
 				$results   = $this->get_zone_feed( $zone_slug );
 				if ( is_wp_error( $results ) ) {
-					self::send_user_error($results->get_error_message());
+					self::send_user_error( $results->get_error_message() );
 				}
 				$this->json_return( $results );
 			}

--- a/zoninator.php
+++ b/zoninator.php
@@ -30,277 +30,293 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 */
 
-if( ! class_exists( 'Zoninator' ) ) :
+if ( ! class_exists( 'Zoninator' ) ) :
+	define( 'ZONINATOR_VERSION', '0.10.0' );
+	define( 'ZONINATOR_PATH', __DIR__ );
+	define( 'ZONINATOR_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
 
-define( 'ZONINATOR_VERSION', '0.10.0' );
-define( 'ZONINATOR_PATH', dirname( __FILE__ ) );
-define( 'ZONINATOR_URL', trailingslashit( plugins_url( '', __FILE__ ) ) );
+	require_once ZONINATOR_PATH . '/functions.php';
+	require_once ZONINATOR_PATH . '/widget.zone-posts.php';
 
-require_once( ZONINATOR_PATH . '/functions.php' );
-require_once( ZONINATOR_PATH . '/widget.zone-posts.php');
+	class Zoninator {
 
-class Zoninator
-{
-	var $key = 'zoninator';
-	var $zone_taxonomy = 'zoninator_zones';
-	var $zone_term_prefix = 'zone-';
-	var $zone_meta_prefix = '_zoninator_order_';
-	var $zone_nonce_prefix = 'zone-nonce';
-	var $zone_ajax_nonce_action = 'ajax-action';
-	var $zone_lock_period = 30; // number of seconds a lock is valid for
-	var $zone_max_lock_period = 600; // max number of seconds for all locks in a session
-	var $post_types = null;
-	var $zone_detail_defaults = array(
-		'description' => ''
+		var $key                    = 'zoninator';
+		var $zone_taxonomy          = 'zoninator_zones';
+		var $zone_term_prefix       = 'zone-';
+		var $zone_meta_prefix       = '_zoninator_order_';
+		var $zone_nonce_prefix      = 'zone-nonce';
+		var $zone_ajax_nonce_action = 'ajax-action';
+		var $zone_lock_period       = 30; // number of seconds a lock is valid for
+		var $zone_max_lock_period   = 600; // max number of seconds for all locks in a session
+		var $post_types             = null;
+		var $zone_detail_defaults   = array(
+			'description' => '',
 		// Add additional properties here!
-	);
-	var $zone_messages = null;
-	var $posts_per_page = 10;
-	/**
-	 * @var Zoninator_Api
-	 */
-	public $rest_api = null;
-	/**
-	 * @var array|string[] Default post types that support zones.
-	 */
-	public $default_post_types = array( 'post' );
-
-	function __construct() {
-		add_action( 'init', array( $this, 'init' ), 99 ); // init later after other post types have been registered
-
-		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
-
-		add_action( 'widgets_init', array( $this, 'widgets_init' ) );
-
-		add_action( 'init', array( $this, 'add_zone_feed' ) );
-
-		add_action( 'template_redirect', array( $this, 'do_zoninator_feeds' ) );
-
-		add_action( 'split_shared_term', array( $this, 'split_shared_term' ), 10, 4 );
-
-		$this->maybe_add_rest_api();
-	}
-
-	public function maybe_add_rest_api() {
-		global $wp_version;
-		if ( version_compare( $wp_version, '4.7', '<' ) ) {
-			return false;
-		}
-
-		include_once 'includes/class-zoninator-api.php';
-		$this->rest_api = new Zoninator_Api( $this );
-	}
-
-	function add_zone_feed() {
-		add_rewrite_tag( '%' . $this->zone_taxonomy . '%', '([^&]+)' );
-		add_rewrite_rule( '^zones/([^/]+)/feed.json/?$', 'index.php?' . $this->zone_taxonomy . '=$matches[1]', 'top' );
-	}
-
-	function init() {
-		$this->zone_messages = array(
-			'insert-success' => __( 'The zone was successfully created.', 'zoninator' ),
-			'update-success' => __( 'The zone was successfully updated.', 'zoninator' ),
-			'delete-success' => __( 'The zone was successfully deleted.', 'zoninator' ),
-			'error-general' => __( 'Sorry, something went wrong! Please try again?', 'zoninator' ),
-			'error-zone-lock' => __( 'Sorry, this zone is in use by %s and is currently locked. Please try again later.', 'zoninator' ),
-			'error-zone-lock-max' => __( 'Sorry, you have reached the maximum idle limit and will now be redirected to the Dashboard.', 'zoninator' ),
 		);
+		var $zone_messages  = null;
+		var $posts_per_page = 10;
+		/**
+		 * @var Zoninator_Api
+		 */
+		public $rest_api = null;
+		/**
+		 * @var array|string[] Default post types that support zones.
+		 */
+		public $default_post_types = array( 'post' );
 
-		$this->zone_lock_period 	= apply_filters( 'zoninator_zone_lock_period', 		$this->zone_lock_period );
-		$this->zone_max_lock_period = apply_filters( 'zoninator_zone_max_lock_period', 	$this->zone_max_lock_period );
-		$this->posts_per_page 		= apply_filters( 'zoninator_posts_per_page', 		$this->posts_per_page );
+		function __construct() {
+			add_action( 'init', array( $this, 'init' ), 99 ); // init later after other post types have been registered
 
-		do_action( 'zoninator_pre_init' );
+			add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
 
-		// Default post type support
-		foreach( $this->default_post_types as $post_type )
-			add_post_type_support( $post_type, $this->zone_taxonomy );
+			add_action( 'widgets_init', array( $this, 'widgets_init' ) );
 
-		// Register taxonomy
-		if( ! taxonomy_exists( $this->zone_taxonomy ) ) {
-			register_taxonomy( $this->zone_taxonomy, $this->get_supported_post_types(), array(
-				'label' => __( 'Zones', 'zoninator' ),
-				'hierarchical' => false,
-				'query_var' => false,
-				'rewrite' => false,
-				'public' => false,
+			add_action( 'init', array( $this, 'add_zone_feed' ) );
 
-			) );
+			add_action( 'template_redirect', array( $this, 'do_zoninator_feeds' ) );
+
+			add_action( 'split_shared_term', array( $this, 'split_shared_term' ), 10, 4 );
+
+			$this->maybe_add_rest_api();
 		}
 
-		add_action( 'admin_init', array( $this, 'admin_controller' ) );
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		public function maybe_add_rest_api() {
+			global $wp_version;
+			if ( version_compare( $wp_version, '4.7', '<' ) ) {
+				return false;
+			}
 
-		add_action( 'admin_menu', array( $this, 'admin_page_init' ) );
+			include_once 'includes/class-zoninator-api.php';
+			$this->rest_api = new Zoninator_Api( $this );
+		}
 
-		# Add default advanced search fields
-		add_action( 'zoninator_advanced_search_fields', array( $this, 'zone_advanced_search_cat_filter' ) );
-		add_action( 'zoninator_advanced_search_fields', array( $this, 'zone_advanced_search_date_filter' ), 20 );
+		function add_zone_feed() {
+			add_rewrite_tag( '%' . $this->zone_taxonomy . '%', '([^&]+)' );
+			add_rewrite_rule( '^zones/([^/]+)/feed.json/?$', 'index.php?' . $this->zone_taxonomy . '=$matches[1]', 'top' );
+		}
 
-		do_action( 'zoninator_post_init' );
-	}
-
-	public function load_textdomain() {
-		load_plugin_textdomain( 'zoninator', false, basename( ZONINATOR_PATH ) . '/language' );
-	}
-
-	function widgets_init() {
-		register_widget( 'Zoninator_ZonePosts_Widget' );
-	}
-
-	// Add necessary AJAX actions
-	function admin_ajax_init( ) {
-		add_action( 'wp_ajax_zoninator_reorder_posts', array( $this, 'ajax_reorder_posts' ) );
-		add_action( 'wp_ajax_zoninator_add_post', array( $this, 'ajax_add_post' ) );
-		add_action( 'wp_ajax_zoninator_remove_post', array( $this, 'ajax_remove_post' ) );
-		add_action( 'wp_ajax_zoninator_search_posts', array( $this, 'ajax_search_posts' ) );
-		add_action( 'wp_ajax_zoninator_update_lock', array( $this, 'ajax_update_lock' ) );
-		add_action( 'wp_ajax_zoninator_update_recent', array( $this, 'ajax_recent_posts' ) );
-
-	}
-
-	function admin_init() {
-
-		$this->admin_ajax_init();
-
-		// Enqueue Scripts and Styles
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
-	}
-
-	function admin_page_init() {
-		// Set up page
-		add_menu_page( __( 'Zoninator', 'zoninator' ), __( 'Zones', 'zoninator' ), $this->_get_manage_zones_cap(), $this->key, array( $this, 'admin_page' ), '', 11 );
-	}
-
-	function admin_enqueue_scripts() {
-		if( $this->is_zoninator_page() ) {
-			wp_enqueue_script( 'zoninator-js', ZONINATOR_URL . 'js/zoninator.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-widget', 'jquery-ui-mouse', 'jquery-ui-position', 'jquery-ui-sortable', 'jquery-ui-autocomplete' ), ZONINATOR_VERSION, true );
-
-			$options = array(
-				'baseUrl' => $this->_get_zone_page_url(),
-				'adminUrl' => admin_url(),
-				'ajaxNonceAction' => $this->_get_nonce_key( $this->zone_ajax_nonce_action ),
-				'errorGeneral' => $this->_get_message( 'error-general' ),
-				'errorZoneLock' => sprintf( $this->_get_message( 'error-zone-lock' ), __( 'another user', 'zoninator' ) ),
-				'errorZoneLockMax' => $this->_get_message( 'error-zone-lock-max' ),
-				'zoneLockPeriod' => $this->zone_lock_period,
-				'zoneLockPeriodMax' => $this->zone_max_lock_period,
+		function init() {
+			$this->zone_messages = array(
+				'insert-success'      => __( 'The zone was successfully created.', 'zoninator' ),
+				'update-success'      => __( 'The zone was successfully updated.', 'zoninator' ),
+				'delete-success'      => __( 'The zone was successfully deleted.', 'zoninator' ),
+				'error-general'       => __( 'Sorry, something went wrong! Please try again?', 'zoninator' ),
+				'error-zone-lock'     => __( 'Sorry, this zone is in use by %s and is currently locked. Please try again later.', 'zoninator' ),
+				'error-zone-lock-max' => __( 'Sorry, you have reached the maximum idle limit and will now be redirected to the Dashboard.', 'zoninator' ),
 			);
-			wp_localize_script( 'zoninator-js', 'zoninatorOptions', $options );
 
-			// For mobile support
-			// http://github.com/furf/jquery-ui-touch-punch
-			wp_enqueue_script( 'jquery-ui-touch-punch', ZONINATOR_URL . 'js/jquery.ui.touch-punch.min.js', array( 'jquery-ui-core', 'jquery-ui-widget', 'jquery-ui-mouse' ) );
+			$this->zone_lock_period     = apply_filters( 'zoninator_zone_lock_period', $this->zone_lock_period );
+			$this->zone_max_lock_period = apply_filters( 'zoninator_zone_max_lock_period', $this->zone_max_lock_period );
+			$this->posts_per_page       = apply_filters( 'zoninator_posts_per_page', $this->posts_per_page );
 
+			do_action( 'zoninator_pre_init' );
+
+			// Default post type support
+			foreach ( $this->default_post_types as $post_type ) {
+				add_post_type_support( $post_type, $this->zone_taxonomy );
+			}
+
+			// Register taxonomy
+			if ( ! taxonomy_exists( $this->zone_taxonomy ) ) {
+				register_taxonomy(
+					$this->zone_taxonomy,
+					$this->get_supported_post_types(),
+					array(
+						'label'        => __( 'Zones', 'zoninator' ),
+						'hierarchical' => false,
+						'query_var'    => false,
+						'rewrite'      => false,
+						'public'       => false,
+
+					)
+				);
+			}
+
+			add_action( 'admin_init', array( $this, 'admin_controller' ) );
+			add_action( 'admin_init', array( $this, 'admin_init' ) );
+
+			add_action( 'admin_menu', array( $this, 'admin_page_init' ) );
+
+			// Add default advanced search fields
+			add_action( 'zoninator_advanced_search_fields', array( $this, 'zone_advanced_search_cat_filter' ) );
+			add_action( 'zoninator_advanced_search_fields', array( $this, 'zone_advanced_search_date_filter' ), 20 );
+
+			do_action( 'zoninator_post_init' );
 		}
-	}
 
-	function admin_enqueue_styles() {
-		if( $this->is_zoninator_page() ) {
-			wp_enqueue_style( 'zoninator-jquery-ui', ZONINATOR_URL . 'css/jquery-ui/smoothness/jquery-ui-zoninator.css', false, ZONINATOR_VERSION, 'all' );
-			wp_enqueue_style( 'zoninator-styles', ZONINATOR_URL . 'css/zoninator.css', false, ZONINATOR_VERSION, 'all' );
+		public function load_textdomain() {
+			load_plugin_textdomain( 'zoninator', false, basename( ZONINATOR_PATH ) . '/language' );
 		}
-	}
 
-	function admin_controller() {
-		if( $this->is_zoninator_page() ) {
-			$action = $this->_get_request_var( 'action' );
+		function widgets_init() {
+			register_widget( 'Zoninator_ZonePosts_Widget' );
+		}
 
-			switch( $action ) {
+		// Add necessary AJAX actions
+		function admin_ajax_init() {
+			add_action( 'wp_ajax_zoninator_reorder_posts', array( $this, 'ajax_reorder_posts' ) );
+			add_action( 'wp_ajax_zoninator_add_post', array( $this, 'ajax_add_post' ) );
+			add_action( 'wp_ajax_zoninator_remove_post', array( $this, 'ajax_remove_post' ) );
+			add_action( 'wp_ajax_zoninator_search_posts', array( $this, 'ajax_search_posts' ) );
+			add_action( 'wp_ajax_zoninator_update_lock', array( $this, 'ajax_update_lock' ) );
+			add_action( 'wp_ajax_zoninator_update_recent', array( $this, 'ajax_recent_posts' ) );
+		}
 
-				case 'insert':
-				case 'update':
-					$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
+		function admin_init() {
 
-					$this->verify_nonce( $action );
-					$this->verify_access( $action, $zone_id );
+			$this->admin_ajax_init();
 
-					$name = $this->_get_post_var( 'name', '', array( $this, '_sanitize_value' ) );
-					$slug = $this->_get_post_var( 'slug', sanitize_title( $name ) );
-					$details = array(
-						'description' => $this->_get_post_var( 'description', '', array( $this, '_sanitize_value' ) )
-					);
+			// Enqueue Scripts and Styles
+			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
+		}
 
-					// TODO: handle additional properties
-					if( $zone_id ) {
-						$result = $this->update_zone( $zone_id, array(
-							'name' => $name,
-							'slug' => $slug,
-							'details' => $details
-						) );
+		function admin_page_init() {
+			// Set up page
+			add_menu_page( __( 'Zoninator', 'zoninator' ), __( 'Zones', 'zoninator' ), $this->_get_manage_zones_cap(), $this->key, array( $this, 'admin_page' ), '', 11 );
+		}
 
-					} else {
-						$result = $this->insert_zone( $slug, $name, $details );
-					}
+		function admin_enqueue_scripts() {
+			if ( $this->is_zoninator_page() ) {
+				wp_enqueue_script( 'zoninator-js', ZONINATOR_URL . 'js/zoninator.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-widget', 'jquery-ui-mouse', 'jquery-ui-position', 'jquery-ui-sortable', 'jquery-ui-autocomplete' ), ZONINATOR_VERSION, true );
 
-					if( is_wp_error( $result ) ) {
-						wp_redirect( add_query_arg( 'message', 'error-general' ) );
-						exit;
-					} else {
-						if( ! $zone_id && isset( $result['term_id'] ) )
-							$zone_id = $result['term_id'];
+				$options = array(
+					'baseUrl'           => $this->_get_zone_page_url(),
+					'adminUrl'          => admin_url(),
+					'ajaxNonceAction'   => $this->_get_nonce_key( $this->zone_ajax_nonce_action ),
+					'errorGeneral'      => $this->_get_message( 'error-general' ),
+					'errorZoneLock'     => sprintf( $this->_get_message( 'error-zone-lock' ), __( 'another user', 'zoninator' ) ),
+					'errorZoneLockMax'  => $this->_get_message( 'error-zone-lock-max' ),
+					'zoneLockPeriod'    => $this->zone_lock_period,
+					'zoneLockPeriodMax' => $this->zone_max_lock_period,
+				);
+				wp_localize_script( 'zoninator-js', 'zoninatorOptions', $options );
 
-						// Redirect with success message
-						$message = sprintf( '%s-success', $action );
-						wp_redirect( $this->_get_zone_page_url( array( 'action' => 'edit', 'zone_id' => $zone_id, 'message' => $message ) ) );
-						exit;
-					}
-					break;
-
-				case 'delete':
-					$zone_id = $this->_get_request_var( 'zone_id', 0, 'absint' );
-
-					$this->verify_nonce( $action );
-					$this->verify_access( $action, $zone_id );
-
-					if( $zone_id ) {
-						$result = $this->delete_zone( $zone_id );
-					}
-
-					if( is_wp_error( $result ) ) {
-						$redirect_args = array( 'error' => $result->get_error_messages() );
-					} else {
-						$redirect_args = array( 'message' => 'delete-success' );
-					}
-
-					wp_redirect( $this->_get_zone_page_url( $redirect_args ) );
-					exit;
+				// For mobile support
+				// http://github.com/furf/jquery-ui-touch-punch
+				wp_enqueue_script( 'jquery-ui-touch-punch', ZONINATOR_URL . 'js/jquery.ui.touch-punch.min.js', array( 'jquery-ui-core', 'jquery-ui-widget', 'jquery-ui-mouse' ) );
 			}
 		}
-	}
 
-	function admin_page() {
-		global $zoninator_admin_page;
-
-		$view = $this->_get_value_or_default( 'view', $zoninator_admin_page, 'edit.php' );
-		$view = sprintf( '%s/views/%s', ZONINATOR_PATH, $view );
-		$title = __( 'Zones', 'zoninator' );
-
-		$zones = $this->get_zones( apply_filters( 'zoninator_admin_page_get_zones_args', array() ) );
-
-		$default_active_zone = 0;
-		if( ! $this->_current_user_can_add_zones() ) {
-			if( ! empty( $zones ) )
-				$default_active_zone = $zones[0]->term_id;
+		function admin_enqueue_styles() {
+			if ( $this->is_zoninator_page() ) {
+				wp_enqueue_style( 'zoninator-jquery-ui', ZONINATOR_URL . 'css/jquery-ui/smoothness/jquery-ui-zoninator.css', false, ZONINATOR_VERSION, 'all' );
+				wp_enqueue_style( 'zoninator-styles', ZONINATOR_URL . 'css/zoninator.css', false, ZONINATOR_VERSION, 'all' );
+			}
 		}
 
-		$active_zone_id = $this->_get_request_var( 'zone_id', $default_active_zone, 'absint' );
-		$active_zone = ! empty( $active_zone_id ) ? $this->get_zone( $active_zone_id ) : array();
-		if ( ! empty( $active_zone ) )
-			$title = __( 'Edit Zone', 'zoninator' );
+		function admin_controller() {
+			if ( $this->is_zoninator_page() ) {
+				$action = $this->_get_request_var( 'action' );
 
-		$message = $this->_get_message( $this->_get_get_var( 'message', '', 'urldecode' ) );
-		$error = $this->_get_get_var( 'error', '', 'urldecode' );
+				switch ( $action ) {
+					case 'insert':
+					case 'update':
+						$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
 
-		?>
+						$this->verify_nonce( $action );
+						$this->verify_access( $action, $zone_id );
+
+						$name    = $this->_get_post_var( 'name', '', array( $this, '_sanitize_value' ) );
+						$slug    = $this->_get_post_var( 'slug', sanitize_title( $name ) );
+						$details = array(
+							'description' => $this->_get_post_var( 'description', '', array( $this, '_sanitize_value' ) ),
+						);
+
+						// TODO: handle additional properties
+						if ( $zone_id ) {
+							$result = $this->update_zone(
+								$zone_id,
+								array(
+									'name'    => $name,
+									'slug'    => $slug,
+									'details' => $details,
+								)
+							);
+						} else {
+							$result = $this->insert_zone( $slug, $name, $details );
+						}
+
+						if ( is_wp_error( $result ) ) {
+							wp_redirect( add_query_arg( 'message', 'error-general' ) );
+							exit;
+						} else {
+							if ( ! $zone_id && isset( $result['term_id'] ) ) {
+								$zone_id = $result['term_id'];
+							}
+
+							// Redirect with success message
+							$message = sprintf( '%s-success', $action );
+							wp_redirect(
+								$this->_get_zone_page_url(
+									array(
+										'action'  => 'edit',
+										'zone_id' => $zone_id,
+										'message' => $message,
+									)
+								)
+							);
+							exit;
+						}
+						break;
+
+					case 'delete':
+						$zone_id = $this->_get_request_var( 'zone_id', 0, 'absint' );
+
+						$this->verify_nonce( $action );
+						$this->verify_access( $action, $zone_id );
+
+						if ( $zone_id ) {
+							$result = $this->delete_zone( $zone_id );
+						}
+
+						if ( is_wp_error( $result ) ) {
+							$redirect_args = array( 'error' => $result->get_error_messages() );
+						} else {
+							$redirect_args = array( 'message' => 'delete-success' );
+						}
+
+						wp_redirect( $this->_get_zone_page_url( $redirect_args ) );
+						exit;
+				}
+			}
+		}
+
+		function admin_page() {
+			global $zoninator_admin_page;
+
+			$view  = $this->_get_value_or_default( 'view', $zoninator_admin_page, 'edit.php' );
+			$view  = sprintf( '%s/views/%s', ZONINATOR_PATH, $view );
+			$title = __( 'Zones', 'zoninator' );
+
+			$zones = $this->get_zones( apply_filters( 'zoninator_admin_page_get_zones_args', array() ) );
+
+			$default_active_zone = 0;
+			if ( ! $this->_current_user_can_add_zones() ) {
+				if ( ! empty( $zones ) ) {
+					$default_active_zone = $zones[0]->term_id;
+				}
+			}
+
+			$active_zone_id = $this->_get_request_var( 'zone_id', $default_active_zone, 'absint' );
+			$active_zone    = ! empty( $active_zone_id ) ? $this->get_zone( $active_zone_id ) : array();
+			if ( ! empty( $active_zone ) ) {
+				$title = __( 'Edit Zone', 'zoninator' );
+			}
+
+			$message = $this->_get_message( $this->_get_get_var( 'message', '', 'urldecode' ) );
+			$error   = $this->_get_get_var( 'error', '', 'urldecode' );
+
+			?>
 		<div class="wrap zoninator-page">
 			<div id="icon-edit-pages" class="icon32"><br /></div>
 			<h2>
 				<?php echo esc_html( $title ); ?>
-				<?php if( $this->_current_user_can_add_zones() ) :
-					$new_link = $this->_get_zone_page_url( array( 'action' => 'new' ) ); ?>
-					<?php if( $active_zone_id ) : ?>
+				<?php
+				if ( $this->_current_user_can_add_zones() ) :
+					$new_link = $this->_get_zone_page_url( array( 'action' => 'new' ) );
+					?>
+					<?php if ( $active_zone_id ) : ?>
 						<a href="<?php echo esc_url( $new_link ); ?>" class="add-new-h2 zone-button-add-new"><?php esc_html_e( 'Add New', 'zoninator' ); ?></a>
 					<?php else : ?>
 						<span class="nav-tab nav-tab-active zone-tab zone-tab-active"><?php esc_html_e( 'Add New', 'zoninator' ); ?></span>
@@ -308,12 +324,12 @@ class Zoninator
 				<?php endif; ?>
 			</h2>
 
-			<?php if( $message ) : ?>
+				<?php if ( $message ) : ?>
 				<div id="zone-message" class="updated below-h2">
 					<p><?php echo esc_html( $message ); ?></p>
 				</div>
 			<?php endif; ?>
-			<?php if( $error ) : ?>
+				<?php if ( $error ) : ?>
 				<div id="zone-message" class="error below-h2">
 					<p><?php echo esc_html( $error ); ?></p>
 				</div>
@@ -321,26 +337,33 @@ class Zoninator
 
 			<div id="zoninator-wrap">
 
-				<?php $this->admin_page_zone_tabs( $zones, $active_zone_id ); ?>
-				<?php $this->admin_page_zone_edit( $active_zone ); ?>
+					<?php $this->admin_page_zone_tabs( $zones, $active_zone_id ); ?>
+					<?php $this->admin_page_zone_edit( $active_zone ); ?>
 
 			</div>
 		</div>
-		<?php
-	}
+			<?php
+		}
 
-	function admin_page_zone_tabs( $zones, $active_zone_id = 0 ) {
-		$new_link = $this->_get_zone_page_url( array( 'action' => 'new' ) );
-		?>
+		function admin_page_zone_tabs( $zones, $active_zone_id = 0 ) {
+			$new_link = $this->_get_zone_page_url( array( 'action' => 'new' ) );
+			?>
 		<div class="nav-tabs-container zone-tabs-container">
 			<div class="nav-tabs-nav-wrapper zone-tabs-nav-wrapper">
 				<div class="nav-tabs-wrapper zone-tabs-wrapper">
 					<div class="nav-tabs zone-tabs">
-						<?php foreach( $zones as $zone ) : ?>
+						<?php foreach ( $zones as $zone ) : ?>
 							<?php $zone_id = $this->get_zone_id( $zone ); ?>
-							<?php $zone_link = $this->_get_zone_page_url( array( 'action' => 'edit', 'zone_id' => $zone_id ) ); ?>
+							<?php
+							$zone_link = $this->_get_zone_page_url(
+								array(
+									'action'  => 'edit',
+									'zone_id' => $zone_id,
+								)
+							);
+							?>
 
-							<?php if( $active_zone_id && $zone_id == $active_zone_id ) : ?>
+							<?php if ( $active_zone_id && $zone_id == $active_zone_id ) : ?>
 								<span class="nav-tab nav-tab-active zone-tab zone-tab-active"><?php echo esc_html( $zone->name ); ?></span>
 							<?php else : ?>
 								<a href="<?php echo esc_url( $zone_link ); ?>" class="nav-tab zone-tab"><?php echo esc_html( $zone->name ); ?></a>
@@ -350,35 +373,40 @@ class Zoninator
 				</div>
 			</div>
 		</div>
-		<?php
-	}
+			<?php
+		}
 
-	function admin_page_zone_edit( $zone = null ) {
-		$zone_id = $this->_get_value_or_default( 'term_id', $zone, 0, 'absint' );
-		$zone_name = $this->_get_value_or_default( 'name', $zone );
-		$zone_slug = $this->_get_value_or_default( 'slug', $zone, '', array( $this, 'get_unformatted_zone_slug' ) );
-		$zone_description = $this->_get_value_or_default( 'description', $zone );
+		function admin_page_zone_edit( $zone = null ) {
+			$zone_id          = $this->_get_value_or_default( 'term_id', $zone, 0, 'absint' );
+			$zone_name        = $this->_get_value_or_default( 'name', $zone );
+			$zone_slug        = $this->_get_value_or_default( 'slug', $zone, '', array( $this, 'get_unformatted_zone_slug' ) );
+			$zone_description = $this->_get_value_or_default( 'description', $zone );
 
-		$zone_posts = $zone_id ? $this->get_zone_posts( $zone ) : array();
+			$zone_posts = $zone_id ? $this->get_zone_posts( $zone ) : array();
 
-		$zone_locked = $this->is_zone_locked( $zone_id );
+			$zone_locked = $this->is_zone_locked( $zone_id );
 
-		$delete_link = $this->_get_zone_page_url( array( 'action' => 'delete', 'zone_id' => $zone_id ) );
-		$delete_link = wp_nonce_url( $delete_link, $this->_get_nonce_key( 'delete' ) );
-		?>
+			$delete_link = $this->_get_zone_page_url(
+				array(
+					'action'  => 'delete',
+					'zone_id' => $zone_id,
+				)
+			);
+			$delete_link = wp_nonce_url( $delete_link, $this->_get_nonce_key( 'delete' ) );
+			?>
 		<div id="zone-edit-wrapper">
-			<?php if( ( $zone_id == 0 && $this->_current_user_can_add_zones() ) || ( $zone_id != 0 && $this->_current_user_can_manage_zones() ) ) : ?>
-				<?php if( $zone_locked ) : ?>
+			<?php if ( ( $zone_id == 0 && $this->_current_user_can_add_zones() ) || ( $zone_id != 0 && $this->_current_user_can_manage_zones() ) ) : ?>
+				<?php if ( $zone_locked ) : ?>
 					<?php $locking_user = get_userdata( $zone_locked ); ?>
 					<div class="updated below-h2">
-						<p><?php echo sprintf( $this->_get_message( 'error-zone-lock' ), sprintf( '<a href="mailto:%s">%s</a>', esc_attr( $locking_user->user_email ), esc_html( $locking_user->display_name ) ) ); ?></p>
+						<p><?php printf( $this->_get_message( 'error-zone-lock' ), sprintf( '<a href="mailto:%s">%s</a>', esc_attr( $locking_user->user_email ), esc_html( $locking_user->display_name ) ) ); ?></p>
 					</div>
 					<input type="hidden" id="zone-locked" name="zone-locked" value="1" />
 				<?php endif; ?>
 				<div class="col-wrap zone-col zone-info-col">
 					<div class="form-wrap zone-form zone-info-form">
 
-						<?php if( $this->_current_user_can_edit_zones( $zone_id ) && ! $zone_locked ) : ?>
+						<?php if ( $this->_current_user_can_edit_zones( $zone_id ) && ! $zone_locked ) : ?>
 
 							<form id="zone-info" method="post">
 
@@ -389,7 +417,7 @@ class Zoninator
 									<input type="text" id="zone-name" name="name" value="<?php echo esc_attr( $zone_name ); ?>" />
 								</div>
 
-								<?php if( $zone_id ) : ?>
+								<?php if ( $zone_id ) : ?>
 								<div class="form-field zone-field">
 									<label for="zone-slug"><?php esc_html_e( 'Slug', 'zoninator' ); ?></label>
 									<span><?php echo esc_attr( $zone_slug ); ?></span>
@@ -404,18 +432,18 @@ class Zoninator
 
 								<?php do_action( 'zoninator_post_zone_fields', $zone ); ?>
 
-								<?php if( $zone_id ) : ?>
-									<input type="hidden" name="zone_id" id="zone_id" value="<?php echo esc_attr( $zone_id ) ?>" />
+								<?php if ( $zone_id ) : ?>
+									<input type="hidden" name="zone_id" id="zone_id" value="<?php echo esc_attr( $zone_id ); ?>" />
 									<?php wp_nonce_field( $this->_get_nonce_key( 'update' ) ); ?>
 								<?php else : ?>
 									<?php wp_nonce_field( $this->_get_nonce_key( 'insert' ) ); ?>
 								<?php endif; ?>
 
 								<div class="submit-field submitbox">
-									<input type="submit" value="<?php esc_attr_e('Save zone info', 'zoninator'); ?>" name="submit" class="button" />
+									<input type="submit" value="<?php esc_attr_e( 'Save zone info', 'zoninator' ); ?>" name="submit" class="button" />
 
-									<?php if( $zone_id ) : ?>
-										<a href="<?php echo $delete_link ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( 'Are you sure you want to delete this zone?', 'zoninator' ); ?>')"><?php esc_html_e('Delete', 'zoninator') ?></a>
+									<?php if ( $zone_id ) : ?>
+										<a href="<?php echo $delete_link; ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( 'Are you sure you want to delete this zone?', 'zoninator' ); ?>')"><?php esc_html_e( 'Delete', 'zoninator' ); ?></a>
 									<?php endif; ?>
 								</div>
 
@@ -444,7 +472,7 @@ class Zoninator
 									<span><?php echo esc_html( $zone_description ); ?></span>
 								</div>
 
-								<input type="hidden" name="zone_id" id="zone_id" value="<?php echo esc_attr( $zone_id ) ?>" />
+								<input type="hidden" name="zone_id" id="zone_id" value="<?php echo esc_attr( $zone_id ); ?>" />
 
 								<?php do_action( 'zoninator_post_zone_readonly', $zone ); ?>
 							</div>
@@ -458,7 +486,7 @@ class Zoninator
 
 				<div class="col-wrap zone-col zone-posts-col">
 					<div class="zone-posts-wrapper <?php echo ! $this->_current_user_can_manage_zones( $zone_id ) || $zone_locked ? 'readonly' : ''; ?>">
-						<?php if( $zone_id ) : ?>
+						<?php if ( $zone_id ) : ?>
 							<h3><?php esc_html_e( 'Zone Content', 'zoninator' ); ?></h3>
 
 							<?php $this->zone_advanced_search_filters(); ?>
@@ -473,7 +501,7 @@ class Zoninator
 							</div>
 
 							<div class="zone-posts-list">
-								<?php foreach( $zone_posts as $post ) : ?>
+								<?php foreach ( $zone_posts as $post ) : ?>
 									<?php $this->admin_page_zone_post( $post, $zone ); ?>
 								<?php endforeach; ?>
 							</div>
@@ -486,20 +514,25 @@ class Zoninator
 			<?php endif; ?>
 		</div>
 
-		<?php
-	}
+			<?php
+		}
 
-	function admin_page_zone_post( $post, $zone ) {
-		$columns = apply_filters( 'zoninator_zone_post_columns', array(
-			'position' => array( $this, 'admin_page_zone_post_col_position' ),
-			'info' => array( $this, 'admin_page_zone_post_col_info' )
-		), $post, $zone );
-		?>
+		function admin_page_zone_post( $post, $zone ) {
+			$columns = apply_filters(
+				'zoninator_zone_post_columns',
+				array(
+					'position' => array( $this, 'admin_page_zone_post_col_position' ),
+					'info'     => array( $this, 'admin_page_zone_post_col_info' ),
+				),
+				$post,
+				$zone
+			);
+			?>
 		<div id="zone-post-<?php echo $post->ID; ?>" class="zone-post" data-post-id="<?php echo $post->ID; ?>">
 			<table>
 				<tr>
-					<?php foreach( $columns as $column_key => $column_callback ) : ?>
-						<?php if( is_callable( $column_callback ) ) : ?>
+					<?php foreach ( $columns as $column_key => $column_callback ) : ?>
+						<?php if ( is_callable( $column_callback ) ) : ?>
 							<td class="zone-post-col zone-post-<?php echo $column_key; ?>">
 								<?php call_user_func( $column_callback, $post, $zone ); ?>
 							</td>
@@ -509,1221 +542,1292 @@ class Zoninator
 			</table>
 			<input type="hidden" name="zone-post-id" value="<?php echo $post->ID; ?>" />
 		</div>
-		<?php
-	}
+			<?php
+		}
 
-	function admin_page_zone_post_col_position( $post, $zone ) {
-		$current_position = $this->get_post_order( $post->ID, $zone );
-		?>
+		function admin_page_zone_post_col_position( $post, $zone ) {
+			$current_position = $this->get_post_order( $post->ID, $zone );
+			?>
 		<span title="<?php esc_attr_e( 'Click and drag to change the position of this item.', 'zoninator' ); ?>">
 			<?php echo esc_html( $current_position ); ?>
 		</span>
-		<?php
-	}
-	function admin_page_zone_post_col_info( $post, $zone ) {
-		$action_links = array(
-			sprintf( '<a href="%s" class="edit" target="_blank" title="%s">%s</a>', get_edit_post_link( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'Edit', 'zoninator' ) ),
-			sprintf( '<a href="#" class="delete" title="%s">%s</a>', __( 'Remove this item from the zone', 'zoninator' ), __( 'Remove', 'zoninator' ) ),
-			sprintf( '<a href="%s" class="view" target="_blank" title="%s">%s</a>', get_permalink( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'View', 'zoninator' ) ),
+			<?php
+		}
+		function admin_page_zone_post_col_info( $post, $zone ) {
+			$action_links = array(
+				sprintf( '<a href="%s" class="edit" target="_blank" title="%s">%s</a>', get_edit_post_link( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'Edit', 'zoninator' ) ),
+				sprintf( '<a href="#" class="delete" title="%s">%s</a>', __( 'Remove this item from the zone', 'zoninator' ), __( 'Remove', 'zoninator' ) ),
+				sprintf( '<a href="%s" class="view" target="_blank" title="%s">%s</a>', get_permalink( $post->ID ), __( 'Opens in new window', 'zoninator' ), __( 'View', 'zoninator' ) ),
 			// Move To
 			// Copy To
-		);
-		?>
-		<?php echo sprintf( '%s <span class="zone-post-status">(%s)</span>', esc_html( $post->post_title ), esc_html( $post->post_status ) ); ?>
+			);
+			?>
+			<?php printf( '%s <span class="zone-post-status">(%s)</span>', esc_html( $post->post_title ), esc_html( $post->post_status ) ); ?>
 
 		<div class="row-actions">
 			<?php echo implode( ' | ', $action_links ); ?>
 		</div>
-		<?php
-	}
+			<?php
+		}
 
-	function zone_advanced_search_filters() {
-		?>
+		function zone_advanced_search_filters() {
+			?>
 		<div class="zone-advanced-search-filters-heading">
 			<span class="zone-toggle-advanced-search" data-alt-label="<?php esc_attr_e( 'Hide', 'zoninator' ); ?>"><?php esc_html_e( 'Show Filters', 'zoninator' ); ?></span>
 		</div>
 		<div class="zone-advanced-search-filters-wrapper">
 			<?php do_action( 'zoninator_advanced_search_fields' ); ?>
 		</div>
-		<?php
-	}
+			<?php
+		}
 
-	function zone_advanced_search_cat_filter() {
-		$current_cat = $this->_get_post_var( 'zone_advanced_filter_taxonomy', '', 'absint' );
-		?>
+		function zone_advanced_search_cat_filter() {
+			$current_cat = $this->_get_post_var( 'zone_advanced_filter_taxonomy', '', 'absint' );
+			?>
 		<label for="zone_advanced_filter_taxonomy"><?php esc_html_e( 'Filter:', 'zoninator' ); ?></label>
-		<?php
-		wp_dropdown_categories( apply_filters( 'zoninator_advanced_filter_category', array(
-			'show_option_all' =>  __( 'Show all Categories', 'zoninator' ),
-			'selected' => $current_cat,
-			'name' => 'zone_advanced_filter_taxonomy',
-			'id' => 'zone_advanced_filter_taxonomy',
-			'hide_if_empty' => true,
-		) ) );
-	}
+			<?php
+			wp_dropdown_categories(
+				apply_filters(
+					'zoninator_advanced_filter_category',
+					array(
+						'show_option_all' => __( 'Show all Categories', 'zoninator' ),
+						'selected'        => $current_cat,
+						'name'            => 'zone_advanced_filter_taxonomy',
+						'id'              => 'zone_advanced_filter_taxonomy',
+						'hide_if_empty'   => true,
+					)
+				)
+			);
+		}
 
-	function zone_advanced_search_date_filter() {
-		$current_date = $this->_get_post_var( 'zone_advanced_filter_date', apply_filters( 'zoninator_advanced_filter_date_default', '' ), 'striptags' );
-		$date_filters = apply_filters( 'zoninator_advanced_filter_date', array( 'all', 'today', 'yesterday') );
-		?>
+		function zone_advanced_search_date_filter() {
+			$current_date = $this->_get_post_var( 'zone_advanced_filter_date', apply_filters( 'zoninator_advanced_filter_date_default', '' ), 'striptags' );
+			$date_filters = apply_filters( 'zoninator_advanced_filter_date', array( 'all', 'today', 'yesterday' ) );
+			?>
 		<select name="zone_advanced_filter_date" id="zone_advanced_filter_date">
 			<?php
 			// Convert string dates into actual dates
-			foreach( $date_filters as $date ) :
+			foreach ( $date_filters as $date ) :
 				if ( true === is_array( $date ) ) {
 					$output = array_key_exists( 'value', $date ) ? $date['value'] : 0;
-					$label = array_key_exists( 'label', $date ) ? $date['label'] : $output;
+					$label  = array_key_exists( 'label', $date ) ? $date['label'] : $output;
 				} else {
 					$timestamp = strtotime( $date );
-					$output = ( $timestamp ) ? date( 'Y-m-d', $timestamp ) : 0;
-					$label = $date;
+					$output    = ( $timestamp ) ? date( 'Y-m-d', $timestamp ) : 0;
+					$label     = $date;
 				}
-				echo sprintf( '<option value="%s" %s>%s</option>', esc_attr( $output ), selected( $output, $current_date, false ), esc_html( $label ) );
-			endforeach;
+				printf( '<option value="%s" %s>%s</option>', esc_attr( $output ), selected( $output, $current_date, false ), esc_html( $label ) );
+				endforeach;
 			?>
 		</select>
-		<?php
-	}
+			<?php
+		}
 
-	function ajax_recent_posts() {
+		function ajax_recent_posts() {
 
-		$cat = $this->_get_post_var( 'cat', '', 'absint' );
-		$date = $this->_get_post_var( 'date', '', 'striptags' );
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
+			$cat     = $this->_get_post_var( 'cat', '', 'absint' );
+			$date    = $this->_get_post_var( 'date', '', 'striptags' );
+			$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
 
-		$limit = $this->posts_per_page;
-		$post_types = $this->get_supported_post_types();
-		$zone_posts = $this->get_zone_posts( $zone_id );
-		$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
+			$limit         = $this->posts_per_page;
+			$post_types    = $this->get_supported_post_types();
+			$zone_posts    = $this->get_zone_posts( $zone_id );
+			$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
 
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
+			// Verify nonce
+			$this->verify_nonce( $this->zone_ajax_nonce_action );
+			$this->verify_access( '', $zone_id );
 
-		if( is_wp_error( $zone_posts ) ) {
-			$status = 0;
-			$content = $zone_posts->get_error_message();
-		} else {
-			$args = apply_filters( 'zoninator_recent_posts_args', array(
-				'posts_per_page' => $limit,
-				'order' => 'DESC',
-				'orderby' => 'post_date',
-				'post_type' => $post_types,
-				'ignore_sticky_posts' => true,
-				'post_status' => array( 'publish', 'future' ),
-				'post__not_in' => $zone_post_ids,
-				'suppress_filters' => false,
-			) );
+			if ( is_wp_error( $zone_posts ) ) {
+				$status  = 0;
+				$content = $zone_posts->get_error_message();
+			} else {
+				$args = apply_filters(
+					'zoninator_recent_posts_args',
+					array(
+						'posts_per_page'      => $limit,
+						'order'               => 'DESC',
+						'orderby'             => 'post_date',
+						'post_type'           => $post_types,
+						'ignore_sticky_posts' => true,
+						'post_status'         => array( 'publish', 'future' ),
+						'post__not_in'        => $zone_post_ids,
+						'suppress_filters'    => false,
+					)
+				);
 
-			if ( $this->_validate_category_filter( $cat ) ) {
-				$args['cat'] = $cat;
+				if ( $this->_validate_category_filter( $cat ) ) {
+					$args['cat'] = $cat;
+				}
+
+				if ( $this->_validate_date_filter( $date ) ) {
+					$filter_date_parts = explode( '-', $date );
+					$args['year']      = $filter_date_parts[0];
+					$args['monthnum']  = $filter_date_parts[1];
+					$args['day']       = $filter_date_parts[2];
+				}
+
+				$content      = '';
+				$recent_posts = get_posts( $args );
+				foreach ( $recent_posts as $post ) :
+					$content .= sprintf( '<option value="%d">%s</option>', $post->ID, get_the_title( $post->ID ) . ' (' . $post->post_status . ')' );
+				endforeach;
+				wp_reset_postdata();
+				$status = 1;
 			}
 
-			if ( $this->_validate_date_filter( $date ) ) {
-				$filter_date_parts = explode( '-', $date );
-				$args['year'] = $filter_date_parts[0];
-				$args['monthnum'] = $filter_date_parts[1];
-				$args['day'] = $filter_date_parts[2];
+			$empty_label = '';
+			if ( ! $content ) {
+				$empty_label = __( 'No results found', 'zoninator' );
+			} elseif ( $cat ) {
+				$empty_label = sprintf( __( 'Choose post from %s', 'zoninator' ), get_the_category_by_ID( $cat ) );
+			} else {
+				$empty_label = __( 'Choose a post', 'zoninator' );
 			}
 
-			$content = '';
+			$content = '<option value="">' . esc_html( $empty_label ) . '</option>' . $content;
+
+			$this->ajax_return( $status, $content );
+		}
+
+		function zone_admin_recent_posts_dropdown( $zone_id ) {
+
+			$limit         = $this->posts_per_page;
+			$post_types    = $this->get_supported_post_types();
+			$zone_posts    = $this->get_zone_posts( $zone_id );
+			$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
+
+			$args = apply_filters(
+				'zoninator_recent_posts_args',
+				array(
+					'posts_per_page'      => $limit,
+					'order'               => 'DESC',
+					'orderby'             => 'post_date',
+					'post_type'           => $post_types,
+					'ignore_sticky_posts' => true,
+					'post_status'         => array( 'publish', 'future' ),
+					'post__not_in'        => $zone_post_ids,
+					'suppress_filters'    => false,
+				)
+			);
+
 			$recent_posts = get_posts( $args );
-			foreach ( $recent_posts as $post ) :
-				$content .= sprintf( '<option value="%d">%s</option>', $post->ID, get_the_title( $post->ID ) . ' (' . $post->post_status . ')' );
-			endforeach;
-			wp_reset_postdata();
-			$status = 1;
-		}
-
-		$empty_label = '';
-		if ( ! $content ) {
-			$empty_label =  __( 'No results found', 'zoninator' );
-		} elseif ( $cat ) {
-			$empty_label = sprintf( __( 'Choose post from %s', 'zoninator' ), get_the_category_by_ID( $cat ) );
-		} else {
-			$empty_label = __( 'Choose a post', 'zoninator' );
-		}
-
-		$content = '<option value="">' . esc_html( $empty_label ) . '</option>' . $content;
-
-		$this->ajax_return( $status, $content );
-	}
-
-	function zone_admin_recent_posts_dropdown( $zone_id ) {
-
-		$limit = $this->posts_per_page;
-		$post_types = $this->get_supported_post_types();
-		$zone_posts = $this->get_zone_posts( $zone_id );
-		$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
-
-		$args = apply_filters( 'zoninator_recent_posts_args', array(
-			'posts_per_page' => $limit,
-			'order' => 'DESC',
-			'orderby' => 'post_date',
-			'post_type' => $post_types,
-			'ignore_sticky_posts' => true,
-			'post_status' => array( 'publish', 'future' ),
-			'post__not_in' => $zone_post_ids,
-			'suppress_filters' => false,
-		) );
-
-		$recent_posts = get_posts( $args );
-		?>
+			?>
 		<div class="zone-search-wrapper">
-			<label for="zone-post-search-latest"><?php esc_html_e( 'Add Recent Content', 'zoninator' );?></label><br />
+			<label for="zone-post-search-latest"><?php esc_html_e( 'Add Recent Content', 'zoninator' ); ?></label><br />
 			<select name="search-posts" id="zone-post-latest">
 				<option value=""><?php esc_html_e( 'Choose a post', 'zoninator' ); ?></option>
 				<?php
 				foreach ( $recent_posts as $post ) :
-					echo sprintf( '<option value="%d">%s</option>', $post->ID, esc_html( get_the_title( $post->ID ) . ' (' . $post->post_status . ')' ) );
-				endforeach;
+					printf( '<option value="%d">%s</option>', $post->ID, esc_html( get_the_title( $post->ID ) . ' (' . $post->post_status . ')' ) );
+					endforeach;
 				wp_reset_postdata();
 				?>
 			</select>
 		</div>
-		<?php
-	}
+			<?php
+		}
 
-	function zone_admin_search_form() {
-		?>
+		function zone_admin_search_form() {
+			?>
 		<div class="zone-search-wrapper">
-			<label for="zone-post-search"><?php esc_html_e( 'Search for content', 'zoninator' );?></label>
+			<label for="zone-post-search"><?php esc_html_e( 'Search for content', 'zoninator' ); ?></label>
 			<input type="text" id="zone-post-search" name="search" />
 			<p class="description"><?php esc_html_e( 'Enter a term or phrase in the text box above to search for and add content to this zone.', 'zoninator' ); ?></p>
 		</div>
-		<?php
-	}
-
-	function is_zoninator_page() {
-		global $current_screen;
-
-		if( function_exists( 'get_current_screen' ) )
-			$screen = get_current_screen();
-
-		if( empty( $screen ) ) {
-			return ! empty( $_REQUEST['page'] ) && sanitize_key( $_REQUEST['page'] ) == $this->key;
-		} else {
-			return ! empty( $screen->id ) && strstr( $screen->id, $this->key );
-		}
-	}
-
-	function ajax_return( $status, $content = '', $action = '' ) {
-		$action = ! empty( $action ) ? $action : $this->zone_ajax_nonce_action;
-		$nonce = wp_create_nonce( $this->_get_nonce_key( $action ) );
-
-		echo json_encode( array(
-			'status' => $status,
-			'content' => $content,
-			'nonce' => $nonce,
-		) );
-		exit;
-	}
-
-	function ajax_add_post() {
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
-		$post_id = $this->_get_post_var( 'post_id', 0, 'absint' );
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		// Validate
-		if( ! $zone_id || ! $post_id )
-			$this->ajax_return( 0 );
-
-		$result = $this->add_zone_posts( $zone_id, $post_id, true );
-
-		if( is_wp_error( $result ) ) {
-			$status = 0;
-			$content = $result->get_error_message();
-		} else {
-			$post = get_post( $post_id );
-			$zone = $this->get_zone( $zone_id );
-
-			ob_start();
-			$this->admin_page_zone_post( $post, $zone );
-			$content = ob_get_contents();
-			ob_end_clean();
-
-			$status = 1;
+			<?php
 		}
 
-		$this->ajax_return( $status, $content );
-	}
+		function is_zoninator_page() {
+			global $current_screen;
 
-	function ajax_remove_post() {
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
-		$post_id = $this->_get_post_var( 'post_id', 0, 'absint' );
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		// Validate
-		if( ! $zone_id || ! $post_id )
-			$this->ajax_return( 0 );
-
-		$result = $this->remove_zone_posts( $zone_id, $post_id );
-
-		if( is_wp_error( $result ) ) {
-			$status = 0;
-			$content = $result->get_error_message();
-		} else {
-			$status = 1;
-			$content = '';
-		}
-
-		$this->ajax_return( $status, $content );
-	}
-
-	function ajax_reorder_posts() {
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
-		$post_ids = (array) $this->_get_post_var( 'posts', array(), 'absint' );
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		// validate
-		if( ! $zone_id || empty( $post_ids ) )
-			$this->ajax_return( 0 );
-
-		$result = $this->add_zone_posts( $zone_id, $post_ids, false );
-
-		if( is_wp_error( $result ) ) {
-			$status = 0;
-			$content = $result->get_error_message();
-		} else {
-			$status = 1;
-			$content = '';
-		}
-
-		$this->ajax_return( $status, $content );
-	}
-
-	// TODO: implement in front-end
-	function ajax_move_zone_post( $from_zone, $to_zone, $post_id ) {
-		$from_zone_id = $this->_get_post_var( 'from_zone_id', 0, 'absint' );
-		$to_zone_id = $this->_get_post_var( 'to_zone_id', 0, 'absint' );
-
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-
-		// TODO: validate both zones exist, post exists
-
-		// Add to new zone
-		$this->add_zone_posts( $to_zone_id, $post_id, true );
-
-		// Remove from old zone
-		$this->remove_zone_posts( $from_zone_id, $post_id );
-	}
-
-	function ajax_search_posts() {
-
-		$q = $this->_get_request_var( 'term', '', 'stripslashes' );
-
-		if( ! empty( $q ) ) {
-
-			$filter_cat = $this->_get_request_var( 'cat', '', 'absint' );
-			$filter_date = $this->_get_request_var( 'date', '', 'striptags' );
-
-			$post_types = $this->get_supported_post_types();
-			$limit = $this->_get_request_var( 'limit', $this->posts_per_page );
-			if( $limit <= 0 )
-				$limit = $this->posts_per_page;
-			$exclude = (array) $this->_get_request_var( 'exclude', array(), 'absint' );
-
-			$args = apply_filters( 'zoninator_search_args', array(
-				's' => $q,
-				'post__not_in' => $exclude,
-				'posts_per_page' => $limit,
-				'post_type' => $post_types,
-				'post_status' => array( 'publish', 'future' ),
-				'order' => 'DESC',
-				'orderby' => 'post_date',
-				'suppress_filters' => true,
-				'no_found_rows' => true,
-			) );
-
-			if ( $this->_validate_category_filter( $filter_cat ) ) {
-				$args['cat'] = $filter_cat;
+			if ( function_exists( 'get_current_screen' ) ) {
+				$screen = get_current_screen();
 			}
 
-			if ( $this->_validate_date_filter( $filter_date ) ) {
-				$filter_date_parts = explode( '-', $filter_date );
-				$args['year'] = $filter_date_parts[0];
-				$args['monthnum'] = $filter_date_parts[1];
-				$args['day'] = $filter_date_parts[2];
+			if ( empty( $screen ) ) {
+				return ! empty( $_REQUEST['page'] ) && sanitize_key( $_REQUEST['page'] ) == $this->key;
+			} else {
+				return ! empty( $screen->id ) && strstr( $screen->id, $this->key );
+			}
+		}
+
+		function ajax_return( $status, $content = '', $action = '' ) {
+			$action = ! empty( $action ) ? $action : $this->zone_ajax_nonce_action;
+			$nonce  = wp_create_nonce( $this->_get_nonce_key( $action ) );
+
+			echo json_encode(
+				array(
+					'status'  => $status,
+					'content' => $content,
+					'nonce'   => $nonce,
+				)
+			);
+			exit;
+		}
+
+		function ajax_add_post() {
+			$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
+			$post_id = $this->_get_post_var( 'post_id', 0, 'absint' );
+
+			// Verify nonce
+			$this->verify_nonce( $this->zone_ajax_nonce_action );
+			$this->verify_access( '', $zone_id );
+
+			// Validate
+			if ( ! $zone_id || ! $post_id ) {
+				$this->ajax_return( 0 );
 			}
 
-			$query = new WP_Query( $args );
-			$stripped_posts = array();
+			$result = $this->add_zone_posts( $zone_id, $post_id, true );
 
-			if ( ! $query->have_posts() ) {
-				echo json_encode( array() );
+			if ( is_wp_error( $result ) ) {
+				$status  = 0;
+				$content = $result->get_error_message();
+			} else {
+				$post = get_post( $post_id );
+				$zone = $this->get_zone( $zone_id );
+
+				ob_start();
+				$this->admin_page_zone_post( $post, $zone );
+				$content = ob_get_contents();
+				ob_end_clean();
+
+				$status = 1;
+			}
+
+			$this->ajax_return( $status, $content );
+		}
+
+		function ajax_remove_post() {
+			$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
+			$post_id = $this->_get_post_var( 'post_id', 0, 'absint' );
+
+			// Verify nonce
+			$this->verify_nonce( $this->zone_ajax_nonce_action );
+			$this->verify_access( '', $zone_id );
+
+			// Validate
+			if ( ! $zone_id || ! $post_id ) {
+				$this->ajax_return( 0 );
+			}
+
+			$result = $this->remove_zone_posts( $zone_id, $post_id );
+
+			if ( is_wp_error( $result ) ) {
+				$status  = 0;
+				$content = $result->get_error_message();
+			} else {
+				$status  = 1;
+				$content = '';
+			}
+
+			$this->ajax_return( $status, $content );
+		}
+
+		function ajax_reorder_posts() {
+			$zone_id  = $this->_get_post_var( 'zone_id', 0, 'absint' );
+			$post_ids = (array) $this->_get_post_var( 'posts', array(), 'absint' );
+
+			// Verify nonce
+			$this->verify_nonce( $this->zone_ajax_nonce_action );
+			$this->verify_access( '', $zone_id );
+
+			// validate
+			if ( ! $zone_id || empty( $post_ids ) ) {
+				$this->ajax_return( 0 );
+			}
+
+			$result = $this->add_zone_posts( $zone_id, $post_ids, false );
+
+			if ( is_wp_error( $result ) ) {
+				$status  = 0;
+				$content = $result->get_error_message();
+			} else {
+				$status  = 1;
+				$content = '';
+			}
+
+			$this->ajax_return( $status, $content );
+		}
+
+		// TODO: implement in front-end
+		function ajax_move_zone_post( $from_zone, $to_zone, $post_id ) {
+			$from_zone_id = $this->_get_post_var( 'from_zone_id', 0, 'absint' );
+			$to_zone_id   = $this->_get_post_var( 'to_zone_id', 0, 'absint' );
+
+			$this->verify_nonce( $this->zone_ajax_nonce_action );
+
+			// TODO: validate both zones exist, post exists
+
+			// Add to new zone
+			$this->add_zone_posts( $to_zone_id, $post_id, true );
+
+			// Remove from old zone
+			$this->remove_zone_posts( $from_zone_id, $post_id );
+		}
+
+		function ajax_search_posts() {
+
+			$q = $this->_get_request_var( 'term', '', 'stripslashes' );
+
+			if ( ! empty( $q ) ) {
+				$filter_cat  = $this->_get_request_var( 'cat', '', 'absint' );
+				$filter_date = $this->_get_request_var( 'date', '', 'striptags' );
+
+				$post_types = $this->get_supported_post_types();
+				$limit      = $this->_get_request_var( 'limit', $this->posts_per_page );
+				if ( $limit <= 0 ) {
+					$limit = $this->posts_per_page;
+				}
+				$exclude = (array) $this->_get_request_var( 'exclude', array(), 'absint' );
+
+				$args = apply_filters(
+					'zoninator_search_args',
+					array(
+						's'                => $q,
+						'post__not_in'     => $exclude,
+						'posts_per_page'   => $limit,
+						'post_type'        => $post_types,
+						'post_status'      => array( 'publish', 'future' ),
+						'order'            => 'DESC',
+						'orderby'          => 'post_date',
+						'suppress_filters' => true,
+						'no_found_rows'    => true,
+					)
+				);
+
+				if ( $this->_validate_category_filter( $filter_cat ) ) {
+					$args['cat'] = $filter_cat;
+				}
+
+				if ( $this->_validate_date_filter( $filter_date ) ) {
+					$filter_date_parts = explode( '-', $filter_date );
+					$args['year']      = $filter_date_parts[0];
+					$args['monthnum']  = $filter_date_parts[1];
+					$args['day']       = $filter_date_parts[2];
+				}
+
+				$query          = new WP_Query( $args );
+				$stripped_posts = array();
+
+				if ( ! $query->have_posts() ) {
+					echo json_encode( array() );
+					exit;
+				}
+
+				foreach ( $query->posts as $post ) {
+					$stripped_posts[] = apply_filters(
+						'zoninator_search_results_post',
+						array(
+							'title'       => ! empty( $post->post_title ) ? $post->post_title : __( '(no title)', 'zoninator' ),
+							'post_id'     => $post->ID,
+							'date'        => get_the_time( get_option( 'date_format' ), $post ),
+							'post_type'   => $post->post_type,
+							'post_status' => $post->post_status,
+						),
+						$post
+					);
+				}
+
+				echo json_encode( $stripped_posts );
+				exit;
+			}
+		}
+
+		function ajax_update_lock() {
+			$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
+
+			$this->verify_nonce( $this->zone_ajax_nonce_action );
+			$this->verify_access( '', $zone_id );
+
+			if ( ! $zone_id ) {
 				exit;
 			}
 
-			foreach( $query->posts as $post ) {
-				$stripped_posts[] = apply_filters( 'zoninator_search_results_post', array(
-					'title' => ! empty( $post->post_title ) ? $post->post_title : __( '(no title)', 'zoninator' ),
-					'post_id' => $post->ID,
-					'date' => get_the_time( get_option( 'date_format' ), $post ),
-					'post_type' => $post->post_type,
-					'post_status' => $post->post_status,
-				), $post );
+			if ( ! $this->is_zone_locked( $zone_id ) ) {
+				$this->lock_zone( $zone_id );
+				$this->ajax_return( 1, '' );
+			}
+		}
+
+		function get_supported_post_types() {
+			if ( isset( $this->post_types ) ) {
+				return $this->post_types;
 			}
 
-			echo json_encode( $stripped_posts );
-			exit;
-		}
-	}
+			$this->post_types = array();
 
-	function ajax_update_lock() {
-		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
+			foreach ( get_post_types() as $post_type ) {
+				if ( post_type_supports( $post_type, $this->zone_taxonomy ) ) {
+					array_push( $this->post_types, $post_type );
+				}
+			}
 
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
-
-		if( ! $zone_id )
-			exit;
-
-		if( ! $this->is_zone_locked( $zone_id ) ) {
-			$this->lock_zone( $zone_id );
-			$this->ajax_return( 1, '' );
-		}
-	}
-
-	function get_supported_post_types() {
-		if( isset( $this->post_types ) )
 			return $this->post_types;
-
-		$this->post_types = array();
-
-		foreach( get_post_types() as $post_type ) {
-			if( post_type_supports( $post_type, $this->zone_taxonomy ) )
-				array_push( $this->post_types, $post_type );
 		}
 
-		return $this->post_types;
-	}
+		/**
+		 * Registers a post type to be available for zones
+		 *
+		 * @param string|array $post_types A post type string or array of post type strings to register.
+		 * @return bool True if any post types were added, false if not.
+		 */
+		function register_zone_post_type( $post_types = '' ) {
 
-	/**
-	 * Registers a post type to be available for zones
-	 *
-	 * @param string|array $post_types A post type string or array of post type strings to register.
-	 * @return bool True if any post types were added, false if not.
-	 */
-	function register_zone_post_type( $post_types = '' ) {
+			$did_register_post_types = false;
 
-		$did_register_post_types = false;
-
-		if ( ! is_array( $post_types ) ) {
-			$post_types = array( $post_types );
-		}
-
-		foreach ( $post_types as $post_type ) {
-
-			if ( ! post_type_exists( $post_type ) ) {
-				continue;
+			if ( ! is_array( $post_types ) ) {
+				$post_types = array( $post_types );
 			}
 
-			add_post_type_support( $post_type, $this->zone_taxonomy );
-			register_taxonomy_for_object_type( $this->zone_taxonomy, $post_type );
+			foreach ( $post_types as $post_type ) {
+				if ( ! post_type_exists( $post_type ) ) {
+					continue;
+				}
 
-			// Clear Zoninator supported post types cache
-			unset( $this->post_types );
+				add_post_type_support( $post_type, $this->zone_taxonomy );
+				register_taxonomy_for_object_type( $this->zone_taxonomy, $post_type );
 
-			$did_register_post_types = true;
+				// Clear Zoninator supported post types cache
+				unset( $this->post_types );
 
+				$did_register_post_types = true;
+			}
+
+			return $did_register_post_types;
 		}
 
-		return $did_register_post_types;
+		function insert_zone( $slug, $name = '', $details = array() ) {
 
-	}
+			// slug cannot be empty
+			if ( empty( $slug ) ) {
+				return new WP_Error( 'zone-empty-slug', __( 'Slug is a required field.', 'zoninator' ) );
+			}
 
-	function insert_zone( $slug, $name = '', $details = array() ) {
+			$slug = $this->get_formatted_zone_slug( $slug );
+			$name = ! empty( $name ) ? $name : $slug;
 
-		// slug cannot be empty
-		if( empty( $slug ) )
-			return new WP_Error( 'zone-empty-slug', __( 'Slug is a required field.', 'zoninator' ) );
-
-		$slug = $this->get_formatted_zone_slug( $slug );
-		$name = ! empty( $name ) ? $name : $slug;
-
-		$details = wp_parse_args( $details, $this->zone_detail_defaults );
-		$details = maybe_serialize( stripslashes_deep( $details ) );
-
-		$args = array(
-			'slug' => $slug,
-			'description' => $details,
-		);
-
-		// Filterize to allow other inputs
-		$args = apply_filters( 'zoninator_insert_zone', $args );
-
-		return wp_insert_term( $name, $this->zone_taxonomy, $args );
-	}
-
-	function update_zone( $zone, $data = array() ) {
-		$zone_id = $this->get_zone_id( $zone );
-
-		if( $this->zone_exists( $zone_id ) ) {
-			$zone = $this->get_zone( $zone );
-
-			$name = $this->_get_value_or_default( 'name', $data, $zone->name );
-			$slug = $this->_get_value_or_default( 'slug', $data, $zone->slug, array( $this, 'get_formatted_zone_slug' ) );
-			$details = $this->_get_value_or_default( 'details', $data, array() );
-
-			// TODO: Back-fill current zone details
-			//$details = wp_parse_args( $details, $this->zone_detail_defaults );
 			$details = wp_parse_args( $details, $this->zone_detail_defaults );
 			$details = maybe_serialize( stripslashes_deep( $details ) );
 
 			$args = array(
-				'name' => $name,
-				'slug' => $slug,
-				'description' => $details
+				'slug'        => $slug,
+				'description' => $details,
 			);
 
 			// Filterize to allow other inputs
-			$args = apply_filters( 'zoninator_update_zone', $args, $zone_id, $zone );
+			$args = apply_filters( 'zoninator_insert_zone', $args );
 
-			return wp_update_term( $zone_id, $this->zone_taxonomy, $args );
+			return wp_insert_term( $name, $this->zone_taxonomy, $args );
 		}
-		return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
-	}
 
-	function delete_zone( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-		$meta_key = $this->get_zone_meta_key( $zone );
+		function update_zone( $zone, $data = array() ) {
+			$zone_id = $this->get_zone_id( $zone );
 
-		$this->_empty_zone_posts_cache( $meta_key );
+			if ( $this->zone_exists( $zone_id ) ) {
+				$zone = $this->get_zone( $zone );
 
-		if( $this->zone_exists( $zone_id ) ) {
-			// Delete all post associations for the zone
-			$this->remove_zone_posts( $zone_id );
+				$name    = $this->_get_value_or_default( 'name', $data, $zone->name );
+				$slug    = $this->_get_value_or_default( 'slug', $data, $zone->slug, array( $this, 'get_formatted_zone_slug' ) );
+				$details = $this->_get_value_or_default( 'details', $data, array() );
 
-			// Delete the term
-			$delete = wp_delete_term( $zone_id, $this->zone_taxonomy );
+				// TODO: Back-fill current zone details
+				// $details = wp_parse_args( $details, $this->zone_detail_defaults );
+				$details = wp_parse_args( $details, $this->zone_detail_defaults );
+				$details = maybe_serialize( stripslashes_deep( $details ) );
 
-			if( ! $delete ) {
-				return new WP_Error( 'delete-zone', __( 'Sorry, we couldn\'t delete the zone.', 'zoninator' ) );
+				$args = array(
+					'name'        => $name,
+					'slug'        => $slug,
+					'description' => $details,
+				);
+
+				// Filterize to allow other inputs
+				$args = apply_filters( 'zoninator_update_zone', $args, $zone_id, $zone );
+
+				return wp_update_term( $zone_id, $this->zone_taxonomy, $args );
+			}
+			return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
+		}
+
+		function delete_zone( $zone ) {
+			$zone_id  = $this->get_zone_id( $zone );
+			$meta_key = $this->get_zone_meta_key( $zone );
+
+			$this->_empty_zone_posts_cache( $meta_key );
+
+			if ( $this->zone_exists( $zone_id ) ) {
+				// Delete all post associations for the zone
+				$this->remove_zone_posts( $zone_id );
+
+				// Delete the term
+				$delete = wp_delete_term( $zone_id, $this->zone_taxonomy );
+
+				if ( ! $delete ) {
+					return new WP_Error( 'delete-zone', __( 'Sorry, we couldn\'t delete the zone.', 'zoninator' ) );
+				} else {
+					do_action( 'zoninator_delete_zone', $zone_id );
+					return $delete;
+				}
+			}
+			return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
+		}
+
+		/**
+		 * @param $zone
+		 * @param $posts
+		 * @param bool  $append
+		 * @return bool|WP_Error
+		 */
+		function add_zone_posts( $zone, $posts, $append = false ) {
+			$zone     = $this->get_zone( $zone );
+			$meta_key = $this->get_zone_meta_key( $zone );
+
+			$this->_empty_zone_posts_cache( $meta_key );
+
+			if ( $append ) {
+				// Order should be the highest post order
+				$last_post = $this->get_last_post_in_zone( $zone );
+				if ( $last_post ) {
+					$order = $this->get_post_order( $last_post, $zone );
+				} else {
+					$order = 0;
+				}
 			} else {
-				do_action( 'zoninator_delete_zone', $zone_id );
-				return $delete;
-			}
-		}
-		return new WP_Error( 'invalid-zone', __( 'Sorry, that zone doesn\'t exist.', 'zoninator' ) );
-	}
-
-	/**
-	 * @param $zone
-	 * @param $posts
-	 * @param bool $append
-	 * @return bool|WP_Error
-	 */
-	function add_zone_posts( $zone, $posts, $append = false ) {
-		$zone = $this->get_zone( $zone );
-		$meta_key = $this->get_zone_meta_key( $zone );
-
-		$this->_empty_zone_posts_cache( $meta_key );
-
-		if( $append ) {
-			// Order should be the highest post order
-			$last_post = $this->get_last_post_in_zone( $zone );
-			if( $last_post )
-				$order = $this->get_post_order( $last_post, $zone );
-			else
 				$order = 0;
-		} else {
-			$order = 0;
-			$this->remove_zone_posts( $zone );
-		}
-
-		foreach( (array) $posts as $post ) {
-			$post_id = $this->get_post_id( $post );
-			if( $post_id ) {
-				$order++;
-				update_metadata( 'post', $post_id, $meta_key, $order, true );
+				$this->remove_zone_posts( $zone );
 			}
-			// TODO: remove_object_terms -- but need remove object terms function :(
+
+			foreach ( (array) $posts as $post ) {
+				$post_id = $this->get_post_id( $post );
+				if ( $post_id ) {
+					++$order;
+					update_metadata( 'post', $post_id, $meta_key, $order, true );
+				}
+				// TODO: remove_object_terms -- but need remove object terms function :(
+			}
+
+			clean_term_cache( $this->get_zone_id( $zone ), $this->zone_taxonomy ); // flush cache for our zone term and related APC caches
+
+			do_action( 'zoninator_add_zone_posts', $posts, $zone );
+
+			return true;
 		}
 
-		clean_term_cache( $this->get_zone_id( $zone ), $this->zone_taxonomy ); // flush cache for our zone term and related APC caches
+		/**
+		 * @param $zone
+		 * @param null $posts
+		 * @return bool|WP_Error
+		 */
+		function remove_zone_posts( $zone, $posts = null ) {
+			$zone     = $this->get_zone( $zone );
+			$meta_key = $this->get_zone_meta_key( $zone );
 
-		do_action( 'zoninator_add_zone_posts', $posts, $zone );
+			$this->_empty_zone_posts_cache( $meta_key );
 
-		return true;
-	}
+			// if null, delete all
+			if ( ! $posts ) {
+				$posts = $this->get_zone_posts( $zone );
+			}
 
-	/**
-	 * @param $zone
-	 * @param null $posts
-	 * @return bool|WP_Error
-	 */
-	function remove_zone_posts( $zone, $posts = null ) {
-		$zone = $this->get_zone( $zone );
-		$meta_key = $this->get_zone_meta_key( $zone );
+			foreach ( (array) $posts as $post ) {
+				$post_id = $this->get_post_id( $post );
+				if ( $post_id ) {
+					delete_metadata( 'post', $post_id, $meta_key );
+				}
+			}
 
-		$this->_empty_zone_posts_cache( $meta_key );
+			clean_term_cache( $this->get_zone_id( $zone ), $this->zone_taxonomy ); // flush cache for our zone term and related APC caches
 
-		// if null, delete all
-		if( ! $posts )
-			$posts = $this->get_zone_posts( $zone );
-
-		foreach( (array) $posts as $post ) {
-			$post_id = $this->get_post_id( $post );
-			if( $post_id )
-				delete_metadata( 'post', $post_id, $meta_key );
+			do_action( 'zoninator_remove_zone_posts', $posts, $zone );
 		}
 
-		clean_term_cache( $this->get_zone_id( $zone ), $this->zone_taxonomy ); // flush cache for our zone term and related APC caches
+		function get_zone_posts( $zone, $args = array() ) {
+			// Check cache first
+			if ( $posts = $this->get_zone_posts_from_cache( $zone, $args ) ) {
+				return $posts;
+			}
 
-		do_action( 'zoninator_remove_zone_posts', $posts, $zone );
-	}
+			$query = $this->get_zone_query( $zone, $args );
+			$posts = $query->posts;
 
-	function get_zone_posts( $zone, $args = array() ) {
-		// Check cache first
-		if( $posts = $this->get_zone_posts_from_cache( $zone, $args ) )
+			// Add posts to cache
+			$this->add_zone_posts_to_cache( $posts, $zone, $args );
+
 			return $posts;
+		}
 
-		$query = $this->get_zone_query( $zone, $args );
-		$posts = $query->posts;
+		function get_zone_query( $zone, $args = array() ) {
+			$meta_key = $this->get_zone_meta_key( $zone );
 
-		// Add posts to cache
-		$this->add_zone_posts_to_cache( $posts, $zone, $args );
+			$defaults = array(
+				'order'               => 'ASC',
+				'posts_per_page'      => -1,
+				'post_type'           => $this->get_supported_post_types(),
+				'ignore_sticky_posts' => '1', // don't want sticky posts messing up our order
+			);
 
-		return $posts;
-	}
+			// Default to published posts on the front-end
+			if ( ! is_admin() ) {
+				$defaults['post_status'] = array( 'publish' );
+			}
 
-	function get_zone_query( $zone, $args = array() ) {
-		$meta_key = $this->get_zone_meta_key( $zone );
+			if ( is_admin() ) { // skip APC in the admin
+				$defaults['suppress_filters'] = true;
+			}
 
-		$defaults = array(
-			'order' => 'ASC',
-			'posts_per_page' => -1,
-			'post_type' => $this->get_supported_post_types(),
-			'ignore_sticky_posts' => '1', // don't want sticky posts messing up our order
-		);
+			$args = wp_parse_args( $args, $defaults );
 
-		// Default to published posts on the front-end
-		if ( ! is_admin() )
-			$defaults['post_status'] = array( 'publish' );
+			// Un-overridable args
+			$args['orderby']  = 'meta_value_num';
+			$args['meta_key'] = $meta_key;
 
-		if ( is_admin() ) // skip APC in the admin
-			$defaults['suppress_filters'] = true;
-
-		$args = wp_parse_args( $args, $defaults );
-
-		// Un-overridable args
-		$args['orderby'] = 'meta_value_num';
-		$args['meta_key'] = $meta_key;
-
-		/* // 3.1-friendly, though missing sort support which is why we're using the old way
-		if( function_exists( 'get_post_format' ) ) {
+			/*
+			// 3.1-friendly, though missing sort support which is why we're using the old way
+			if( function_exists( 'get_post_format' ) ) {
 			$args['meta_query'] = array(
 				array(
 					'key' => $meta_key,
 					'type' => 'NUMERIC'
 				)
 			);
-		} else {
+			} else {
 			$args['meta_key'] = $meta_key;
-		}
-		*/
-		return new WP_Query( $args );
-	}
-
-	function get_last_post_in_zone( $zone ) {
-		return $this->get_single_post_in_zone( $zone, array(
-			'order' => 'DESC',
-		) );
-	}
-
-	function get_first_post_in_zone( $zone ) {
-		return $this->get_single_post_in_zone( $zone );
-	}
-
-	function get_prev_post_in_zone( $zone, $post_id ) {
-		// TODO: test this works
-		$order = $this->get_post_order_in_zone( $zone, $post_id );
-
-		return $this->get_single_post_in_zone( $zone, array(
-			'meta_value' => $order,
-			'meta_compare' => '<='
-		) );
-	}
-
-	function get_next_post_in_zone( $zone, $post_id ) {
-		// TODO: test this works
-		$order = $this->get_post_order_in_zone( $zone, $post_id );
-
-		return $this->get_single_post_in_zone( $zone, array(
-			'meta_value' => $order,
-			'meta_compare' => '>='
-		) );
-
-	}
-
-	function get_single_post_in_zone( $zone, $args = array() ) {
-
-		$args = wp_parse_args( $args, array(
-			'posts_per_page' => 1,
-			'showposts' => 1,
-		) );
-
-		$post = $this->get_zone_posts( $zone, $args );
-
-		if( is_array( $post ) && ! empty( $post ) )
-			return array_pop( $post );
-
-		return false;
-	}
-
-	function get_zones_for_post( $post_id ) {
-		// TODO: build this out
-
-		// get_object_terms
-		// get_terms
-
-		// OR
-
-		// get all meta_keys that match the prefix
-		// strip the prefix
-
-		// OR
-
-		// get all zones and see if there's a matching meta entry
-		// strip the prefix from keys
-
-		// array_map( 'absint', $zone_ids )
-		// $zones = array();
-		// foreach( $zone_ids as $zone_id ) {
-			// $zones[] = get_zone( $zone_id );
-		//}
-		//return $zones;
-	}
-
-	function get_zones( $args = array() ) {
-
-		$args = wp_parse_args( $args, array(
-			'orderby' => 'id',
-			'order' => 'ASC',
-			'hide_empty' => 0,
-		) );
-
-		$zones = get_terms( $this->zone_taxonomy, $args );
-
-		if ( ! is_wp_error( $zones ) ) {
-			// Add extra fields in description as properties
-			foreach ( $zones as $zone ) {
-				$zone = $this->_fill_zone_details( $zone );
 			}
-
-			return $zones;
+			*/
+			return new WP_Query( $args );
 		}
 
-		return false;
-	}
-
-	function get_zone( $zone ) {
-		if( is_int( $zone ) ) {
-			$field = 'id';
-		} elseif( is_string( $zone ) ) {
-			$field = 'slug';
-			$zone = $this->get_zone_slug( $zone );
-		} elseif( is_object( $zone ) ) {
-			return $zone;
-		} else {
-			return false;
-		}
-
-		if ( function_exists( 'wpcom_vip_get_term_by' ) ) {
-			$zone = wpcom_vip_get_term_by( $field, $zone, $this->zone_taxonomy );
-		} else {
-			$zone = get_term_by( $field, $zone, $this->zone_taxonomy );
-		}
-
-		if( ! $zone )
-			return false;
-
-		return $this->_fill_zone_details( $zone );
-	}
-
-	function lock_zone( $zone, $user_id = 0 ) {
-		$zone_id = $this->get_zone_id( $zone );
-
-		if( ! $zone_id )
-			return false;
-
-		if( ! $user_id ) {
-			$user = wp_get_current_user();
-			$user_id = $user->ID;
-		}
-
-		$lock_key = $this->get_zone_meta_key( $zone );
-		$expiry = $this->zone_lock_period + 1; // Add a one to avoid most race condition issues between lock expiry and ajax call
-		set_transient( $lock_key, $user->ID, $expiry );
-
-		// Possible alternative: set zone lock as property with time and user
-	}
-
-	// Not really needed with transients...
-	function unlock_zone( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-
-		if( ! $zone_id )
-			return false;
-
-		$lock_key = $this->get_zone_meta_key( $zone );
-
-		delete_transient( $lock_key );
-	}
-
-	function is_zone_locked( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-		if( ! $zone_id )
-			return false;
-
-		$user = wp_get_current_user();
-		$lock_key = $this->get_zone_meta_key( $zone );
-
-		$lock = get_transient( $lock_key );
-
-		// If lock doesn't exist, or check if current user same as lock user
-		if( ! $lock || absint( $lock ) === absint( $user->ID ) )
-			return false;
-		else
-			// return user_id of locking user
-			return absint( $lock );
-	}
-
-	function zone_exists( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-
-		if( term_exists( $zone_id, $this->zone_taxonomy ) )
-			return true;
-
-		return false;
-	}
-
-	function get_zone_id( $zone ) {
-		if( is_int( $zone ) )
-			return $zone;
-
-		$zone = $this->get_zone( $zone );
-		if( is_object( $zone ) )
-			$zone = $zone->term_id;
-
-		return (int)$zone;
-	}
-
-	function get_zone_meta_key( $zone ) {
-		$zone_id = $this->get_zone_id( $zone );
-		return $this->zone_meta_prefix . $zone_id;
-	}
-
-	function get_zone_slug( $zone ) {
-		if( is_int( $zone ) )
-			$zone = $this->get_zone( $zone );
-
-		if( is_object( $zone ) )
-			$zone = $zone->slug;
-
-		return $this->get_formatted_zone_slug( $zone );
-	}
-
-	function get_formatted_zone_slug( $slug ) {
-		return $slug; // legacy function -- slugs can no longer be changed
-	}
-	function get_unformatted_zone_slug( $slug ) {
-		return $slug; // legacy function -- slugs can no longer be changed
-	}
-
-	function get_post_id( $post ) {
-		if( is_int( $post ) )
-			return $post;
-		elseif( is_array( $post ) )
-			return absint( $post['ID'] );
-		elseif( is_object( $post ) )
-			return $post->ID;
-
-		return false;
-	}
-
-	function get_post_order( $post, $zone ) {
-		$post_id = $this->get_post_id( $post );
-		$meta_key = $this->get_zone_meta_key( $zone );
-
-		return get_metadata( 'post', $post_id, $meta_key, true );
-	}
-
-	function verify_nonce( $action ) {
-		$action = $this->_get_nonce_key( $action );
-		$nonce = $this->_get_request_var( $action );
-
-		if( empty( $nonce ) )
-			$nonce = $this->_get_request_var( '_wpnonce' );
-
-		if( ! wp_verify_nonce( $nonce, $action ) )
-			$this->_unauthorized_access();
-	}
-
-	function verify_access( $action = '', $zone_id = null ) {
-		// TODO: should check if zone locked
-
-		$verify_function = '';
-		switch( $action ) {
-			case 'insert':
-				$verify_function = '_current_user_can_add_zones';
-				break;
-			case 'update':
-			case 'delete':
-				$verify_function = '_current_user_can_edit_zones';
-				break;
-			default:
-				$verify_function = '_current_user_can_manage_zones';
-				break;
-		}
-
-		if( ! call_user_func( array( $this, $verify_function ), $zone_id ) )
-			$this->_unauthorized_access();
-	}
-
-	function _unauthorized_access() {
-		wp_die( __( 'Sorry, you\'re not supposed to do that...', 'zoninator' ) );
-	}
-
-	function _fill_zone_details( $zone ) {
-		if( ! empty( $zone->zoninator_parsed ) && $zone->zoninator_parsed )
-			return $zone;
-
-		$details = array();
-
-		if( ! empty( $zone->description ) )
-			$details = maybe_unserialize( $zone->description );
-
-		$details = wp_parse_args( $details, $this->zone_detail_defaults );
-
-		foreach( $details as $detail_key => $detail_value ) {
-			$zone->$detail_key = $detail_value;
-		}
-
-		$zone->zoninator_parsed = true;
-
-		return $zone;
-	}
-
-	function do_zoninator_feeds() {
-		$query_var = get_query_var( $this->zone_taxonomy );
-
-		if ( ! empty( $query_var ) ) {
-			$zone_slug = get_query_var( $this->zone_taxonomy );
-			$results = $this->get_zone_feed( $zone_slug );
-			if ( is_wp_error( $results ) ) {
-				$this->send_user_error( $results->get_error_message() );
-			}
-			$this->json_return( $results, false );
-		}
-
-		return;
-
-	}
-
-	private function filter_zone_feed_fields( $results ) {
-		$filtered_results = array();
-		$whitelisted_fields = apply_filters(
-			'zoninator_zone_feed_fields',
-			array( 'ID', 'post_date', 'post_title', 'post_content', 'post_excerpt', 'post_status', 'guid' )
-		);
-
-		$filtered_results = array();
-		$i = 0;
-		foreach ( $results as $result ) {
-			if ( ! isset( $filtered_results[ $i ] ) ) {
-				$filtered_results[$i] = new stdClass();
-			}
-			foreach( $whitelisted_fields as $field ) {
-				if ( ! isset ( $filtered_results[$i] ) ) {
-					$filtered_results[$i] = new stdClass;
-				}
-				$filtered_results[$i]->$field = $result->$field;
-			}
-			$i++;
-		}
-
-		return $filtered_results;
-	}
-
-	/**
-	 * Encode some data and echo it (possibly without cached headers)
-	 *
-	 * @param array $data
-	 */
-	private function json_return( $data ) {
-
-		if ( $data == NULL )
-			return false;
-
-		header( 'Content-Type: application/json' );
-		echo json_encode( $data );
-		exit();
-	}
-
-	private static function send_user_error( $message ) {
-		self::status_header_with_message( 406, $message );
-		exit();
-	}
-
-	/**
-	* Modify the header and description in the global array
-	*
-	* @global array $wp_header_to_desc
-	* @param int $status
-	* @param string $message
-	*/
-	private static function status_header_with_message( $status, $message ) {
-		global $wp_header_to_desc;
-
-		$status = absint( $status );
-		$official_message = isset( $wp_header_to_desc[$status] ) ? $wp_header_to_desc[$status] : '';
-		$wp_header_to_desc[$status] = $message;
-
-		status_header( $status );
-
-		$wp_header_to_desc[$status] = $official_message;
-	}
-
-	// TODO: Caching needs to be testing properly before being implemented!
-	function get_zone_cache_key( $zone, $args = array() ) {
-		return '';
-
-		$meta_key = $this->get_zone_meta_key( $zone );
-		$hash = md5( serialize( $args ) );
-		return $meta_key . $hash;
-	}
-
-	function get_zone_posts_from_cache( $zone, $args = array() ) {
-		return false; // TODO: implement
-
-		$meta_key = $this->get_zone_meta_key( $zone );
-		$cache_key = $this->get_zone_cache_key( $zone, $args );
-		if( $posts = wp_cache_get( $cache_key, $meta_key ) )
-			return $posts;
-		return false;
-	}
-
-	function add_zone_posts_to_cache( $posts, $zone, $args = array() ) {
-		return; // TODO: implement
-
-		$meta_key = $this->get_zone_meta_key( $zone );
-		$cache_key = $this->get_zone_cache_key( $zone, $args );
-		wp_cache_set( $cache_key, $posts, $meta_key );
-	}
-
-	// Handle 4.2 term-splitting
-	function split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
-		if ( $this->zone_taxonomy === $taxonomy ) {
-			do_action( 'zoninator_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
-
-			// Quick, easy switcheroo; add posts to new zone id and remove from the old one.
-			$posts = $this->get_zone_posts( $old_term_id );
-			if ( ! empty( $posts ) ) {
-				$this->add_zone_posts( $new_term_id, $posts );
-				$this->remove_zone_posts( $old_term_id );
-			}
-
-			do_action( 'zoninator_did_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
-		}
-	}
-
-	function _empty_zone_posts_cache( $meta_key ) {
-		return; // TODO: implement
-	}
-
-	function _get_message( $message_id, $encode = false ) {
-		$message = '';
-
-		if( ! empty( $this->zone_messages[$message_id] ) )
-			$message = $this->zone_messages[$message_id];
-
-		if( $encode )
-			$message = urlencode( $message );
-
-		return $message;
-	}
-
-	function _get_nonce_key( $action ) {
-		return sprintf( '%s-%s', $this->zone_nonce_prefix, $action );
-	}
-
-	function _current_user_can_add_zones() {
-		return current_user_can( $this->_get_add_zones_cap() );
-	}
-
-	function _current_user_can_edit_zones( $zone_id ) {
-		$has_cap = current_user_can( $this->_get_edit_zones_cap() );
-		return apply_filters( 'zoninator_current_user_can_edit_zone', $has_cap, $zone_id );
-	}
-
-	function _current_user_can_manage_zones() {
-		return current_user_can( $this->_get_manage_zones_cap() );
-	}
-
-	function _get_add_zones_cap() {
-		return apply_filters( 'zoninator_add_zone_cap', 'edit_others_posts' );
-	}
-
-	function _get_edit_zones_cap() {
-		return apply_filters( 'zoninator_edit_zone_cap', 'edit_others_posts' );
-	}
-
-	function _get_manage_zones_cap() {
-		return apply_filters( 'zoninator_manage_zone_cap', 'edit_others_posts' );
-	}
-
-	function _get_zone_page_url( $args = array() ) {
-		$url = menu_page_url( $this->key, false );
-
-		foreach( $args as $arg_key => $arg_value ) {
-			$url = add_query_arg( $arg_key, $arg_value, $url );
-		}
-
-		return $url;
-	}
-
-	function _validate_date_filter( $date ) {
-		return preg_match( '/([0-9]{4})-([0-9]{2})-([0-9]{2})/', $date );
-	}
-
-	function _validate_category_filter( $cat ) {
-		return $cat && get_term_by( 'id', $cat, 'category' );
-	}
-
-	function _sanitize_value( $var ) {
-		return htmlentities( stripslashes( $var ) );
-	}
-
-	function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {
-		if( is_object( $object ) )
-			$value = ! empty( $object->$var ) ? $object->$var : $default;
-		elseif( is_array( $object ) )
-			$value = ! empty( $object[$var] ) ? $object[$var] : $default;
-		else
-			$value = $default;
-
-		if( is_callable( $sanitize_callback ) ) {
-			if( is_array( $value ) )
-				$value = array_map( $sanitize_callback, $value );
-			else
-				$value = call_user_func( $sanitize_callback, $value );
-		}
-
-		return $value;
-	}
-
-	function _get_request_var( $var, $default = '', $sanitize_callback = '' ) {
-		return $this->_get_value_or_default( $var, $_REQUEST, $default, $sanitize_callback );
-	}
-
-	function _get_get_var( $var, $default = '', $sanitize_callback = '' ) {
-		return $this->_get_value_or_default( $var, $_GET, $default, $sanitize_callback );
-	}
-	function _get_post_var( $var, $default = '', $sanitize_callback = '' ) {
-		return $this->_get_value_or_default( $var, $_POST, $default, $sanitize_callback );
-	}
-
-	public function get_admin_zone_post($post, $zone) {
-		return apply_filters('zoninator_zone_post_columns', array(
-			'post_id' => $post->ID,
-			'position' => array(
-				'current_position' => intval( $this->get_post_order( $post->ID, $zone ) ),
-				'change_position_message' => esc_attr__( 'Click and drag to change the position of this item.', 'zoninator' ),
-				'key' => 'position'
-			),
-			'info' => array(
-				'key' => 'info',
-				'post' => array(
-					'post_title'  => esc_html( $post->post_title ),
-					'post_status' => esc_html( $post->post_status )
-				),
-				'action_link_data' => array(
-					array(
-						'action' => 'edit',
-						'anchor'     => get_edit_post_link( $post->ID ),
-						'title' => __( 'Opens in new window', 'zoninator' ),
-						'text'  => __( 'Edit', 'zoninator' ),
-						'target' => "_blank"
-					),
-					array(
-						'action' => 'delete',
-						'anchor'     => '#',
-						'title' => '',
-						'text'  => __( 'Remove', 'zoninator' )
-					),
-					array(
-						'action' => 'view',
-						'anchor'     => get_permalink( $post->ID ),
-						'title' => __( 'Opens in new window', 'zoninator' ),
-						'text'  => __( 'View', 'zoninator' ),
-						'target' => "_blank"
-					)
+		function get_last_post_in_zone( $zone ) {
+			return $this->get_single_post_in_zone(
+				$zone,
+				array(
+					'order' => 'DESC',
 				)
-			)
-		), $post, $zone);
-	}
-
-	public function get_admin_zone_posts( $zone_or_id ) {
-		$zone = $this->get_zone( $zone_or_id );
-		$posts = $this->get_zone_posts( $zone );
-		$admin_zone_posts = array();
-
-		foreach ( $posts as $post ) {
-			$admin_zone_posts[] = $this->get_admin_zone_post( $post, $zone );
+			);
 		}
 
-		return $admin_zone_posts;
-	}
-
-	/**
-	 * @param $zone_slug_or_id
-	 * @return array|WP_Error
-	 */
-	function get_zone_feed( $zone_slug_or_id ) {
-		$zone_id = $this->get_zone( $zone_slug_or_id );
-
-		if ( empty( $zone_id ) ) {
-			return new WP_Error( 'invalid-zone-supplied', __( 'Invalid zone supplied', 'zoninator' ) );
+		function get_first_post_in_zone( $zone ) {
+			return $this->get_single_post_in_zone( $zone );
 		}
 
-		$results = $this->get_zone_posts( $zone_id, apply_filters( 'zoninator_json_feed_fields', array(), $zone_slug_or_id ) );
-		$filtered_results = $this->filter_zone_feed_fields( $results );
+		function get_prev_post_in_zone( $zone, $post_id ) {
+			// TODO: test this works
+			$order = $this->get_post_order_in_zone( $zone, $post_id );
 
-		return apply_filters( 'zoninator_json_feed_results', $filtered_results, $zone_slug_or_id );
-	}
-
-	public function check( $action = '', $zone_id = null ) {
-		// TODO: should check if zone locked
-		if ( 'insert' == $action ) {
-			return $this->_current_user_can_add_zones();
+			return $this->get_single_post_in_zone(
+				$zone,
+				array(
+					'meta_value'   => $order,
+					'meta_compare' => '<=',
+				)
+			);
 		}
 
-		if ( 'update' == $action || 'delete' == $action ) {
-			return $this->_current_user_can_edit_zones( $zone_id );
+		function get_next_post_in_zone( $zone, $post_id ) {
+			// TODO: test this works
+			$order = $this->get_post_order_in_zone( $zone, $post_id );
+
+			return $this->get_single_post_in_zone(
+				$zone,
+				array(
+					'meta_value'   => $order,
+					'meta_compare' => '>=',
+				)
+			);
 		}
 
-		return $this->_current_user_can_manage_zones();
+		function get_single_post_in_zone( $zone, $args = array() ) {
+
+			$args = wp_parse_args(
+				$args,
+				array(
+					'posts_per_page' => 1,
+					'showposts'      => 1,
+				)
+			);
+
+			$post = $this->get_zone_posts( $zone, $args );
+
+			if ( is_array( $post ) && ! empty( $post ) ) {
+				return array_pop( $post );
+			}
+
+			return false;
+		}
+
+		function get_zones_for_post( $post_id ) {
+			// TODO: build this out
+
+			// get_object_terms
+			// get_terms
+
+			// OR
+
+			// get all meta_keys that match the prefix
+			// strip the prefix
+
+			// OR
+
+			// get all zones and see if there's a matching meta entry
+			// strip the prefix from keys
+
+			// array_map( 'absint', $zone_ids )
+			// $zones = array();
+			// foreach( $zone_ids as $zone_id ) {
+			// $zones[] = get_zone( $zone_id );
+			// }
+			// return $zones;
+		}
+
+		function get_zones( $args = array() ) {
+
+			$args = wp_parse_args(
+				$args,
+				array(
+					'orderby'    => 'id',
+					'order'      => 'ASC',
+					'hide_empty' => 0,
+				)
+			);
+
+			$zones = get_terms( $this->zone_taxonomy, $args );
+
+			if ( ! is_wp_error( $zones ) ) {
+				// Add extra fields in description as properties
+				foreach ( $zones as $zone ) {
+					$zone = $this->_fill_zone_details( $zone );
+				}
+
+				return $zones;
+			}
+
+			return false;
+		}
+
+		function get_zone( $zone ) {
+			if ( is_int( $zone ) ) {
+				$field = 'id';
+			} elseif ( is_string( $zone ) ) {
+				$field = 'slug';
+				$zone  = $this->get_zone_slug( $zone );
+			} elseif ( is_object( $zone ) ) {
+				return $zone;
+			} else {
+				return false;
+			}
+
+			if ( function_exists( 'wpcom_vip_get_term_by' ) ) {
+				$zone = wpcom_vip_get_term_by( $field, $zone, $this->zone_taxonomy );
+			} else {
+				$zone = get_term_by( $field, $zone, $this->zone_taxonomy );
+			}
+
+			if ( ! $zone ) {
+				return false;
+			}
+
+			return $this->_fill_zone_details( $zone );
+		}
+
+		function lock_zone( $zone, $user_id = 0 ) {
+			$zone_id = $this->get_zone_id( $zone );
+
+			if ( ! $zone_id ) {
+				return false;
+			}
+
+			if ( ! $user_id ) {
+				$user    = wp_get_current_user();
+				$user_id = $user->ID;
+			}
+
+			$lock_key = $this->get_zone_meta_key( $zone );
+			$expiry   = $this->zone_lock_period + 1; // Add a one to avoid most race condition issues between lock expiry and ajax call
+			set_transient( $lock_key, $user->ID, $expiry );
+
+			// Possible alternative: set zone lock as property with time and user
+		}
+
+		// Not really needed with transients...
+		function unlock_zone( $zone ) {
+			$zone_id = $this->get_zone_id( $zone );
+
+			if ( ! $zone_id ) {
+				return false;
+			}
+
+			$lock_key = $this->get_zone_meta_key( $zone );
+
+			delete_transient( $lock_key );
+		}
+
+		function is_zone_locked( $zone ) {
+			$zone_id = $this->get_zone_id( $zone );
+			if ( ! $zone_id ) {
+				return false;
+			}
+
+			$user     = wp_get_current_user();
+			$lock_key = $this->get_zone_meta_key( $zone );
+
+			$lock = get_transient( $lock_key );
+
+			// If lock doesn't exist, or check if current user same as lock user
+			if ( ! $lock || absint( $lock ) === absint( $user->ID ) ) {
+				return false;
+			} else {          // return user_id of locking user
+				return absint( $lock );
+			}
+		}
+
+		function zone_exists( $zone ) {
+			$zone_id = $this->get_zone_id( $zone );
+
+			if ( term_exists( $zone_id, $this->zone_taxonomy ) ) {
+				return true;
+			}
+
+			return false;
+		}
+
+		function get_zone_id( $zone ) {
+			if ( is_int( $zone ) ) {
+				return $zone;
+			}
+
+			$zone = $this->get_zone( $zone );
+			if ( is_object( $zone ) ) {
+				$zone = $zone->term_id;
+			}
+
+			return (int) $zone;
+		}
+
+		function get_zone_meta_key( $zone ) {
+			$zone_id = $this->get_zone_id( $zone );
+			return $this->zone_meta_prefix . $zone_id;
+		}
+
+		function get_zone_slug( $zone ) {
+			if ( is_int( $zone ) ) {
+				$zone = $this->get_zone( $zone );
+			}
+
+			if ( is_object( $zone ) ) {
+				$zone = $zone->slug;
+			}
+
+			return $this->get_formatted_zone_slug( $zone );
+		}
+
+		function get_formatted_zone_slug( $slug ) {
+			return $slug; // legacy function -- slugs can no longer be changed
+		}
+		function get_unformatted_zone_slug( $slug ) {
+			return $slug; // legacy function -- slugs can no longer be changed
+		}
+
+		function get_post_id( $post ) {
+			if ( is_int( $post ) ) {
+				return $post;
+			} elseif ( is_array( $post ) ) {
+				return absint( $post['ID'] );
+			} elseif ( is_object( $post ) ) {
+				return $post->ID;
+			}
+
+			return false;
+		}
+
+		function get_post_order( $post, $zone ) {
+			$post_id  = $this->get_post_id( $post );
+			$meta_key = $this->get_zone_meta_key( $zone );
+
+			return get_metadata( 'post', $post_id, $meta_key, true );
+		}
+
+		function verify_nonce( $action ) {
+			$action = $this->_get_nonce_key( $action );
+			$nonce  = $this->_get_request_var( $action );
+
+			if ( empty( $nonce ) ) {
+				$nonce = $this->_get_request_var( '_wpnonce' );
+			}
+
+			if ( ! wp_verify_nonce( $nonce, $action ) ) {
+				$this->_unauthorized_access();
+			}
+		}
+
+		function verify_access( $action = '', $zone_id = null ) {
+			// TODO: should check if zone locked
+
+			$verify_function = '';
+			switch ( $action ) {
+				case 'insert':
+					$verify_function = '_current_user_can_add_zones';
+					break;
+				case 'update':
+				case 'delete':
+					$verify_function = '_current_user_can_edit_zones';
+					break;
+				default:
+					$verify_function = '_current_user_can_manage_zones';
+					break;
+			}
+
+			if ( ! call_user_func( array( $this, $verify_function ), $zone_id ) ) {
+				$this->_unauthorized_access();
+			}
+		}
+
+		function _unauthorized_access() {
+			wp_die( __( 'Sorry, you\'re not supposed to do that...', 'zoninator' ) );
+		}
+
+		function _fill_zone_details( $zone ) {
+			if ( ! empty( $zone->zoninator_parsed ) && $zone->zoninator_parsed ) {
+				return $zone;
+			}
+
+			$details = array();
+
+			if ( ! empty( $zone->description ) ) {
+				$details = maybe_unserialize( $zone->description );
+			}
+
+			$details = wp_parse_args( $details, $this->zone_detail_defaults );
+
+			foreach ( $details as $detail_key => $detail_value ) {
+				$zone->$detail_key = $detail_value;
+			}
+
+			$zone->zoninator_parsed = true;
+
+			return $zone;
+		}
+
+		function do_zoninator_feeds() {
+			$query_var = get_query_var( $this->zone_taxonomy );
+
+			if ( ! empty( $query_var ) ) {
+				$zone_slug = get_query_var( $this->zone_taxonomy );
+				$results   = $this->get_zone_feed( $zone_slug );
+				if ( is_wp_error( $results ) ) {
+					$this->send_user_error( $results->get_error_message() );
+				}
+				$this->json_return( $results, false );
+			}
+
+			return;
+		}
+
+		private function filter_zone_feed_fields( $results ) {
+			$filtered_results   = array();
+			$whitelisted_fields = apply_filters(
+				'zoninator_zone_feed_fields',
+				array( 'ID', 'post_date', 'post_title', 'post_content', 'post_excerpt', 'post_status', 'guid' )
+			);
+
+			$filtered_results = array();
+			$i                = 0;
+			foreach ( $results as $result ) {
+				if ( ! isset( $filtered_results[ $i ] ) ) {
+					$filtered_results[ $i ] = new stdClass();
+				}
+				foreach ( $whitelisted_fields as $field ) {
+					if ( ! isset( $filtered_results[ $i ] ) ) {
+						$filtered_results[ $i ] = new stdClass();
+					}
+					$filtered_results[ $i ]->$field = $result->$field;
+				}
+				++$i;
+			}
+
+			return $filtered_results;
+		}
+
+		/**
+		 * Encode some data and echo it (possibly without cached headers)
+		 *
+		 * @param array $data
+		 */
+		private function json_return( $data ) {
+
+			if ( $data == null ) {
+				return false;
+			}
+
+			header( 'Content-Type: application/json' );
+			echo json_encode( $data );
+			exit();
+		}
+
+		private static function send_user_error( $message ) {
+			self::status_header_with_message( 406, $message );
+			exit();
+		}
+
+		/**
+		 * Modify the header and description in the global array
+		 *
+		 * @global array $wp_header_to_desc
+		 * @param int    $status
+		 * @param string $message
+		 */
+		private static function status_header_with_message( $status, $message ) {
+			global $wp_header_to_desc;
+
+			$status                       = absint( $status );
+			$official_message             = isset( $wp_header_to_desc[ $status ] ) ? $wp_header_to_desc[ $status ] : '';
+			$wp_header_to_desc[ $status ] = $message;
+
+			status_header( $status );
+
+			$wp_header_to_desc[ $status ] = $official_message;
+		}
+
+		// TODO: Caching needs to be testing properly before being implemented!
+		function get_zone_cache_key( $zone, $args = array() ) {
+			return '';
+
+			$meta_key = $this->get_zone_meta_key( $zone );
+			$hash     = md5( serialize( $args ) );
+			return $meta_key . $hash;
+		}
+
+		function get_zone_posts_from_cache( $zone, $args = array() ) {
+			return false; // TODO: implement
+
+			$meta_key  = $this->get_zone_meta_key( $zone );
+			$cache_key = $this->get_zone_cache_key( $zone, $args );
+			if ( $posts = wp_cache_get( $cache_key, $meta_key ) ) {
+				return $posts;
+			}
+			return false;
+		}
+
+		function add_zone_posts_to_cache( $posts, $zone, $args = array() ) {
+			return; // TODO: implement
+
+			$meta_key  = $this->get_zone_meta_key( $zone );
+			$cache_key = $this->get_zone_cache_key( $zone, $args );
+			wp_cache_set( $cache_key, $posts, $meta_key );
+		}
+
+		// Handle 4.2 term-splitting
+		function split_shared_term( $old_term_id, $new_term_id, $term_taxonomy_id, $taxonomy ) {
+			if ( $this->zone_taxonomy === $taxonomy ) {
+				do_action( 'zoninator_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
+
+				// Quick, easy switcheroo; add posts to new zone id and remove from the old one.
+				$posts = $this->get_zone_posts( $old_term_id );
+				if ( ! empty( $posts ) ) {
+					$this->add_zone_posts( $new_term_id, $posts );
+					$this->remove_zone_posts( $old_term_id );
+				}
+
+				do_action( 'zoninator_did_split_shared_term', $old_term_id, $new_term_id, $term_taxonomy_id );
+			}
+		}
+
+		function _empty_zone_posts_cache( $meta_key ) {
+			return; // TODO: implement
+		}
+
+		function _get_message( $message_id, $encode = false ) {
+			$message = '';
+
+			if ( ! empty( $this->zone_messages[ $message_id ] ) ) {
+				$message = $this->zone_messages[ $message_id ];
+			}
+
+			if ( $encode ) {
+				$message = urlencode( $message );
+			}
+
+			return $message;
+		}
+
+		function _get_nonce_key( $action ) {
+			return sprintf( '%s-%s', $this->zone_nonce_prefix, $action );
+		}
+
+		function _current_user_can_add_zones() {
+			return current_user_can( $this->_get_add_zones_cap() );
+		}
+
+		function _current_user_can_edit_zones( $zone_id ) {
+			$has_cap = current_user_can( $this->_get_edit_zones_cap() );
+			return apply_filters( 'zoninator_current_user_can_edit_zone', $has_cap, $zone_id );
+		}
+
+		function _current_user_can_manage_zones() {
+			return current_user_can( $this->_get_manage_zones_cap() );
+		}
+
+		function _get_add_zones_cap() {
+			return apply_filters( 'zoninator_add_zone_cap', 'edit_others_posts' );
+		}
+
+		function _get_edit_zones_cap() {
+			return apply_filters( 'zoninator_edit_zone_cap', 'edit_others_posts' );
+		}
+
+		function _get_manage_zones_cap() {
+			return apply_filters( 'zoninator_manage_zone_cap', 'edit_others_posts' );
+		}
+
+		function _get_zone_page_url( $args = array() ) {
+			$url = menu_page_url( $this->key, false );
+
+			foreach ( $args as $arg_key => $arg_value ) {
+				$url = add_query_arg( $arg_key, $arg_value, $url );
+			}
+
+			return $url;
+		}
+
+		function _validate_date_filter( $date ) {
+			return preg_match( '/([0-9]{4})-([0-9]{2})-([0-9]{2})/', $date );
+		}
+
+		function _validate_category_filter( $cat ) {
+			return $cat && get_term_by( 'id', $cat, 'category' );
+		}
+
+		function _sanitize_value( $var ) {
+			return htmlentities( stripslashes( $var ) );
+		}
+
+		function _get_value_or_default( $var, $object, $default = '', $sanitize_callback = '' ) {
+			if ( is_object( $object ) ) {
+				$value = ! empty( $object->$var ) ? $object->$var : $default;
+			} elseif ( is_array( $object ) ) {
+				$value = ! empty( $object[ $var ] ) ? $object[ $var ] : $default;
+			} else {
+				$value = $default;
+			}
+
+			if ( is_callable( $sanitize_callback ) ) {
+				if ( is_array( $value ) ) {
+					$value = array_map( $sanitize_callback, $value );
+				} else {
+					$value = call_user_func( $sanitize_callback, $value );
+				}
+			}
+
+			return $value;
+		}
+
+		function _get_request_var( $var, $default = '', $sanitize_callback = '' ) {
+			return $this->_get_value_or_default( $var, $_REQUEST, $default, $sanitize_callback );
+		}
+
+		function _get_get_var( $var, $default = '', $sanitize_callback = '' ) {
+			return $this->_get_value_or_default( $var, $_GET, $default, $sanitize_callback );
+		}
+		function _get_post_var( $var, $default = '', $sanitize_callback = '' ) {
+			return $this->_get_value_or_default( $var, $_POST, $default, $sanitize_callback );
+		}
+
+		public function get_admin_zone_post( $post, $zone ) {
+			return apply_filters(
+				'zoninator_zone_post_columns',
+				array(
+					'post_id'  => $post->ID,
+					'position' => array(
+						'current_position'        => intval( $this->get_post_order( $post->ID, $zone ) ),
+						'change_position_message' => esc_attr__( 'Click and drag to change the position of this item.', 'zoninator' ),
+						'key'                     => 'position',
+					),
+					'info'     => array(
+						'key'              => 'info',
+						'post'             => array(
+							'post_title'  => esc_html( $post->post_title ),
+							'post_status' => esc_html( $post->post_status ),
+						),
+						'action_link_data' => array(
+							array(
+								'action' => 'edit',
+								'anchor' => get_edit_post_link( $post->ID ),
+								'title'  => __( 'Opens in new window', 'zoninator' ),
+								'text'   => __( 'Edit', 'zoninator' ),
+								'target' => '_blank',
+							),
+							array(
+								'action' => 'delete',
+								'anchor' => '#',
+								'title'  => '',
+								'text'   => __( 'Remove', 'zoninator' ),
+							),
+							array(
+								'action' => 'view',
+								'anchor' => get_permalink( $post->ID ),
+								'title'  => __( 'Opens in new window', 'zoninator' ),
+								'text'   => __( 'View', 'zoninator' ),
+								'target' => '_blank',
+							),
+						),
+					),
+				),
+				$post,
+				$zone
+			);
+		}
+
+		public function get_admin_zone_posts( $zone_or_id ) {
+			$zone             = $this->get_zone( $zone_or_id );
+			$posts            = $this->get_zone_posts( $zone );
+			$admin_zone_posts = array();
+
+			foreach ( $posts as $post ) {
+				$admin_zone_posts[] = $this->get_admin_zone_post( $post, $zone );
+			}
+
+			return $admin_zone_posts;
+		}
+
+		/**
+		 * @param $zone_slug_or_id
+		 * @return array|WP_Error
+		 */
+		function get_zone_feed( $zone_slug_or_id ) {
+			$zone_id = $this->get_zone( $zone_slug_or_id );
+
+			if ( empty( $zone_id ) ) {
+				return new WP_Error( 'invalid-zone-supplied', __( 'Invalid zone supplied', 'zoninator' ) );
+			}
+
+			$results          = $this->get_zone_posts( $zone_id, apply_filters( 'zoninator_json_feed_fields', array(), $zone_slug_or_id ) );
+			$filtered_results = $this->filter_zone_feed_fields( $results );
+
+			return apply_filters( 'zoninator_json_feed_results', $filtered_results, $zone_slug_or_id );
+		}
+
+		public function check( $action = '', $zone_id = null ) {
+			// TODO: should check if zone locked
+			if ( 'insert' == $action ) {
+				return $this->_current_user_can_add_zones();
+			}
+
+			if ( 'update' == $action || 'delete' == $action ) {
+				return $this->_current_user_can_edit_zones( $zone_id );
+			}
+
+			return $this->_current_user_can_manage_zones();
+		}
 	}
-}
 
-function Zoninator() {
-	global $zoninator;
-	if ( ! isset( $zoninator ) || null === $zoninator ) {
-		$zoninator = new Zoninator;
+	function Zoninator() {
+		global $zoninator;
+		if ( ! isset( $zoninator ) || null === $zoninator ) {
+			$zoninator = new Zoninator();
+		}
+		return $zoninator;
 	}
-	return $zoninator;
-}
 
-Zoninator();
-
+	Zoninator();
 endif;

--- a/zoninator.php
+++ b/zoninator.php
@@ -88,6 +88,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 			include_once 'includes/class-zoninator-api.php';
 			$this->rest_api = new Zoninator_Api( $this );
+			return null;
 		}
 
 		function add_zone_feed() {
@@ -1339,6 +1340,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			set_transient( $lock_key, $user->ID, $expiry );
 
 			// Possible alternative: set zone lock as property with time and user
+			return null;
 		}
 
 		// Not really needed with transients...
@@ -1352,6 +1354,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			$lock_key = $this->get_zone_meta_key( $zone );
 
 			delete_transient( $lock_key );
+			return null;
 		}
 
 		function is_zone_locked( $zone ) {

--- a/zoninator.php
+++ b/zoninator.php
@@ -1516,7 +1516,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				$zone_slug = get_query_var( $this->zone_taxonomy );
 				$results   = $this->get_zone_feed( $zone_slug );
 				if ( is_wp_error( $results ) ) {
-					$this->send_user_error( $results->get_error_message() );
+					self::send_user_error($results->get_error_message());
 				}
 				$this->json_return( $results, false );
 			}
@@ -1581,7 +1581,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			global $wp_header_to_desc;
 
 			$status                       = absint( $status );
-			$official_message             = isset( $wp_header_to_desc[ $status ] ) ? $wp_header_to_desc[ $status ] : '';
+			$official_message             = $wp_header_to_desc[ $status ] ?? '';
 			$wp_header_to_desc[ $status ] = $message;
 
 			status_header( $status );

--- a/zoninator.php
+++ b/zoninator.php
@@ -86,7 +86,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 				return false;
 			}
 
-			include_once 'includes/class-zoninator-api.php';
+			include_once __DIR__ . '/includes/class-zoninator-api.php';
 			$this->rest_api = new Zoninator_Api( $this );
 			return null;
 		}

--- a/zoninator.php
+++ b/zoninator.php
@@ -289,10 +289,8 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			$zones = $this->get_zones( apply_filters( 'zoninator_admin_page_get_zones_args', array() ) );
 
 			$default_active_zone = 0;
-			if ( ! $this->_current_user_can_add_zones() ) {
-				if ( ! empty( $zones ) ) {
-					$default_active_zone = $zones[0]->term_id;
-				}
+			if ( ! $this->_current_user_can_add_zones() && ! empty( $zones ) ) {
+				$default_active_zone = $zones[0]->term_id;
 			}
 
 			$active_zone_id = $this->_get_request_var( 'zone_id', $default_active_zone, 'absint' );

--- a/zoninator.php
+++ b/zoninator.php
@@ -955,7 +955,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 			foreach ( get_post_types() as $post_type ) {
 				if ( post_type_supports( $post_type, $this->zone_taxonomy ) ) {
-					array_push( $this->post_types, $post_type );
+					$this->post_types[] = $post_type;
 				}
 			}
 

--- a/zoninator.php
+++ b/zoninator.php
@@ -1381,12 +1381,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 		function zone_exists( $zone ) {
 			$zone_id = $this->get_zone_id( $zone );
-
-			if ( term_exists( $zone_id, $this->zone_taxonomy ) ) {
-				return true;
-			}
-
-			return false;
+			return (bool) term_exists( $zone_id, $this->zone_taxonomy );
 		}
 
 		function get_zone_id( $zone ) {

--- a/zoninator.php
+++ b/zoninator.php
@@ -40,21 +40,21 @@ if ( ! class_exists( 'Zoninator' ) ) :
 
 	class Zoninator {
 
-		var $key                    = 'zoninator';
-		var $zone_taxonomy          = 'zoninator_zones';
-		var $zone_term_prefix       = 'zone-';
-		var $zone_meta_prefix       = '_zoninator_order_';
-		var $zone_nonce_prefix      = 'zone-nonce';
-		var $zone_ajax_nonce_action = 'ajax-action';
-		var $zone_lock_period       = 30; // number of seconds a lock is valid for
-		var $zone_max_lock_period   = 600; // max number of seconds for all locks in a session
-		var $post_types             = null;
-		var $zone_detail_defaults   = array(
+		public $key                    = 'zoninator';
+		public $zone_taxonomy          = 'zoninator_zones';
+		public $zone_term_prefix       = 'zone-';
+		public $zone_meta_prefix       = '_zoninator_order_';
+		public $zone_nonce_prefix      = 'zone-nonce';
+		public $zone_ajax_nonce_action = 'ajax-action';
+		public $zone_lock_period       = 30; // number of seconds a lock is valid for
+		public $zone_max_lock_period   = 600; // max number of seconds for all locks in a session
+		public $post_types             = null;
+		public $zone_detail_defaults   = array(
 			'description' => '',
 		// Add additional properties here!
 		);
-		var $zone_messages  = null;
-		var $posts_per_page = 10;
+		public $zone_messages  = null;
+		public $posts_per_page = 10;
 		/**
 		 * @var Zoninator_Api
 		 */
@@ -511,7 +511,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 						<?php endif; ?>
 					</div>
 				</div>
-			<?php endif; ?>
+<?php endif; ?>
 		</div>
 
 			<?php

--- a/zoninator.php
+++ b/zoninator.php
@@ -748,7 +748,7 @@ if ( ! class_exists( 'Zoninator' ) ) :
 			if ( empty( $screen ) ) {
 				return ! empty( $_REQUEST['page'] ) && sanitize_key( $_REQUEST['page'] ) == $this->key;
 			} else {
-				return ! empty( $screen->id ) && strstr( $screen->id, $this->key );
+				return ! empty( $screen->id ) && strstr( $screen->id, (string) $this->key );
 			}
 		}
 


### PR DESCRIPTION
https://getrector.com/ is a tool for PHP development that can help rewrite code to meet certain rules, such as tidying up code when different minimum versions of PHP are supported or following common or best practices around code quality, dead code, coding style, and more.

I've applied each PHP ruleset, and then different levels of the prepared sets in different commits - for review, these would be much easier to see the similar changes, that reviewing all the changes at once.

One notable change not covered here is the addition of type declarations. 

I believe there is no change in functionality from this PR.