### PR TITLE
Harden admin UI against reflected and stored XSS

### DIFF
--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -138,15 +138,14 @@ var zoninator = {};
 			var autocomplete = zoninator.$zonePostSearch.data('autocomplete') || zoninator.$zonePostSearch.data('ui-autocomplete');
 
 			autocomplete._renderItem = function(ul, item) {
-				var content = '<a>'
-					+ '<span class="title">' + item.title + '</span>'
-					+ '<span class="type">' + item.post_type + '</span>'
-					+ '<span class="date">' + item.date + '</span>'
-					+ '<span class="status">' + item.post_status + '</span>'
-					+ '</a>';
+				var $anchor = $('<a></a>')
+					.append($('<span class="title"></span>').text(item.title))
+					.append($('<span class="type"></span>').text(item.post_type))
+					.append($('<span class="date"></span>').text(item.date))
+					.append($('<span class="status"></span>').text(item.post_status));
 				return $('<li></li>')
 					.data('item.autocomplete', item)
-					.append(content)
+					.append($anchor)
 					.appendTo(ul)
 					;
 			}

--- a/src/class-zoninator.php
+++ b/src/class-zoninator.php
@@ -83,6 +83,8 @@ class Zoninator {
 			'update-success'      => __( 'The zone was successfully updated.', 'zoninator' ),
 			'delete-success'      => __( 'The zone was successfully deleted.', 'zoninator' ),
 			'error-general'       => __( 'Sorry, something went wrong! Please try again?', 'zoninator' ),
+			'error-delete-zone'   => __( "Sorry, we couldn't delete the zone.", 'zoninator' ),
+			'error-invalid-zone'  => __( "Sorry, that zone doesn't exist.", 'zoninator' ),
 			/* translators: User's display name, or "another user" */
 			'error-zone-lock'     => __( 'Sorry, this zone is in use by %s and is currently locked. Please try again later.', 'zoninator' ),
 			'error-zone-lock-max' => __( 'Sorry, you have reached the maximum idle limit and will now be redirected to the Dashboard.', 'zoninator' ),
@@ -251,7 +253,7 @@ class Zoninator {
 					}
 
 					if ( is_wp_error( $result ) ) {
-						$redirect_args = array( 'error' => $result->get_error_messages() );
+						$redirect_args = array( 'error' => $result->get_error_code() );
 					} else {
 						$redirect_args = array( 'message' => 'delete-success' );
 					}
@@ -281,8 +283,16 @@ class Zoninator {
 			$title = __( 'Edit Zone', 'zoninator' );
 		}
 
-		$message = $this->_get_message( $this->_get_get_var( 'message', '', 'urldecode' ) );
-		$error   = $this->_get_get_var( 'error', '', 'urldecode' );
+		$message    = $this->_get_message( $this->_get_get_var( 'message', '', 'sanitize_key' ) );
+		$error_code = $this->_get_get_var( 'error', '', 'sanitize_key' );
+		if ( $error_code ) {
+			$error = $this->_get_message( 'error-' . $error_code );
+			if ( '' === $error ) {
+				$error = $this->_get_message( 'error-general' );
+			}
+		} else {
+			$error = '';
+		}
 
 		?>
 	<div class="wrap zoninator-page">
@@ -675,7 +685,7 @@ class Zoninator {
 			$content      = '';
 			$recent_posts = get_posts( $args );
 			foreach ( $recent_posts as $post ) :
-				$content .= sprintf( '<option value="%d">%s</option>', $post->ID, get_the_title( $post->ID ) . ' (' . $post->post_status . ')' );
+				$content .= sprintf( '<option value="%d">%s</option>', $post->ID, esc_html( get_the_title( $post->ID ) . ' (' . $post->post_status . ')' ) );
 			endforeach;
 
 			wp_reset_postdata();


### PR DESCRIPTION
## Summary

A pass over the zone admin screen for a security review surfaced three small XSS surfaces. Each requires an attacker who already has some foothold (a post they can title freely, or a URL they can get an editor to click), so none is critical, but each turns the admin page into a delivery mechanism for whatever payload they can land. The point of this branch is to make the admin UI safe regardless of what an upstream filter, importer, or other plugin writes into post titles, post statuses, or the error query parameter.

The autocomplete result renderer in `js/zoninator.js` was assembling result rows by concatenating raw `item.title`, `item.post_type`, `item.date`, and `item.post_status` into HTML. Switching to `jQuery('<span>').text(value)` inserts each value as a text node, so a title containing `<img onerror=…>` is rendered as text rather than evaluated. This is the most likely live exploitation path on a single-site install where Administrators have `unfiltered_html`.

The `ajax_recent_posts` AJAX handler builds a `<select>` of recent posts as an HTML string on the server and the client appends it via `$(returnData.content)`. Titles were not escaped before being interpolated into the option text. Wrapping the `get_the_title( …​ )` fragment in `esc_html()` closes the same kind of stored XSS via the recent-posts dropdown.

The admin error notice in `admin_page()` was rendering `?error=…` from the URL after only `urldecode()`, which let any URL set the text shown in the notice. Output escaping prevented script execution, but it still allowed an attacker-controlled string to appear on a privileged screen — useful for phishing editors. The new code reads a sanitised error code, looks it up in the existing `zone_messages` whitelist (with a fallback to `error-general`), and updates the delete redirect to pass the error code rather than the raw error message strings.

## Test plan

- [ ] On the Zones admin page, type into the search field and verify autocomplete results render correctly for normal post titles.
- [ ] As an Administrator on a single-site install, create a post with a title like `<img src=x onerror=alert(1)>`, then search for it on the Zones admin page and confirm the title appears as text, with no alert.
- [ ] Open the recent-posts dropdown and confirm the same payload renders as text inside the `<select>` and does not execute.
- [ ] Trigger a delete failure (e.g. delete a zone whose term has been removed in another tab) and confirm the redirected admin page shows a sensible error message rather than a blank screen.
- [ ] Visit `/wp-admin/admin.php?page=zoninator&error=<script>alert(1)</script>` and confirm the rendered notice is the generic error message (or empty), not the supplied string.
- [ ] Run `composer cs` to confirm code standards pass.