### PR TITLE
Exclude AI tooling and rector config from WordPress.org deploys

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,4 +1,5 @@
 # Directories
+/.claude/
 /.git/
 /.github/
 /bin/
@@ -14,6 +15,7 @@
 .phpcs.xml.dist
 .wp-env.json
 .wp-env.override.json
+AGENTS.md
 CHANGELOG.md
 composer.json
 composer.lock
@@ -21,3 +23,4 @@ mixtape.json
 package.json
 package-lock.json
 phpunit.xml.dist
+rector.php


### PR DESCRIPTION
## Summary

The 0.11.0 SVN deploy attempt got far enough to stage the trunk and tag commits before failing on authentication, and the staged file list revealed a near-miss: three developer-only files were about to be published to plugin users on WordPress.org. None of them belong in an installed plugin, but each was added to the repository after the last meaningful refresh of `.distignore`, so none was being filtered out.

`.claude/` is Claude Code's local configuration directory — it has no runtime relevance and would only confuse users who happen to look inside their plugins folder. `AGENTS.md` documents how AI assistants should work in the repository, again purely a contributor-side concern. `rector.php` is the configuration for the Rector refactoring tool and only matters when running dev tooling.

This branch adds all three to `.distignore` so the next deploy ships only the plugin code itself. The fix is independent of the SVN credentials issue that actually caused the 0.11.0 deploy to fail; it just happens to be a useful thing to land while the deploy is paused.

## Test plan

- [ ] Confirm `.distignore` lists `/.claude/`, `AGENTS.md`, and `rector.php`.
- [ ] After this is merged and the SVN credentials are refreshed, re-run the 0.11.0 deploy and confirm the staged file list no longer includes any of the three.