### PR TITLE
Enforce auth and nonce on zoninator_search_posts AJAX handler

### DIFF
--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -113,6 +113,7 @@ var zoninator = {};
 
 						// Append more request vars
 						request.action = zoninator.getAjaxAction('search_posts');
+						request._wpnonce = zoninator.getAjaxNonce();
 						request.exclude = zoninator.getZonePostIds();
 
 						// Allow developers to hook onto the request

--- a/src/class-zoninator.php
+++ b/src/class-zoninator.php
@@ -879,6 +879,9 @@ class Zoninator {
 
 	public function ajax_search_posts() {
 
+		$this->verify_nonce( $this->zone_ajax_nonce_action );
+		$this->verify_access();
+
 		$q = $this->_get_request_var( 'term', '', 'stripslashes' );
 
 		if ( ! empty( $q ) ) {

--- a/tests/Integration/ZoninatorAjaxSearchPostsTest.php
+++ b/tests/Integration/ZoninatorAjaxSearchPostsTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Integration tests for the ajax_search_posts admin-ajax handler.
+ *
+ * Covers the authorisation and nonce enforcement added in response to
+ * authenticated information disclosure of scheduled (future) posts via
+ * wp_ajax_zoninator_search_posts.
+ *
+ * @package Automattic\Zoninator
+ */
+
+namespace Automattic\Zoninator\Tests\Integration;
+
+use WP_Ajax_UnitTestCase;
+use WPAjaxDieContinueException;
+use WPAjaxDieStopException;
+use Zoninator;
+
+/**
+ * @group ajax
+ */
+class Zoninator_Ajax_Search_Posts_Test extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * @var int
+	 */
+	private $future_post_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		$this->future_post_id = self::factory()->post->create( array(
+			'post_title'  => 'zoninator_future_leak_canary',
+			'post_status' => 'future',
+			'post_date'   => gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ),
+		) );
+
+		$_REQUEST = array();
+		$_POST    = array();
+		$_GET     = array();
+	}
+
+	public function tear_down(): void {
+		$_REQUEST = array();
+		$_POST    = array();
+		$_GET     = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * A subscriber must not be able to reach the search handler, even when
+	 * authenticated. This guards against authenticated enumeration of
+	 * scheduled posts via the search oracle.
+	 */
+	public function test_subscriber_is_blocked_without_json_output(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$_POST['action'] = 'zoninator_search_posts';
+		$_POST['term']   = 'zoninator_future_leak';
+
+		$this->expectException( WPAjaxDieStopException::class );
+
+		try {
+			$this->_handleAjax( 'zoninator_search_posts' );
+		} finally {
+			$this->assertStringNotContainsString(
+				'zoninator_future_leak_canary',
+				$this->_last_response,
+				'Subscriber must not receive search results for future posts.'
+			);
+		}
+	}
+
+	/**
+	 * An authorised user without a valid nonce must be rejected. This guards
+	 * against CSRF against the search endpoint.
+	 */
+	public function test_admin_without_nonce_is_blocked(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$_POST['action'] = 'zoninator_search_posts';
+		$_POST['term']   = 'zoninator_future_leak';
+
+		$this->expectException( WPAjaxDieStopException::class );
+
+		$this->_handleAjax( 'zoninator_search_posts' );
+	}
+
+	/**
+	 * An authorised user with a valid nonce receives JSON results for matches,
+	 * confirming the legitimate flow still works after the fix.
+	 */
+	public function test_admin_with_valid_nonce_receives_results(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$zoninator  = Zoninator();
+		$nonce_key  = $zoninator->_get_nonce_key( $zoninator->zone_ajax_nonce_action );
+		$nonce      = wp_create_nonce( $nonce_key );
+
+		$_POST['action']   = 'zoninator_search_posts';
+		$_POST['term']     = 'zoninator_future_leak';
+		$_POST['_wpnonce'] = $nonce;
+
+		try {
+			$this->_handleAjax( 'zoninator_search_posts' );
+			$this->fail( 'Expected handler to exit after emitting JSON.' );
+		} catch ( WPAjaxDieStopException $e ) {
+			// Expected. Handler calls exit after echoing JSON.
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Also acceptable under some test die handlers.
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertIsArray( $response );
+		$this->assertNotEmpty( $response );
+
+		$ids = array_map( static fn( $row ) => (int) $row['post_id'], $response );
+		$this->assertContains( $this->future_post_id, $ids );
+	}
+}


### PR DESCRIPTION
## Summary

The `wp_ajax_zoninator_search_posts` handler was reachable by any
authenticated user, including subscribers, and returned title, ID,
date, type and status for posts in `publish` or `future` status.
Because the underlying `WP_Query` runs on the `s` parameter, a
low-privileged user could brute-force scheduled post titles character
by character through a search oracle, exposing embargoed content. The
Zones admin UI is gated by `edit_others_posts`, but the AJAX endpoint
itself had no nonce or capability check, leaving a gap between the UI
and the handler.

This change brings `ajax_search_posts` into line with every other
Zoninator AJAX endpoint. `verify_nonce` and `verify_access` are now
called at the top of the method, with `verify_access` falling through
to its default branch and checking `edit_others_posts` — the same cap
that already gates the Zones page. The autocomplete on the Zones page
sends `_wpnonce` alongside its existing search request, so the
legitimate editor flow is unchanged.

The new integration test exercises the handler under three scenarios:
a subscriber is rejected without leaking results, an authenticated
admin without a valid nonce is rejected, and an admin with a valid
nonce continues to receive matching posts.

## Test plan

- [ ] `composer test:integration` passes, including the new
      `ZoninatorAjaxSearchPostsTest`
- [ ] On a fresh install, an editor can still use the post search on
      the Zones admin page
- [ ] As a subscriber, posting `action=zoninator_search_posts` to
      `admin-ajax.php` returns `wp_die`'s rejection page rather than
      JSON