### PR TITLE
Small correctness fixes around locks, AJAX, and i18n

### DIFF
--- a/src/class-zoninator-api-controller.php
+++ b/src/class-zoninator-api-controller.php
@@ -177,7 +177,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		$zone_id     = $this->get_param( $request, 'zone_id', 0, 'absint' );
 		$name        = $this->get_param( $request, 'name', '' );
 		$slug        = $this->get_param( $request, 'slug', '' );
-		$description = $this->get_param( $request, 'description', '', 'strip_tags' );
+		$description = $this->get_param( $request, 'description', '' );
 
 		$zone          = $this->instance->get_zone( $zone_id );
 		$update_params = array();

--- a/src/class-zoninator.php
+++ b/src/class-zoninator.php
@@ -433,7 +433,7 @@ class Zoninator {
 								<input type="submit" value="<?php esc_attr_e( 'Save zone info', 'zoninator' ); ?>" name="submit" class="button" />
 
 								<?php if ( $zone_id ) : ?>
-									<a href="<?php echo esc_url( $delete_link ); ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( 'Are you sure you want to delete this zone?', 'zoninator' ); ?>')"><?php esc_html_e( 'Delete', 'zoninator' ); ?></a>
+									<a href="<?php echo esc_url( $delete_link ); ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete this zone?', 'zoninator' ) ); ?>')"><?php esc_html_e( 'Delete', 'zoninator' ); ?></a>
 									<?php
 								endif;
 								?>
@@ -633,14 +633,14 @@ class Zoninator {
 		$date    = $this->_get_post_var( 'date', '', 'striptags' );
 		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
 
+		// Verify nonce and capability before doing any DB work.
+		$this->verify_nonce( $this->zone_ajax_nonce_action );
+		$this->verify_access( '', $zone_id );
+
 		$limit         = $this->posts_per_page;
 		$post_types    = $this->get_supported_post_types();
 		$zone_posts    = $this->get_zone_posts( $zone_id );
 		$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
 
 		if ( is_wp_error( $zone_posts ) ) {
 			$status  = 0;
@@ -1325,13 +1325,12 @@ class Zoninator {
 		}
 
 		if ( ! $user_id ) {
-			$user    = wp_get_current_user();
-			$user_id = $user->ID;
+			$user_id = get_current_user_id();
 		}
 
 		$lock_key = $this->get_zone_meta_key( $zone );
 		$expiry   = $this->zone_lock_period + 1; // Add a one to avoid most race condition issues between lock expiry and ajax call
-		set_transient( $lock_key, $user->ID, $expiry );
+		set_transient( $lock_key, $user_id, $expiry );
 
 		// Possible alternative: set zone lock as property with time and user
 		return null;


### PR DESCRIPTION
## Summary

A handful of unrelated small bugs surfaced during a security review. None is exploitable on its own, but each is the kind of latent fault that turns into something larger after the next refactor, so it is worth shipping them together while the area is fresh in mind.

`ajax_recent_posts` ran the zone post query before checking the nonce and capability. The handler bailed cleanly before returning anything to an unauthorised caller, so there is no live disclosure today, but the inversion is fragile — a future refactor that moves any output to before the check would silently turn into a leak. Moving the checks to the top of the function also avoids paying the database cost for unauthorised calls.

`lock_zone( $zone, $user_id )` only defined the local `$user` variable inside the `if ( ! $user_id )` branch but later did `set_transient( …, $user->ID, … )` unconditionally. Calling it with an explicit user id therefore emitted an undefined-variable notice and stored either nothing or the wrong value (depending on PHP version). The fix reaches for `get_current_user_id()` and stores `$user_id` directly so both call shapes work. Nothing in the plugin currently calls `lock_zone` with a user id argument, so this is a latent bug rather than a regression.

The Delete confirmation dialog string was wrapped in `esc_js( 'text', 'zoninator' )`. `esc_js` takes one argument, so the second value was discarded and the string was never marked translatable — which means it could not be translated and the string analysis tool would not pick it up either. Wrap it in `__()` and pass a single argument to `esc_js`.

The REST `update_zone` endpoint passed `'strip_tags'` as the late sanitiser for the description, but the field's `sanitize_string` callback had already entity-encoded the input by then, so `strip_tags` had nothing to strip. Drop the redundant callback to keep the layered sanitisation honest and avoid implying that `strip_tags` is doing anything.

## Test plan

- [ ] Open a zone in the admin and use the Recent dropdown filters; confirm the dropdown still updates correctly.
- [ ] Confirm the Delete link still prompts the confirmation dialog with the expected message.
- [ ] Switch the site to a non-default locale with a translation for the confirmation string and confirm the translated message appears (or run `wp i18n make-pot` and confirm the string is now extracted).
- [ ] Update a zone via `PUT /wp-json/zoninator/v1/zones/{id}` with a description containing HTML entities and confirm the description still round-trips as expected.
- [ ] Run `composer cs` and `composer test:integration` to confirm code standards and tests still pass.