### PR TITLE
Release 0.11.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/.distignore
+++ b/.distignore
@@ -1,20 +1,23 @@
-# Specify which files should not be included in the push to WordPress.org.
-# These are all development files and directories.
-# The deploy Action will use rsync + .distignore if the .distignore exists,
-# so it doesn't care what may or may not be ignored via .gitignore.
-
+# Directories
 /.git/
 /.github/
 /bin/
+/node_modules/
 /tests/
-/.distignore
-/.editorconfig
-/.gitattributes
-/.gitignore
-/.phpcs.xml.dist
-/CHANGELOG.md
-/composer.json
-/mixtape.json
-/package.json
-/package-lock.json
-/phpunit.xml.dist
+/vendor/
+
+# Files
+.distignore
+.editorconfig
+.gitattributes
+.gitignore
+.phpcs.xml.dist
+.wp-env.json
+.wp-env.override.json
+CHANGELOG.md
+composer.json
+composer.lock
+mixtape.json
+package.json
+package-lock.json
+phpunit.xml.dist

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,10 +13,6 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
-indent_size = 4
-eclint_block_comment_start = /*
-eclint_block_comment = *
-eclint_block_comment_end = */
 
 [*.yml]
 indent_style = space
@@ -27,6 +23,3 @@ trim_trailing_whitespace = false
 
 [*.txt]
 end_of_line = crlf
-
-[LICENSE]
-indent_style = unset

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The following teams will get auto-tagged for a review.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @Automattic/vip-plugins

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
         patterns: ["*"]
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "Actions"
       include: "scope"
@@ -37,8 +35,6 @@ updates:
           - "yoast/*"
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "Composer"
       include: "scope"
@@ -59,8 +55,6 @@ updates:
           - "@types/*"
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "npm"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+# Configuration for Dependabot version updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+    reviewers:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Actions"
+      include: "scope"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "automattic/*"
+          - "dealerdirect/*"
+          - "php-parallel-lint/*"
+          - "phpcompatibility/*"
+          - "phpunit/*"
+          - "squizlabs/*"
+          - "yoast/*"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Composer"
+      include: "scope"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "@wordpress/*"
+          - "eslint*"
+          - "prettier*"
+          - "@types/*"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "npm"
+      include: "scope"
+    open-pull-requests-limit: 5

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -10,6 +10,8 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check_cs:
     name: "Basic CS and QA checks"
@@ -20,7 +22,7 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: "8.3"
           coverage: none
@@ -29,15 +31,17 @@ jobs:
       # Show PHP lint violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register PHP lint violations to appear as file diff comments
-        uses: korelstar/phplint-problem-matcher@v1
+        uses: korelstar/phplint-problem-matcher@cb2b753750ec7bf13a7cde0a476df8c5605bdfb1 # v1.2.0
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register XML violations to appear as file diff comments
-        uses: korelstar/xmllint-problem-matcher@v1
+        uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0 # v1.2.0
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate
@@ -47,7 +51,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
 
       # Lint PHP.
       - name: Lint PHP against parse errors
@@ -56,7 +60,7 @@ jobs:
       # Needed as runs-on: system doesn't have xml-lint by default.
       # @link https://github.com/marketplace/actions/xml-lint
       - name: Lint phpunit.xml.dist
-        uses: ChristophWurst/xmllint-action@v1
+        uses: ChristophWurst/xmllint-action@7c54ff113fc0f6d4588a15cb4dfe31b6ecca5212 # v1.2.1
         with:
           xml-file: ./phpunit.xml.dist
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -39,7 +39,7 @@ jobs:
         uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0 # v1.2.0
 
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
           php-version: "8.3"
           coverage: none
@@ -51,7 +51,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       # Lint PHP.
       - name: Lint PHP against parse errors

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,13 +4,18 @@ on:
     types: [ released ]
   # Allow manual triggering of the workflow.
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   release:
     name: New release to WordPress.org
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Install SVN (Subversion)
         run: |
@@ -18,7 +23,7 @@ jobs:
           sudo apt-get install subversion
 
       - name: Push to WordPress.org
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # stable
         env:
           SLUG: zoninator
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,7 +75,7 @@ jobs:
           WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress }}
 
       - name: Run integration tests (single site)
-        run: composer test-integration
+        run: composer test:integration
 
       - name: Run integration tests (multisite)
-        run: composer test-integration-ms
+        run: composer test:integration-ms

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,6 @@ jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowed_failure }}
 
     env:
       WP_VERSION: ${{ matrix.wordpress }}
@@ -23,19 +22,9 @@ jobs:
           # Check lowest supported WP version, with the lowest supported PHP.
           - wordpress: '6.4'
             php: '7.4'
-            allowed_failure: false
-          # Check latest WP release with the highest supported PHP.
-          - wordpress: '6.8'
-            php: 'latest'
-            allowed_failure: false
-          # Check upcoming WP (master is the development branch).
+          # Check latest WP with the latest PHP.
           - wordpress: 'master'
             php: 'latest'
-            allowed_failure: true
-          # Check upcoming PHP - only needed when a new version has been forked (typically Sep-Nov)
-#          - wordpress: 'trunk'
-#            php: 'nightly'
-#            allowed_failure: true
       fail-fast: false
 
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,13 +38,13 @@ jobs:
         run: npm install -g @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
           php-version: ${{ matrix.php }}
           tools: composer
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           composer-options: "${{ matrix.composer-options }}"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - "**.md"
 
+permissions: {}
+
 jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
@@ -39,27 +41,33 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Install wordpress environment
         run: npm install -g @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: ${{ matrix.php }}
           tools: composer
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
         with:
           composer-options: "${{ matrix.composer-options }}"
 
       - name: Setup problem matchers for PHP
-        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+        run: echo "::add-matcher::${RUNNER_TOOL_CACHE}/php.json"
+        env:
+          RUNNER_TOOL_CACHE: ${{ runner.tool_cache }}
 
       - name: Setup Problem Matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+        run: echo "::add-matcher::${RUNNER_TOOL_CACHE}/phpunit.json"
+        env:
+          RUNNER_TOOL_CACHE: ${{ runner.tool_cache }}
 
       - name: Setup wp-env
         run: wp-env start

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -19,15 +19,15 @@ jobs:
       matrix:
         include:
           # Check lowest supported WP version, with the lowest supported PHP.
-          - wordpress: '5.9'
+          - wordpress: '6.4'
             php: '7.4'
             allowed_failure: false
-          # Check latest WP with the highest supported PHP.
-          - wordpress: 'latest'
+          # Check latest WP release with the highest supported PHP.
+          - wordpress: '6.8'
             php: 'latest'
             allowed_failure: false
-          # Check upcoming WP.
-          - wordpress: 'trunk'
+          # Check upcoming WP (master is the development branch).
+          - wordpress: 'master'
             php: 'latest'
             allowed_failure: true
           # Check upcoming PHP - only needed when a new version has been forked (typically Sep-Nov)

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -41,10 +41,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install wordpress environment
+        run: npm install -g @wordpress/env
+
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v3
@@ -57,25 +61,13 @@ jobs:
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Show PHP and PHPUnit version info
-        run: |
-          php --version
-          ./vendor/bin/phpunit --version
-
-      - name: Start MySQL Service
-        run: sudo systemctl start mysql.service
-
-      # This is needed as the integration tests use SVN to download the WordPress core and test dependencies.
-      - name: Install SVN (Subversion)
-        run: |
-          sudo apt-get update
-          sudo apt-get install subversion
-
-      - name: Prepare environment for integration tests
-        run: composer prepare-ci ${{ matrix.wordpress }}
+      - name: Setup wp-env
+        run: wp-env start
+        env:
+          WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress }}
 
       - name: Run integration tests (single site)
