### PR TITLE
Migrate integration tests to use wp-env

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -41,10 +41,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install wordpress environment
+        run: npm install -g @wordpress/env
+
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3
@@ -57,25 +61,13 @@ jobs:
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Show PHP and PHPUnit version info
-        run: |
-          php --version
-          ./vendor/bin/phpunit --version
-
-      - name: Start MySQL Service
-        run: sudo systemctl start mysql.service
-
-      # This is needed as the integration tests use SVN to download the WordPress core and test dependencies.
-      - name: Install SVN (Subversion)
-        run: |
-          sudo apt-get update
-          sudo apt-get install subversion
-
-      - name: Prepare environment for integration tests
-        run: composer prepare-ci ${{ matrix.wordpress }}
+      - name: Setup wp-env
+        run: wp-env start
+        env:
+          WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress }}
 
       - name: Run integration tests (single site)
-        run: composer test
+        run: composer test-integration
 
       - name: Run integration tests (multisite)
-        run: composer test-ms
+        run: composer test-integration-ms

--- a/composer.json
+++ b/composer.json
@@ -45,16 +45,8 @@
 		"lint-ci": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
 		],
-		"prepare-ci": [
-			"bash bin/install-wp-tests.sh wordpress_test root root localhost"
-		],
-		"test": [
-			"@php ./vendor/bin/phpunit --testsuite WP_Tests"
-		],
-		"test-ms": [
-			"@putenv WP_MULTISITE=1",
-			"@composer test"
-		]
+		"test-integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator ./vendor/bin/phpunit --testsuite WP_Tests",
+		"test-integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite WP_Tests'"
 	},
 	"support": {
 		"issues": "https://github.com/Automattic/zoninator/issues",


### PR DESCRIPTION
Replace SVN-based test setup with @wordpress/env.

Changes:
- Use wp-env to set up WordPress test environment
- Update matrix: 'latest' → '6.8', 'trunk' → 'master'
- Rename composer scripts: test/test-ms → test-integration/test-integration-ms
- Remove SVN dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)