### PR TITLE
Harden zone description deserialisation and lock down /zones index

### DIFF
--- a/src/class-zoninator-api-controller.php
+++ b/src/class-zoninator-api-controller.php
@@ -337,11 +337,22 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	/**
 	 * Check if a given request has access to the zones index.
 	 *
+	 * Defaults to requiring a logged-in user to avoid leaking zone names and
+	 * descriptions to anonymous callers. Sites that integrated against the
+	 * historical unauthenticated behaviour can restore it via the
+	 * zoninator_rest_get_zones_permissions_check filter.
+	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
+	 * @return bool
 	 */
 	public function get_zones_permissions_check( $request ) {
-		return true;
+		/**
+		 * Filter whether the GET /zones REST endpoint authorises the request.
+		 *
+		 * @param bool            $authorised Whether the caller may list zones.
+		 * @param WP_REST_Request $request    The current REST request.
+		 */
+		return (bool) apply_filters( 'zoninator_rest_get_zones_permissions_check', is_user_logged_in(), $request );
 	}
 
 	/**

--- a/src/class-zoninator.php
+++ b/src/class-zoninator.php
@@ -1478,8 +1478,16 @@ class Zoninator {
 
 		$details = array();
 
-		if ( ! empty( $zone->description ) ) {
-			$details = maybe_unserialize( $zone->description );
+		if ( ! empty( $zone->description ) && is_serialized( $zone->description ) ) {
+			// Disallow object instantiation to prevent PHP object injection if a
+			// crafted serialized payload reaches the term description via any path.
+			// Silenced because unserialize() can still emit notices on truncated or
+			// malformed payloads that pass is_serialized().
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+			$unserialized = @unserialize( trim( $zone->description ), array( 'allowed_classes' => false ) );
+			if ( is_array( $unserialized ) ) {
+				$details = $unserialized;
+			}
 		}
 
 		$details = wp_parse_args( $details, $this->zone_detail_defaults );


### PR DESCRIPTION
## Summary

Zone "details" (currently just the description text) are persisted by serialising an array into the term description and read back via `maybe_unserialize` on every render of the admin page and on every REST or feed response that touches a zone. That makes the description column a high-traffic deserialisation sink. If anything — a buggy companion plugin, a database compromise, a future filter on `zoninator_insert_zone` — manages to write a crafted payload into a zone description, the next read instantiates whatever PHP objects the payload names. That is the standard shape of a POP-gadget RCE chain, and it is the kind of finding that turns into a public advisory the moment a popular plugin happens to ship a usable gadget.

The fix swaps `maybe_unserialize` for an explicit `is_serialized` check followed by `unserialize()` with `allowed_classes => false`, plus an `is_array()` sanity check on the result. Strings that are not serialised are left untouched and still flow through `wp_parse_args`, so legitimate descriptions are unchanged. PHP objects in a payload are turned into `__PHP_Incomplete_Class` instances rather than instantiated, neutralising the gadget chain regardless of which classes happen to be loaded.

While the deserialisation path was open, the `GET /wp-json/zoninator/v1/zones` endpoint was happy to return the full list of zone names and descriptions to any anonymous caller. There is no first-party need for that — the admin UI is the only consumer — and an unauthenticated reader is exactly the audience an attacker would use to confirm the shape of a payload they had just written. The endpoint now requires a logged-in user, with the historical behaviour preserved behind a `zoninator_rest_get_zones_permissions_check` filter so anyone integrating against the public listing can opt back in deliberately.

The companion `GET /zones/{id}/posts` endpoint is left as-is, because it shares its data with the documented public `/zones/{slug}/feed.json` rewrite and locking one without the other would not actually close anything.

## Test plan

- [ ] Create a zone with a description, edit it, and confirm the description still round-trips correctly through the admin screen.
- [ ] Run `composer test:integration` and confirm tests still pass.
- [ ] As a logged-in user, hit `GET /wp-json/zoninator/v1/zones` and confirm the response lists zones as before.
- [ ] As an anonymous user (incognito window), hit the same URL and confirm a `rest_forbidden` (or equivalent) response.
- [ ] Add `add_filter( 'zoninator_rest_get_zones_permissions_check', '__return_true' );` in a test mu-plugin and confirm the anonymous request succeeds, demonstrating the opt-back-in path.
- [ ] Set a zone's term description to a serialised payload referencing a class (e.g. via `wp term meta` or direct DB), reload the zone admin screen, and confirm no class is instantiated and the page renders without error.