### PR TITLE
ci: standardise test matrix and update readme

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,6 @@ jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowed_failure }}
 
     env:
       WP_VERSION: ${{ matrix.wordpress }}
@@ -23,19 +22,9 @@ jobs:
           # Check lowest supported WP version, with the lowest supported PHP.
           - wordpress: '6.4'
             php: '7.4'
-            allowed_failure: false
-          # Check latest WP release with the highest supported PHP.
-          - wordpress: '6.8'
-            php: 'latest'
-            allowed_failure: false
-          # Check upcoming WP (master is the development branch).
+          # Check latest WP with the latest PHP.
           - wordpress: 'master'
             php: 'latest'
-            allowed_failure: true
-          # Check upcoming PHP - only needed when a new version has been forked (typically Sep-Nov)
-#          - wordpress: 'trunk'
-#            php: 'nightly'
-#            allowed_failure: true
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 0.10.2  
 Requires at least: 6.4  
-Tested up to: 6.8  
+Tested up to: 6.9  
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  


### PR DESCRIPTION
## Summary

- Updates CI workflow to test against WP 6.4 and master with PHP 7.4 and latest
- Removes allowed_failure flag so CI fails if tests fail on any supported configuration
- Updates README to reflect tested versions (WP 6.9)

## Test plan

- [ ] CI passes on WP 6.4 with PHP 7.4
- [ ] CI passes on WP master with PHP latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)