### PR TITLE
Declare controller property to silence PHP warning

### DIFF
--- a/src/zoninator_rest/controller/class-zoninator-rest-controller-action.php
+++ b/src/zoninator_rest/controller/class-zoninator-rest-controller-action.php
@@ -13,21 +13,28 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Zoninator_REST_Controller_Action
  */
 class Zoninator_REST_Controller_Action {
-	public $controller;
+
+	/**
+	 * The controller name
+	 *
+	 * @var Zoninator_REST_Controller
+	 */
+	public Zoninator_REST_Controller $controller;
+
 
 	/**
 	 * Permitted actions
 	 *
 	 * @var array
 	 */
-	private $actions_to_http_methods = array(
+	private $actions_to_http_methods = [
 		'index'  => WP_REST_Server::READABLE,
 		'show'   => WP_REST_Server::READABLE,
 		'create' => WP_REST_Server::CREATABLE,
 		'update' => WP_REST_Server::EDITABLE,
 		'delete' => WP_REST_Server::DELETABLE,
 		'any'    => WP_REST_Server::ALLMETHODS,
-	);
+	];
 
 	/**
 	 * The action name
@@ -61,14 +68,17 @@ class Zoninator_REST_Controller_Action {
 	 * Zoninator_REST_Controller_Action constructor.
 	 *
 	 * @param Zoninator_REST_Controller $controller Controller.
-	 * @param string                    $action_name The action Name.
+	 * @param string $action_name The action Name.
 	 */
 	public function __construct( $controller, $action_name ) {
 		$is_known_action = in_array( $action_name, array_keys( $this->actions_to_http_methods ), true );
 		Zoninator_REST_Expect::that( $is_known_action, 'Unknown method: ' . $action_name );
 
-		$this->controller  = $controller;
-		$this->action_name = $action_name;
+		$this->controller          = $controller;
+		$this->action_name         = $action_name;
+		$this->handler             = null;
+		$this->args                = null;
+		$this->permission_callback = null;
 	}
 
 	/**
@@ -156,10 +166,8 @@ class Zoninator_REST_Controller_Action {
 			if ( is_string( $callable_func ) && method_exists( $this->controller, $callable_func ) ) {
 				return array( $this->controller, $callable_func );
 			}
-
 			Zoninator_REST_Expect::that( is_callable( $callable_func ), 'Callable Expected: $callable_func' );
 		}
-
 		return $callable_func;
 	}
 }


### PR DESCRIPTION
Declare controller property to silence PHP warnings. Updated code standards to WordPress-VIP-Go phpcs standard.