### PR TITLE
Record the pinned deploy action version in its comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install subversion
 
       - name: Push to WordPress.org
-        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
           SLUG: zoninator
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
## Summary

The release workflow pins `10up/action-wordpress-plugin-deploy` to a full commit SHA, which is what we want for supply-chain safety. The trailing comment, though, read `# stable` rather than naming a release, so the pin was not auditable at a glance: a reviewer could not tell which version that SHA represents without resolving it by hand, and "stable" misleadingly implies a moving target when the pin is in fact fixed.

The pinned SHA (`54bd289b…`) resolves to tag **2.3.0**, so the comment now records that. Nothing functional changes: the commit SHA is untouched, so the workflow deploys using exactly the same action version as before, the label just now identifies it.