### PR TITLE
Sync .distignore fix to main ahead of 0.11.0 deploy retry

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,4 +1,5 @@
 # Directories
+/.claude/
 /.git/
 /.github/
 /bin/
@@ -14,6 +15,7 @@
 .phpcs.xml.dist
 .wp-env.json
 .wp-env.override.json
+AGENTS.md
 CHANGELOG.md
 composer.json
 composer.lock
@@ -21,3 +23,4 @@ mixtape.json
 package.json
 package-lock.json
 phpunit.xml.dist
+rector.php


### PR DESCRIPTION
## Summary

Fast-forwards `main` to include #153, the small `.distignore` cleanup that landed on `develop` immediately after the 0.11.0 release. The deploy to WordPress.org was about to publish `.claude/`, `AGENTS.md`, and `rector.php` because none of them were excluded from packaging. SVN credentials have now been refreshed; getting this commit onto `main` first means the upcoming `workflow_dispatch` of the deploy workflow against `main` will package the correct file set.

The git tag `0.11.0` is intentionally not being moved. The change here is build-only — it affects what's bundled, not the running plugin code — so the slight divergence between the git tag commit and the SVN tag contents is just `.distignore` and is invisible to plugin users.

## Test plan

- [ ] Confirm only `.distignore` changes in this PR.
- [ ] After merging, `gh workflow run deploy.yml --ref main` and confirm the run staging output no longer mentions `.claude/`, `AGENTS.md`, or `rector.php`.