### PR TITLE
Simplify .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,10 +13,6 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
-indent_size = 4
-eclint_block_comment_start = /*
-eclint_block_comment = *
-eclint_block_comment_end = */
 
 [*.yml]
 indent_style = space
@@ -27,6 +23,3 @@ trim_trailing_whitespace = false
 
 [*.txt]
 end_of_line = crlf
-
-[LICENSE]
-indent_style = unset


### PR DESCRIPTION
## Summary

Simplifies the `.editorconfig` file to match the standard configuration used across other plugins.

## Why

Removes non-standard settings (eclint configurations, explicit tab indent size, LICENSE section) to align with WordPress core `.editorconfig` standards.

## Testing

No functional changes - this only updates editor configuration.