-        run: composer test
+        run: composer test-integration
 
       - name: Run integration tests (multisite)
-        run: composer test-ms
+        run: composer test-integration-ms

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,15 @@
-/.phpunit.cache/
+# Dependencies
 /node_modules/
 /vendor/
-/.phpcs.xml
+
+# Composer
 /composer.lock
+
+# Tests
+/.phpunit.cache/
+
+# Local config overrides
+/.phpcs.xml
 /phpcs.xml
 /phpunit.xml
+/.wp-env.override.json

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -50,7 +50,7 @@
 <!--	<rule ref="WordPress-Docs"/>-->
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,20 @@
+{
+  "plugins": [
+    "."
+  ],
+  "phpVersion": "7.4",
+  "config": {
+    "WP_DEBUG": true,
+    "WP_DEBUG_LOG": true,
+    "SCRIPT_DEBUG": true
+  },
+  "lifecycleScripts": {
+    "afterStart": "wp-env run cli wp plugin install query-monitor --activate"
+  },
+  "env": {
+    "tests": {
+      "phpVersion": "8.4",
+      "core": "WordPress/WordPress#trunk"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# Zoninator
+
+Content zone management for WordPress editorial workflows.
+
+## Project Knowledge
+
+| Property | Value |
+|----------|-------|
+| **Main file** | `zoninator.php` |
+| **Text domain** | `zoninator` |
+| **Function prefix** | `zoninator_` |
+| **Namespace** | Global (legacy) |
+| **Source directory** | Root level + `src/` |
+| **Version** | 0.8.0 |
+| **Requires PHP** | 7.4+ |
+
+### Directory Structure
+
+```
+zoninator/
+├── zoninator.php           # Main plugin file and Zoninator class
+├── functions.php            # Helper functions
+├── src/                    # Modern code additions
+├── css/                    # Admin stylesheets
+├── js/                     # Admin JavaScript (zone management UI)
+├── bin/                    # Build/utility scripts
+├── tests/                  # Integration tests
+├── languages/              # Translation files
+├── .github/workflows/      # CI: cs-lint, deploy, integration
+└── .phpcs.xml.dist         # PHPCS configuration
+```
+
+### Key Classes and Files
+
+- `zoninator.php` — Main `Zoninator` class: zone CRUD, post assignment, admin UI
+- `functions.php` — Template tag functions for theme developers
+- Zone data stored as taxonomy terms with post relationships
+
+### Dependencies
+
+- **Dev**: `automattic/vipwpcs`, `yoast/wp-test-utils`
+
+## Commands
+
+```bash
+composer cs                # Check code standards (PHPCS)
+composer cs-fix            # Auto-fix code standard violations
+composer lint              # PHP syntax lint
+composer test:integration  # Run integration tests (requires wp-env)
+composer test:integration-ms  # Run multisite integration tests
+composer coverage          # Run tests with HTML coverage report
+```
+
+**Note:** This plugin has integration tests only — no separate unit test suite.
+
+## Conventions
+
+Follow the standards documented in `~/code/plugin-standards/` for full details. Key points:
+
+- **Commits**: Use the `/commit` skill. Favour explaining "why" over "what".
+- **PRs**: Use the `/pr` skill. Squash and merge by default.
+- **Branch naming**: `feature/description`, `fix/description` from `develop`.
+- **Testing**: Integration tests only in this plugin. Use the existing test patterns. New tests should follow the integration test approach.
+- **Code style**: WordPress coding standards via PHPCS. Tabs for indentation.
+- **i18n**: All user-facing strings must use the `zoninator` text domain.
+
+## Architectural Decisions
+
+- **Taxonomy-based storage**: Zones are stored as custom taxonomy terms, and posts are assigned to zones via term relationships. This leverages WordPress's built-in taxonomy infrastructure rather than custom tables. Do not switch to custom database tables.
+- **Template tags in functions.php**: Theme developers use functions from `functions.php` to display zone content. These are part of the public API — do not rename or remove them without a deprecation cycle.
+- **Global namespace (legacy)**: The main class and functions are in the global namespace. This is legacy — do not introduce namespaced classes alongside global ones without a migration plan.
+- **WordPress.org deployment**: Has a deploy workflow for WordPress.org SVN. Do not manually modify SVN assets.
+## Common Pitfalls
+
+- Do not edit WordPress core files or bundled dependencies in `vendor/`.
+- Run `composer cs` before committing. CI will reject code standard violations.
+- Integration tests require `npx wp-env start` running first.
+- **Template tags are public API**: Functions in `functions.php` (e.g., `z_get_zone_posts()`, `z_get_posts_in_zone()`) are used by themes in production. Do not rename, remove, or change their signatures without a deprecation cycle.
+- Zone ordering is significant — posts within a zone have a specific display order. Ensure any query modifications preserve ordering.
+- The admin UI uses jQuery-based drag-and-drop for zone ordering. Test UI changes in the browser, not just with automated tests.
+- Do not create custom database tables for zone storage. The taxonomy-based approach is intentional and integrates well with WordPress caching and query infrastructure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-04-25
+
+This release raises the minimum WordPress version to 6.4. The REST `GET /wp-json/zoninator/v1/zones` endpoint now requires an authenticated user; sites that depended on anonymous access can restore the previous behaviour via the new `zoninator_rest_get_zones_permissions_check` filter.
+
+### Security
+
+* fix: Enforce auth and nonce on `zoninator_search_posts` AJAX handler by @GaryJones in https://github.com/Automattic/zoninator/pull/151
+* fix: Harden zone description deserialisation and lock down `/zones` REST index by @GaryJones in https://github.com/Automattic/zoninator/pull/149
+* fix: Harden admin UI against reflected and stored XSS by @GaryJones in https://github.com/Automattic/zoninator/pull/148
+
+### Fixed
+
+* fix: Small correctness fixes around locks, AJAX, and i18n by @GaryJones in https://github.com/Automattic/zoninator/pull/150
+
+### Changed
+
+* Bump minimum WordPress version to 6.4 by @GaryJones in https://github.com/Automattic/zoninator/pull/132
+
+### Maintenance
+
+* Migrate test infrastructure to wp-test-utils by @GaryJones in https://github.com/Automattic/zoninator/pull/142
+* ci: Standardise test matrix and update readme by @GaryJones in https://github.com/Automattic/zoninator/pull/139
+* chore: Migrate dependabot reviewers to CODEOWNERS by @GaryJones in https://github.com/Automattic/zoninator/pull/138
+* Standardise configurations and harden GitHub Actions security by @GaryJones in https://github.com/Automattic/zoninator/pull/136
+* Update composer.json for consistency by @GaryJones in https://github.com/Automattic/zoninator/pull/135
+* Simplify .editorconfig file by @GaryJones in https://github.com/Automattic/zoninator/pull/134
+* Migrate integration tests to use wp-env by @GaryJones in https://github.com/Automattic/zoninator/pull/133
+* Add wp-env configuration for local development by @GaryJones in https://github.com/Automattic/zoninator/pull/131
+* Update Composer, npm, and GitHub Actions dependencies via Dependabot
+
+### Documentation
+
+* Add AGENTS.md with structured agent guidance by @GaryJones in https://github.com/Automattic/zoninator/pull/143
+
 ## [0.10.2] - 2025-10-02
 
 ### Fixed
@@ -122,6 +156,7 @@ This release has PHP 7.4 and WordPress 5.9 as the minimum supported versions.
 
 * Initial Release!
 
+[0.11.0]: https://github.com/automattic/zoninator/compare/0.10.2..0.11.0
 [0.10.2]: https://github.com/automattic/zoninator/compare/0.10.1..0.10.2
 [0.10.1]: https://github.com/automattic/zoninator/compare/0.10.0..0.10.1
 [0.10.0]: https://github.com/automattic/zoninator/compare/0.9..0.10.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zone Manager (Zoninator)
 
-Stable tag: 0.10.2  
+Stable tag: 0.11.0  
 Requires at least: 6.4  
 Tested up to: 6.9  
 Requires PHP: 7.4  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 0.10.2  
 Requires at least: 6.4  
-Tested up to: 6.8  
+Tested up to: 6.9  
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Zone Manager (Zoninator)
 
 Stable tag: 0.10.2  
-Requires at least: 5.9  
-Tested up to: 6.6  
+Requires at least: 6.4  
+Tested up to: 6.8  
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpunit": "^9",
-		"rector/rector": "^1.2",
+		"rector/rector": "^2.2",
 		"yoast/wp-test-utils": "^1.2"
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpunit": "^9",
 		"rector/rector": "^1.2",
-		"yoast/phpunit-polyfills": "^1"
+		"yoast/wp-test-utils": "^1.2"
 	},
 	"config": {
 		"allow-plugins": {
@@ -55,8 +55,8 @@
 		"lint-ci": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
 		],
-		"test-integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator ./vendor/bin/phpunit --testsuite WP_Tests",
-		"test-integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite WP_Tests'"
+		"test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator ./vendor/bin/phpunit --testsuite WP_Tests",
+		"test:integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite WP_Tests'"
 	},
 	"scripts-descriptions": {
 		"coverage": "Run tests with code coverage reporting",
@@ -66,7 +66,7 @@
 		"i18n": "Generate a POT file for translation",
 		"lint": "Run PHP linting",
 		"lint-ci": "Run PHP linting and send results to stdout",
-		"test-integration": "Run all integration tests for the Zoninator plugin",
-		"test-integration-ms": "Run integration tests for the Zoninator plugin in multisite mode"
+		"test:integration": "Run integration tests",
+		"test:integration-ms": "Run integration tests in multisite mode"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -45,16 +45,8 @@
 		"lint-ci": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
 		],
-		"prepare-ci": [
-			"bash bin/install-wp-tests.sh wordpress_test root root localhost"
-		],
-		"test": [
-			"@php ./vendor/bin/phpunit --testsuite WP_Tests"
-		],
-		"test-ms": [
-			"@putenv WP_MULTISITE=1",
-			"@composer test"
-		]
+		"test-integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator ./vendor/bin/phpunit --testsuite WP_Tests",
+		"test-integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite WP_Tests'"
 	},
 	"support": {
 		"issues": "https://github.com/Automattic/zoninator/issues",

--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,39 @@
 {
 	"name": "automattic/zoninator",
-	"type": "wordpress-plugin",
 	"description": "Zone Editor",
-	"homepage": "https://github.com/Automattic/zoninator/",
 	"license": "GPL-2.0-or-later",
+	"type": "wordpress-plugin",
 	"authors": [
 		{
 			"name": "Automattic",
 			"homepage": "https://automattic.com/"
 		}
 	],
+	"homepage": "https://github.com/Automattic/zoninator/",
+	"support": {
+		"issues": "https://github.com/Automattic/zoninator/issues",
+		"source": "https://github.com/Automattic/zoninator"
+	},
 	"require": {
 		"php": ">=7.4",
-		"composer/installers": "~1.0"
+		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^3",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpunit": "^9",
-		"wp-coding-standards/wpcs": "^3",
-		"yoast/phpunit-polyfills": "^1",
-		"rector/rector": "^1.2"
+		"rector/rector": "^1.2",
+		"yoast/phpunit-polyfills": "^1"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"sort-packages": true
 	},
 	"scripts": {
-		"cbf": [
-			"@php ./vendor/bin/phpcbf"
-		],
 		"coverage": [
 			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html"
 		],
@@ -34,7 +41,10 @@
 			"@php ./vendor/bin/phpunit"
 		],
 		"cs": [
-			"@php ./vendor/bin/phpcs"
+			"@php ./vendor/bin/phpcs -q"
+		],
+		"cs-fix": [
+			"@php ./vendor/bin/phpcbf -q"
 		],
 		"i18n": [
 			"@php wp i18n make-pot . ./languages/zoninator.pot"
@@ -48,14 +58,15 @@
 		"test-integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator ./vendor/bin/phpunit --testsuite WP_Tests",
 		"test-integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite WP_Tests'"
 	},
-	"support": {
-		"issues": "https://github.com/Automattic/zoninator/issues",
-		"source": "https://github.com/Automattic/zoninator"
-	},
-	"config": {
-		"allow-plugins": {
-			"composer/installers": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
+	"scripts-descriptions": {
+		"coverage": "Run tests with code coverage reporting",
+		"coverage-ci": "Run tests with code coverage reporting and send results to stdout",
+		"cs": "Run PHP Code Sniffer",
+		"cs-fix": "Run PHP Code Sniffer and fix violations",
+		"i18n": "Generate a POT file for translation",
+		"lint": "Run PHP linting",
+		"lint-ci": "Run PHP linting and send results to stdout",
+		"test-integration": "Run all integration tests for the Zoninator plugin",
+		"test-integration-ms": "Run integration tests for the Zoninator plugin in multisite mode"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,8 @@
 		"lint-ci": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --checkstyle"
 		],
-		"test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator ./vendor/bin/phpunit --testsuite WP_Tests",
-		"test:integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite WP_Tests'"
+		"test:integration": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator ./vendor/bin/phpunit --testsuite integration",
+		"test:integration-ms": "wp-env run tests-cli --env-cwd=wp-content/plugins/zoninator /bin/bash -c 'WP_MULTISITE=1 ./vendor/bin/phpunit --testsuite integration'"
 	},
 	"scripts-descriptions": {
 		"coverage": "Run tests with code coverage reporting",

--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -113,6 +113,7 @@ var zoninator = {};
 
 						// Append more request vars
 						request.action = zoninator.getAjaxAction('search_posts');
+						request._wpnonce = zoninator.getAjaxNonce();
 						request.exclude = zoninator.getZonePostIds();
 
 						// Allow developers to hook onto the request

--- a/js/zoninator.js
+++ b/js/zoninator.js
@@ -138,15 +138,14 @@ var zoninator = {};
 			var autocomplete = zoninator.$zonePostSearch.data('autocomplete') || zoninator.$zonePostSearch.data('ui-autocomplete');
 
 			autocomplete._renderItem = function(ul, item) {
-				var content = '<a>'
-					+ '<span class="title">' + item.title + '</span>'
-					+ '<span class="type">' + item.post_type + '</span>'
-					+ '<span class="date">' + item.date + '</span>'
-					+ '<span class="status">' + item.post_status + '</span>'
-					+ '</a>';
+				var $anchor = $('<a></a>')
+					.append($('<span class="title"></span>').text(item.title))
+					.append($('<span class="type"></span>').text(item.post_type))
+					.append($('<span class="date"></span>').text(item.date))
+					.append($('<span class="status"></span>').text(item.post_status));
 				return $('<li></li>')
 					.data('item.autocomplete', item)
-					.append(content)
+					.append($anchor)
 					.appendTo(ul)
 					;
 			}

--- a/languages/zoninator.pot
+++ b/languages/zoninator.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2025 Mohammad Jangda, Automattic
+# Copyright (C) 2026 Mohammad Jangda, Automattic
 # This file is distributed under the same license as the Zone Manager (Zoninator) plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Zone Manager (Zoninator) 0.10.2\n"
+"Project-Id-Version: Zone Manager (Zoninator) 0.11.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zoninator\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-10-02T13:54:49+00:00\n"
+"POT-Creation-Date: 2026-04-25T16:37:01+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zoninator\n"
@@ -51,8 +51,8 @@ msgstr ""
 msgid "zone id required"
 msgstr ""
 
-#: src/class-zoninator-api-controller.php:500
-#: src/class-zoninator.php:1471
+#: src/class-zoninator-api-controller.php:511
+#: src/class-zoninator.php:1483
 msgid "Sorry, you're not supposed to do that..."
 msgstr ""
 
@@ -116,162 +116,168 @@ msgstr ""
 msgid "Sorry, something went wrong! Please try again?"
 msgstr ""
 
-#. translators: User's display name, or "another user"
+#: src/class-zoninator.php:86
+#: src/class-zoninator.php:1095
+msgid "Sorry, we couldn't delete the zone."
+msgstr ""
+
 #: src/class-zoninator.php:87
+#: src/class-zoninator.php:1078
+#: src/class-zoninator.php:1102
+msgid "Sorry, that zone doesn't exist."
+msgstr ""
+
+#. translators: User's display name, or "another user"
+#: src/class-zoninator.php:89
 #, php-format
 msgid "Sorry, this zone is in use by %s and is currently locked. Please try again later."
 msgstr ""
 
-#: src/class-zoninator.php:88
+#: src/class-zoninator.php:90
 msgid "Sorry, you have reached the maximum idle limit and will now be redirected to the Dashboard."
 msgstr ""
 
-#: src/class-zoninator.php:108
-#: src/class-zoninator.php:155
-#: src/class-zoninator.php:269
+#: src/class-zoninator.php:110
+#: src/class-zoninator.php:157
+#: src/class-zoninator.php:271
 msgid "Zones"
 msgstr ""
 
-#: src/class-zoninator.php:155
+#: src/class-zoninator.php:157
 msgid "Zoninator"
 msgstr ""
 
-#: src/class-zoninator.php:167
+#: src/class-zoninator.php:169
 msgid "another user"
 msgstr ""
 
-#: src/class-zoninator.php:281
+#: src/class-zoninator.php:283
 msgid "Edit Zone"
 msgstr ""
 
-#: src/class-zoninator.php:297
-#: src/class-zoninator.php:299
+#: src/class-zoninator.php:307
+#: src/class-zoninator.php:309
 msgid "Add New"
 msgstr ""
 
-#: src/class-zoninator.php:402
-#: src/class-zoninator.php:451
+#: src/class-zoninator.php:412
+#: src/class-zoninator.php:461
 msgid "Name"
 msgstr ""
 
-#: src/class-zoninator.php:408
-#: src/class-zoninator.php:457
+#: src/class-zoninator.php:418
+#: src/class-zoninator.php:467
 msgid "Slug"
 msgstr ""
 
-#: src/class-zoninator.php:417
-#: src/class-zoninator.php:463
+#: src/class-zoninator.php:427
+#: src/class-zoninator.php:473
 msgid "Description"
 msgstr ""
 
-#: src/class-zoninator.php:433
+#: src/class-zoninator.php:443
 msgid "Save zone info"
 msgstr ""
 
-#: src/class-zoninator.php:436
+#: src/class-zoninator.php:446
+msgid "Are you sure you want to delete this zone?"
+msgstr ""
+
+#: src/class-zoninator.php:446
 msgid "Delete"
 msgstr ""
 
-#: src/class-zoninator.php:484
+#: src/class-zoninator.php:494
 msgid "Zone Content"
 msgstr ""
 
-#: src/class-zoninator.php:506
+#: src/class-zoninator.php:516
 msgid "To create a zone, enter a name (and optional description) and click \"Save zone info\". You can then choose content items to add to the zone."
 msgstr ""
 
-#: src/class-zoninator.php:552
-#: src/class-zoninator.php:1720
+#: src/class-zoninator.php:562
+#: src/class-zoninator.php:1740
 msgid "Click and drag to change the position of this item."
 msgstr ""
 
-#: src/class-zoninator.php:560
-#: src/class-zoninator.php:562
-#: src/class-zoninator.php:1733
-#: src/class-zoninator.php:1746
+#: src/class-zoninator.php:570
+#: src/class-zoninator.php:572
+#: src/class-zoninator.php:1753
+#: src/class-zoninator.php:1766
 msgid "Opens in new window"
 msgstr ""
 
-#: src/class-zoninator.php:560
-#: src/class-zoninator.php:1734
+#: src/class-zoninator.php:570
+#: src/class-zoninator.php:1754
 msgid "Edit"
 msgstr ""
 
-#: src/class-zoninator.php:561
+#: src/class-zoninator.php:571
 msgid "Remove this item from the zone"
 msgstr ""
 
-#: src/class-zoninator.php:561
-#: src/class-zoninator.php:1741
+#: src/class-zoninator.php:571
+#: src/class-zoninator.php:1761
 msgid "Remove"
 msgstr ""
 
-#: src/class-zoninator.php:562
-#: src/class-zoninator.php:1747
+#: src/class-zoninator.php:572
+#: src/class-zoninator.php:1767
 msgid "View"
 msgstr ""
 
-#: src/class-zoninator.php:578
+#: src/class-zoninator.php:588
 msgid "Hide"
 msgstr ""
 
-#: src/class-zoninator.php:578
+#: src/class-zoninator.php:588
 msgid "Show Filters"
 msgstr ""
 
-#: src/class-zoninator.php:589
+#: src/class-zoninator.php:599
 msgid "Filter:"
 msgstr ""
 
-#: src/class-zoninator.php:595
+#: src/class-zoninator.php:605
 msgid "Show all Categories"
 msgstr ""
 
-#: src/class-zoninator.php:687
+#: src/class-zoninator.php:697
 msgid "No results found"
 msgstr ""
 
 #. translators: Category name
-#: src/class-zoninator.php:690
+#: src/class-zoninator.php:700
 #, php-format
 msgid "Choose post from %s"
 msgstr ""
 
-#: src/class-zoninator.php:692
-#: src/class-zoninator.php:727
+#: src/class-zoninator.php:702
+#: src/class-zoninator.php:737
 msgid "Choose a post"
 msgstr ""
 
-#: src/class-zoninator.php:725
+#: src/class-zoninator.php:735
 msgid "Add Recent Content"
 msgstr ""
 
-#: src/class-zoninator.php:743
+#: src/class-zoninator.php:753
 msgid "Search for content"
 msgstr ""
 
-#: src/class-zoninator.php:745
+#: src/class-zoninator.php:755
 msgid "Enter a term or phrase in the text box above to search for and add content to this zone."
 msgstr ""
 
-#: src/class-zoninator.php:936
+#: src/class-zoninator.php:949
 msgid "(no title)"
 msgstr ""
 
-#: src/class-zoninator.php:1018
+#: src/class-zoninator.php:1031
 msgid "Slug is a required field."
 msgstr ""
 
-#: src/class-zoninator.php:1065
-#: src/class-zoninator.php:1089
-msgid "Sorry, that zone doesn't exist."
-msgstr ""
-
-#: src/class-zoninator.php:1082
-msgid "Sorry, we couldn't delete the zone."
-msgstr ""
-
-#: src/class-zoninator.php:1778
+#: src/class-zoninator.php:1798
 msgid "Invalid zone supplied"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1106,10 +1106,11 @@
 			}
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -880,9 +880,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "zoninator",
-	"version": "0.10.2",
+	"version": "0.11.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "zoninator",
-			"version": "0.10.2",
+			"version": "0.11.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"mixtape": "git+https://github.com/Automattic/mixtape.git#3a8440",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "zoninator",
-			"version": "0.9.0",
+			"version": "0.10.2",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"mixtape": "git+https://github.com/Automattic/mixtape.git#3a8440",
@@ -880,10 +880,11 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1010,10 +1010,11 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zoninator",
-	"version": "0.10.2",
+	"version": "0.11.0",
 	"description": "Curation made easy! Create \"zones\" then add and order your content!",
 	"license": "GPL-2.0-or-later",
 	"private": true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,8 +17,8 @@
 	testdox="true">
 
 	<testsuites>
-		<testsuite name="WP_Tests">
-			<directory suffix="-test.php">./tests/</directory>
+		<testsuite name="integration">
+			<directory>./tests/Integration/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/src/class-zoninator-api-controller.php
+++ b/src/class-zoninator-api-controller.php
@@ -337,11 +337,22 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 	/**
 	 * Check if a given request has access to the zones index.
 	 *
+	 * Defaults to requiring a logged-in user to avoid leaking zone names and
+	 * descriptions to anonymous callers. Sites that integrated against the
+	 * historical unauthenticated behaviour can restore it via the
+	 * zoninator_rest_get_zones_permissions_check filter.
+	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
+	 * @return bool
 	 */
 	public function get_zones_permissions_check( $request ) {
-		return true;
+		/**
+		 * Filter whether the GET /zones REST endpoint authorises the request.
+		 *
+		 * @param bool            $authorised Whether the caller may list zones.
+		 * @param WP_REST_Request $request    The current REST request.
+		 */
+		return (bool) apply_filters( 'zoninator_rest_get_zones_permissions_check', is_user_logged_in(), $request );
 	}
 
 	/**

--- a/src/class-zoninator-api-controller.php
+++ b/src/class-zoninator-api-controller.php
@@ -177,7 +177,7 @@ class Zoninator_Api_Controller extends Zoninator_REST_Controller {
 		$zone_id     = $this->get_param( $request, 'zone_id', 0, 'absint' );
 		$name        = $this->get_param( $request, 'name', '' );
 		$slug        = $this->get_param( $request, 'slug', '' );
-		$description = $this->get_param( $request, 'description', '', 'strip_tags' );
+		$description = $this->get_param( $request, 'description', '' );
 
 		$zone          = $this->instance->get_zone( $zone_id );
 		$update_params = array();

--- a/src/class-zoninator.php
+++ b/src/class-zoninator.php
@@ -1478,8 +1478,16 @@ class Zoninator {
 
 		$details = array();
 
-		if ( ! empty( $zone->description ) ) {
-			$details = maybe_unserialize( $zone->description );
+		if ( ! empty( $zone->description ) && is_serialized( $zone->description ) ) {
+			// Disallow object instantiation to prevent PHP object injection if a
+			// crafted serialized payload reaches the term description via any path.
+			// Silenced because unserialize() can still emit notices on truncated or
+			// malformed payloads that pass is_serialized().
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+			$unserialized = @unserialize( trim( $zone->description ), array( 'allowed_classes' => false ) );
+			if ( is_array( $unserialized ) ) {
+				$details = $unserialized;
+			}
 		}
 
 		$details = wp_parse_args( $details, $this->zone_detail_defaults );

--- a/src/class-zoninator.php
+++ b/src/class-zoninator.php
@@ -879,6 +879,9 @@ class Zoninator {
 
 	public function ajax_search_posts() {
 
+		$this->verify_nonce( $this->zone_ajax_nonce_action );
+		$this->verify_access();
+
 		$q = $this->_get_request_var( 'term', '', 'stripslashes' );
 
 		if ( ! empty( $q ) ) {

--- a/src/class-zoninator.php
+++ b/src/class-zoninator.php
@@ -83,6 +83,8 @@ class Zoninator {
 			'update-success'      => __( 'The zone was successfully updated.', 'zoninator' ),
 			'delete-success'      => __( 'The zone was successfully deleted.', 'zoninator' ),
 			'error-general'       => __( 'Sorry, something went wrong! Please try again?', 'zoninator' ),
+			'error-delete-zone'   => __( "Sorry, we couldn't delete the zone.", 'zoninator' ),
+			'error-invalid-zone'  => __( "Sorry, that zone doesn't exist.", 'zoninator' ),
 			/* translators: User's display name, or "another user" */
 			'error-zone-lock'     => __( 'Sorry, this zone is in use by %s and is currently locked. Please try again later.', 'zoninator' ),
 			'error-zone-lock-max' => __( 'Sorry, you have reached the maximum idle limit and will now be redirected to the Dashboard.', 'zoninator' ),
@@ -251,7 +253,7 @@ class Zoninator {
 					}
 
 					if ( is_wp_error( $result ) ) {
-						$redirect_args = array( 'error' => $result->get_error_messages() );
+						$redirect_args = array( 'error' => $result->get_error_code() );
 					} else {
 						$redirect_args = array( 'message' => 'delete-success' );
 					}
@@ -281,8 +283,16 @@ class Zoninator {
 			$title = __( 'Edit Zone', 'zoninator' );
 		}
 
-		$message = $this->_get_message( $this->_get_get_var( 'message', '', 'urldecode' ) );
-		$error   = $this->_get_get_var( 'error', '', 'urldecode' );
+		$message    = $this->_get_message( $this->_get_get_var( 'message', '', 'sanitize_key' ) );
+		$error_code = $this->_get_get_var( 'error', '', 'sanitize_key' );
+		if ( $error_code ) {
+			$error = $this->_get_message( 'error-' . $error_code );
+			if ( '' === $error ) {
+				$error = $this->_get_message( 'error-general' );
+			}
+		} else {
+			$error = '';
+		}
 
 		?>
 	<div class="wrap zoninator-page">
@@ -675,7 +685,7 @@ class Zoninator {
 			$content      = '';
 			$recent_posts = get_posts( $args );
 			foreach ( $recent_posts as $post ) :
-				$content .= sprintf( '<option value="%d">%s</option>', $post->ID, get_the_title( $post->ID ) . ' (' . $post->post_status . ')' );
+				$content .= sprintf( '<option value="%d">%s</option>', $post->ID, esc_html( get_the_title( $post->ID ) . ' (' . $post->post_status . ')' ) );
 			endforeach;
 
 			wp_reset_postdata();

--- a/src/class-zoninator.php
+++ b/src/class-zoninator.php
@@ -433,7 +433,7 @@ class Zoninator {
 								<input type="submit" value="<?php esc_attr_e( 'Save zone info', 'zoninator' ); ?>" name="submit" class="button" />
 
 								<?php if ( $zone_id ) : ?>
-									<a href="<?php echo esc_url( $delete_link ); ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( 'Are you sure you want to delete this zone?', 'zoninator' ); ?>')"><?php esc_html_e( 'Delete', 'zoninator' ); ?></a>
+									<a href="<?php echo esc_url( $delete_link ); ?>" class="submitdelete" onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete this zone?', 'zoninator' ) ); ?>')"><?php esc_html_e( 'Delete', 'zoninator' ); ?></a>
 									<?php
 								endif;
 								?>
@@ -633,14 +633,14 @@ class Zoninator {
 		$date    = $this->_get_post_var( 'date', '', 'striptags' );
 		$zone_id = $this->_get_post_var( 'zone_id', 0, 'absint' );
 
+		// Verify nonce and capability before doing any DB work.
+		$this->verify_nonce( $this->zone_ajax_nonce_action );
+		$this->verify_access( '', $zone_id );
+
 		$limit         = $this->posts_per_page;
 		$post_types    = $this->get_supported_post_types();
 		$zone_posts    = $this->get_zone_posts( $zone_id );
 		$zone_post_ids = wp_list_pluck( $zone_posts, 'ID' );
-
-		// Verify nonce
-		$this->verify_nonce( $this->zone_ajax_nonce_action );
-		$this->verify_access( '', $zone_id );
 
 		if ( is_wp_error( $zone_posts ) ) {
 			$status  = 0;
@@ -1325,13 +1325,12 @@ class Zoninator {
 		}
 
 		if ( ! $user_id ) {
-			$user    = wp_get_current_user();
-			$user_id = $user->ID;
+			$user_id = get_current_user_id();
 		}
 
 		$lock_key = $this->get_zone_meta_key( $zone );
 		$expiry   = $this->zone_lock_period + 1; // Add a one to avoid most race condition issues between lock expiry and ajax call
-		set_transient( $lock_key, $user->ID, $expiry );
+		set_transient( $lock_key, $user_id, $expiry );
 
 		// Possible alternative: set zone lock as property with time and user
 		return null;

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Base test case for integration tests.
+ *
+ * @package Automattic\Zoninator
+ */
+
+namespace Automattic\Zoninator\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPIntegrationTestCase;
+
+/**
+ * Base test case for integration tests.
+ */
+abstract class TestCase extends WPIntegrationTestCase {
+}

--- a/tests/Integration/ZoninatorAjaxSearchPostsTest.php
+++ b/tests/Integration/ZoninatorAjaxSearchPostsTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Integration tests for the ajax_search_posts admin-ajax handler.
+ *
+ * Covers the authorisation and nonce enforcement added in response to
+ * authenticated information disclosure of scheduled (future) posts via
+ * wp_ajax_zoninator_search_posts.
+ *
+ * @package Automattic\Zoninator
+ */
+
+namespace Automattic\Zoninator\Tests\Integration;
+
+use WP_Ajax_UnitTestCase;
+use WPAjaxDieContinueException;
+use WPAjaxDieStopException;
+use Zoninator;
+
+/**
+ * @group ajax
+ */
+class Zoninator_Ajax_Search_Posts_Test extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * @var int
+	 */
+	private $future_post_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		$this->future_post_id = self::factory()->post->create( array(
+			'post_title'  => 'zoninator_future_leak_canary',
+			'post_status' => 'future',
+			'post_date'   => gmdate( 'Y-m-d H:i:s', time() + DAY_IN_SECONDS ),
+		) );
+
+		$_REQUEST = array();
+		$_POST    = array();
+		$_GET     = array();
+	}
+
+	public function tear_down(): void {
+		$_REQUEST = array();
+		$_POST    = array();
+		$_GET     = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * A subscriber must not be able to reach the search handler, even when
+	 * authenticated. This guards against authenticated enumeration of
+	 * scheduled posts via the search oracle.
+	 */
+	public function test_subscriber_is_blocked_without_json_output(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$_POST['action'] = 'zoninator_search_posts';
+		$_POST['term']   = 'zoninator_future_leak';
+
+		$this->expectException( WPAjaxDieStopException::class );
+
+		try {
+			$this->_handleAjax( 'zoninator_search_posts' );
+		} finally {
+			$this->assertStringNotContainsString(
+				'zoninator_future_leak_canary',
+				$this->_last_response,
+				'Subscriber must not receive search results for future posts.'
+			);
+		}
+	}
+
+	/**
+	 * An authorised user without a valid nonce must be rejected. This guards
+	 * against CSRF against the search endpoint.
+	 */
+	public function test_admin_without_nonce_is_blocked(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$_POST['action'] = 'zoninator_search_posts';
+		$_POST['term']   = 'zoninator_future_leak';
+
+		$this->expectException( WPAjaxDieStopException::class );
+
+		$this->_handleAjax( 'zoninator_search_posts' );
+	}
+
+	/**
+	 * An authorised user with a valid nonce receives JSON results for matches,
+	 * confirming the legitimate flow still works after the fix.
+	 */
+	public function test_admin_with_valid_nonce_receives_results(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$zoninator  = Zoninator();
+		$nonce_key  = $zoninator->_get_nonce_key( $zoninator->zone_ajax_nonce_action );
+		$nonce      = wp_create_nonce( $nonce_key );
+
+		$_POST['action']   = 'zoninator_search_posts';
+		$_POST['term']     = 'zoninator_future_leak';
+		$_POST['_wpnonce'] = $nonce;
+
+		try {
+			$this->_handleAjax( 'zoninator_search_posts' );
+			$this->fail( 'Expected handler to exit after emitting JSON.' );
+		} catch ( WPAjaxDieStopException $e ) {
+			// Expected. Handler calls exit after echoing JSON.
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Also acceptable under some test die handlers.
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertIsArray( $response );
+		$this->assertNotEmpty( $response );
+
+		$ids = array_map( static fn( $row ) => (int) $row['post_id'], $response );
+		$this->assertContains( $this->future_post_id, $ids );
+	}
+}

--- a/tests/Integration/ZoninatorApiControllerTest.php
+++ b/tests/Integration/ZoninatorApiControllerTest.php
@@ -1,11 +1,18 @@
 <?php
+/**
+ * Integration tests for the Zoninator API controller.
+ *
+ * @package Automattic\Zoninator
+ */
 
-class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
+namespace Automattic\Zoninator\Tests\Integration;
+
+class Zoninator_Api_Controller_Test extends TestCase {
 
 	/**
 	 * REST Server
 	 *
-	 * @var WP_REST_Server
+	 * @var \WP_REST_Server
 	 */
 	protected $rest_server;
 
@@ -33,7 +40,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Assert Status
 	 *
-	 * @param WP_REST_Response $response Response.
+	 * @param \WP_REST_Response $response Response.
 	 * @param int              $status_code Code.
 	 */
 	public function assert_response_status( $response, $status_code ) {
@@ -63,34 +70,34 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Assert Status 200
 	 *
-	 * @param WP_REST_Response $response Response.
+	 * @param \WP_REST_Response $response Response.
 	 */
 	public function assert_http_response_status_success( $response ) {
-		$this->assert_response_status( $response, MT_Controller::HTTP_OK );
+		$this->assert_response_status( $response, \MT_Controller::HTTP_OK );
 	}
 
 	/**
 	 * Assert Status 201
 	 *
-	 * @param WP_REST_Response $response Response.
+	 * @param \WP_REST_Response $response Response.
 	 */
 	public function assert_http_response_status_created( $response ) {
-		$this->assert_response_status( $response, MT_Controller::HTTP_CREATED );
+		$this->assert_response_status( $response, \MT_Controller::HTTP_CREATED );
 	}
 
 	/**
 	 * Assert Status 404
 	 *
-	 * @param WP_REST_Response $response Response.
+	 * @param \WP_REST_Response $response Response.
 	 */
 	public function assert_http_response_status_not_found( $response ) {
-		$this->assert_response_status( $response, MT_Controller::HTTP_NOT_FOUND );
+		$this->assert_response_status( $response, \MT_Controller::HTTP_NOT_FOUND );
 	}
 
 	/**
 	 * Ensure we got a certain response code
 	 *
-	 * @param WP_REST_Response $response The Response.
+	 * @param \WP_REST_Response $response The Response.
 	 * @param int              $status_code Expected status code.
 	 */
 	public function assertResponseStatus( $response, $status_code ) {
@@ -104,10 +111,10 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * @param string $endpoint The Endpoint.
 	 * @param string $method Http method.
 	 * @param array  $args Any Data/Args.
-	 * @return WP_REST_Response
+	 * @return \WP_REST_Response
 	 */
 	public function request( $endpoint, $method, $args = array() ) {
-		$request = new WP_REST_Request( $method, $endpoint );
+		$request = new \WP_REST_Request( $method, $endpoint );
 		foreach ( $args as $key => $value ) {
 			$request->set_param( $key, $value );
 		}
@@ -120,7 +127,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $endpoint The Endpoint.
 	 * @param array  $args Any Data/Args.
-	 * @return WP_REST_Response
+	 * @return \WP_REST_Response
 	 */
 	public function get( $endpoint, $args = array() ) {
 		return $this->request( $endpoint, 'GET', $args );
@@ -131,7 +138,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $endpoint The Endpoint.
 	 * @param array  $args Any Data/Args.
-	 * @return WP_REST_Response
+	 * @return \WP_REST_Response
 	 */
 	public function post( $endpoint, $args = array() ) {
 		return $this->request( $endpoint, 'POST', $args );
@@ -142,7 +149,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $endpoint The Endpoint.
 	 * @param array  $args Any Data/Args.
-	 * @return WP_REST_Response
+	 * @return \WP_REST_Response
 	 */
 	public function put( $endpoint, $args = array() ) {
 		return $this->request( $endpoint, 'PUT', $args );
@@ -153,7 +160,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $endpoint The Endpoint.
 	 * @param array  $args Any Data/Args.
-	 * @return WP_REST_Response
+	 * @return \WP_REST_Response
 	 */
 	public function delete( $endpoint, $args = array() ) {
 		return $this->request( $endpoint, 'DELETE', $args );
@@ -167,10 +174,10 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		/**
 		 *The global
 		 *
-		 * @var WP_REST_Server $wp_rest_server
+		 * @var \WP_REST_Server $wp_rest_server
 		 */
 		global $wp_rest_server;
-		$this->rest_server = new Spy_REST_Server;
+		$this->rest_server = new \Spy_REST_Server();
 		$wp_rest_server = $this->rest_server;
 		$admin = get_user_by( 'email', 'rest_api_admin_user@test.com' );
 		if ( false === $admin ) {
@@ -187,13 +194,13 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 		$this->login_as_admin();
 		$this->rest_server = $wp_rest_server;
 		do_action( 'rest_api_init' );
-		$this->environment = Zoninator()->rest_api->bootstrap->environment();
+		$this->environment = \Zoninator()->rest_api->bootstrap->environment();
 	}
 
 	/**
 	 * T test_create_zone_responds_with_created_when_method_post
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_create_zone_responds_with_created_when_method_post() {
 		$this->login_as_admin();
@@ -206,7 +213,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_create_zone_fail_if_invalid_data
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_create_zone_fail_if_invalid_data() {
 		$this->login_as_admin();
@@ -219,7 +226,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_create_zone_with_special_chars
 	 *
-	 * @throws Exception E
+	 * @throws \Exception E
 	 */
 	public function test_create_zone_with_special_chars() {
 		$this->login_as_admin();
@@ -237,7 +244,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_update_zone_responds_with_success_when_method_put
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_update_zone_responds_with_success_when_method_put() {
 		$this->login_as_admin();
@@ -251,7 +258,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_update_zone_responds_with_not_found_if_zone_not_exist
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_update_zone_responds_with_not_found_if_zone_not_exist() {
 		$this->login_as_admin();
@@ -264,7 +271,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_delete_zone_responds_with_success_when_method_delete
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_delete_zone_responds_with_success_when_method_delete() {
 		$this->login_as_admin();
@@ -276,7 +283,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_delete_zone_responds_with_not_found_if_zone_not_exist
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_delete_zone_responds_with_not_found_if_zone_not_exist() {
 		$this->login_as_admin();
@@ -287,7 +294,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_update_zone_posts_responds_with_ok_when_method_put
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_update_zone_posts_responds_with_success_when_method_put() {
 		$this->login_as_admin();
@@ -302,7 +309,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_update_zone_posts_responds_with_not_found_if_zone_not_exist
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_update_zone_posts_responds_with_not_found_if_zone_not_exist() {
 		$this->login_as_admin();
@@ -316,7 +323,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_update_zone_posts_fails_if_invalid_data_format
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_update_zone_posts_fails_if_invalid_data() {
 		$this->login_as_admin();
@@ -329,7 +336,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_update_zone_posts_fails_if_invalid_post_id
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_update_zone_posts_fails_if_invalid_post_id() {
 		$this->login_as_admin();
@@ -344,12 +351,12 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * T test_get_zone_posts_success_when_valid_zone_and_posts
 	 *
-	 * @throws Exception E.
+	 * @throws \Exception E.
 	 */
 	public function test_get_zone_posts_success_when_valid_zone_and_posts() {
 		$this->login_as_admin();
 		self::factory()->post->create_many( 5 );
-		$query = new WP_Query();
+		$query = new \WP_Query();
 		$posts = $query->query( array() );
 		$post = $posts[0];
 		$zone_id = $this->add_a_zone();
@@ -365,7 +372,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * Test test_get_zone_posts_success_when_no_posts_in_zone
 	 */
 	public function test_get_zone_posts_success_when_no_posts_in_zone() {
-		$term_factory = new WP_UnitTest_Factory_For_Term( null, Zoninator()->zone_taxonomy );
+		$term_factory = new \WP_UnitTest_Factory_For_Term( null, \Zoninator()->zone_taxonomy );
 		$zone_id = $term_factory->create_object( array(
 			'name' => 'The Zone Add Post one',
 			'description' => 'Zone 2',
@@ -380,7 +387,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 * Test test_get_zone_posts_not_found_when_invalid_zone
 	 */
 	public function test_get_zone_posts_not_found_when_invalid_zone() {
-		$term_factory = new WP_UnitTest_Factory_For_Term( null, Zoninator()->zone_taxonomy );
+		$term_factory = new \WP_UnitTest_Factory_For_Term( null, \Zoninator()->zone_taxonomy );
 		$zone_id = $term_factory->create_object( array(
 			'name' => 'The Zone Add Post one',
 			'description' => 'Zone 2',
@@ -392,7 +399,7 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @return int|WP_Error
+	 * @return int|\WP_Error
 	 */
 	private function _insert_a_post() {
 		$insert = wp_insert_post( array(
@@ -403,14 +410,14 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 			'post_type' => 'post'
 		) );
 		if ( is_wp_error( $insert ) ) {
-			throw new Exception( 'Error' );
+			throw new \Exception( 'Error' );
 		}
 
 		return $insert;
 	}
 
 	private function create_a_zone( $slug, $title ) {
-		$result = Zoninator()->insert_zone( $slug, $title, array( 'description' => rand_str() ) );
+		$result = \Zoninator()->insert_zone( $slug, $title, array( 'description' => rand_str() ) );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -423,10 +430,10 @@ class Zoninator_Api_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $slug Slug.
 	 *
-	 * @return array|mixed|WP_Error
+	 * @return array|mixed|\WP_Error
 	 */
 	private function add_a_zone( $slug = 'zone-1' ) {
-		$term_factory = new WP_UnitTest_Factory_For_Term(null, Zoninator()->zone_taxonomy);
+		$term_factory = new \WP_UnitTest_Factory_For_Term(null, \Zoninator()->zone_taxonomy);
 		return $term_factory->create_object(array(
 			'name' => 'The Zone Add Post one ' . rand_str(),
 			'description' => 'Zone ' . rand_str(),

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-### Running Unit Tests
+### Running Integration Tests
 
 ```bash
 composer install

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,23 +1,53 @@
 <?php
+/**
+ * PHPUnit bootstrap file for Zoninator plugin tests.
+ *
+ * @package Automattic\Zoninator
+ */
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
-if ( ! $_tests_dir ) {
-	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+use Yoast\WPTestUtils\WPIntegration;
+
+require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+// Check for a `--testsuite integration` or `--testsuite=integration` arg when calling phpunit, and
+// use it to conditionally load up WordPress.
+$argv_local     = $GLOBALS['argv'] ?? [];
+$key            = (int) array_search( '--testsuite', $argv_local, true );
+$is_integration = false;
+
+// Check for --testsuite integration (two separate args).
+if ( $key && isset( $argv_local[ $key + 1 ] ) && 'integration' === $argv_local[ $key + 1 ] ) {
+	$is_integration = true;
 }
 
-if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	echo sprintf('Could not find %s/includes/functions.php, have you run bin/install-wp-tests.sh ?', $_tests_dir) . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	exit( 1 );
+// Check for --testsuite=integration (single arg with equals).
+foreach ( $argv_local as $arg ) {
+	if ( '--testsuite=integration' === $arg ) {
+		$is_integration = true;
+		break;
+	}
 }
 
-require_once $_tests_dir . '/includes/functions.php';
+if ( $is_integration ) {
+	$_tests_dir = WPIntegration\get_path_to_wp_test_dir();
 
-function _manually_load_plugin(): void {
-	$thispath = __DIR__;
-	$file = $thispath . '/../zoninator.php';
-	require_once realpath( $file );
+	// Give access to tests_add_filter() function.
+	require_once $_tests_dir . '/includes/functions.php';
+
+	// Manually load the plugin being tested.
+	\tests_add_filter(
+		'muplugins_loaded',
+		function (): void {
+			require dirname( __DIR__ ) . '/zoninator.php';
+		}
+	);
+
+	/*
+	 * Bootstrap WordPress. This will also load the Composer autoload file, the PHPUnit Polyfills
+	 * and the custom autoloader for the TestCase and the mock object classes.
+	 */
+	WPIntegration\bootstrap_it();
+
+	// Add custom test case.
+	require __DIR__ . '/Integration/TestCase.php';
 }
-
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
-
-require $_tests_dir . '/includes/bootstrap.php';

--- a/zoninator.php
+++ b/zoninator.php
@@ -3,7 +3,7 @@
 Plugin Name: Zone Manager (Zoninator)
 Description: Curation made easy! Create "zones" then add and order your content!
 Author: Mohammad Jangda, Automattic
-Version: 0.10.2
+Version: 0.11.0
 Author URI: https://wpvip.com
 Requires at least: 6.4
 Requires PHP: 7.4
@@ -32,7 +32,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 */
 
-define( 'ZONINATOR_VERSION', '0.10.2' );
+define( 'ZONINATOR_VERSION', '0.11.0' );
 define( 'ZONINATOR_FILE', __FILE__ );
 
 require_once __DIR__ . '/functions.php';

--- a/zoninator.php
+++ b/zoninator.php
@@ -5,6 +5,8 @@ Description: Curation made easy! Create "zones" then add and order your content!
 Author: Mohammad Jangda, Automattic
 Version: 0.10.2
 Author URI: https://wpvip.com
+Requires at least: 6.4
+Requires PHP: 7.4
 Text Domain: zoninator
 Domain Path: /languages/
 


### PR DESCRIPTION
## Summary

Cuts the 0.11.0 release. The work itself has already landed on `develop` over the past few months across more than twenty PRs; this branch simply rolls those into a release with the three standard commits — changelog, regenerated POT, version bumps.

The headline of the release is the security work that landed in PRs #148, #149, #150 and #151. Three reflected/stored XSS surfaces on the zone admin screen are now closed, the term-description deserialiser uses `unserialize` with `allowed_classes => false` so a poisoned description cannot trigger PHP object instantiation, and the `zoninator_search_posts` AJAX handler now requires both an authentication check and a valid nonce so a logged-in subscriber can no longer enumerate scheduled-post titles. Alongside that, a handful of latent bugs around the lock heartbeat and the Delete confirm i18n string are tidied up.

The release also raises the minimum WordPress version from 5.9 to 6.4, in line with the rest of our plugin standards. The PHP minimum stays at 7.4.

The one behaviour change worth flagging in upgrade notes is that `GET /wp-json/zoninator/v1/zones` now requires an authenticated user. This previously responded to anonymous callers, which leaked zone names and descriptions to anyone who knew the endpoint existed. The admin UI does not consume this endpoint (it goes through admin-ajax), so that path is unaffected. Sites that genuinely depend on anonymous zone listing — for instance, a static site generator pulling zone metadata at build time — can opt back into the historical behaviour with a one-line filter:

```php
add_filter( 'zoninator_rest_get_zones_permissions_check', '__return_true' );
```

The remainder of the release is the maintenance and dev-environment work that has been accumulating since 0.10.2: migration to `wp-env`, the `wp-test-utils` swap, GitHub Actions hardening, CODEOWNERS migration, and the usual run of Dependabot updates.

Six smoke tests against a live wp-env confirmed each of the security fixes behaves as intended, and one i18n test confirmed the previously-discarded Delete confirm string is now extractable. CI is green on develop ahead of this release branch.

## Test plan

- [ ] Confirm CI checks pass on this branch.
- [ ] Verify the changelog entry on `CHANGELOG.md` covers everything that landed since 0.10.2 and matches the existing format.
- [ ] Verify the version is consistent across `zoninator.php` (header + `ZONINATOR_VERSION` constant), `package.json`, `package-lock.json`, `README.md` (`Stable tag`), and the regenerated `languages/zoninator.pot` (`Project-Id-Version` header).
- [ ] Confirm the regenerated POT preserved `Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zoninator` and now contains the new "Are you sure you want to delete this zone?" string.
- [ ] After merging, tag `0.11.0` from `main`, push the tag, and confirm the GitHub Release + WordPress.org SVN deploy workflows fire.